### PR TITLE
Retry network requests on failure, move search into background task

### DIFF
--- a/example.py
+++ b/example.py
@@ -10,30 +10,42 @@ import struct
 import json
 import time
 import argparse
+import threading
+import atexit
+import sys
+
+import werkzeug.serving
+
 import pokemon_pb2
+
 from google.protobuf.internal import encoder
-from s2sphere import *  
+from s2sphere import *
 from datetime import datetime
 from geopy.geocoders import GoogleV3
+from geopy.exc import GeocoderTimedOut, GeocoderServiceError
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
+from requests.adapters import ConnectionError
+from requests.models import InvalidURL
+
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 API_URL = 'https://pgorelease.nianticlabs.com/plfe/rpc'
 LOGIN_URL = 'https://sso.pokemon.com/sso/login?service=https%3A%2F%2Fsso.pokemon.com%2Fsso%2Foauth2.0%2FcallbackAuthorize'
 LOGIN_OAUTH = 'https://sso.pokemon.com/sso/oauth2.0/accessToken'
 PTC_CLIENT_SECRET = 'w8ScCUXJQc6kXKw8FiOhd8Fixzht18Dq3PEVkUCP5ZPxtgyWsbTvWHFLm2wNY0JR'
+GOOGLEMAPS_KEY = "AIzaSyAZzeHhs-8JZ7i18MjFuM35dJHq70n3Hx4"
 
 SESSION = requests.session()
 SESSION.headers.update({'User-Agent': 'Niantic App'})
 SESSION.verify = False
 
-DEBUG = False
+DEBUG = True
+VERBOSE_DEBUG = False  # if you want to write raw request/response to the console
 COORDS_LATITUDE = 0
 COORDS_LONGITUDE = 0
 COORDS_ALTITUDE = 0
 FLOAT_LAT = 0
 FLOAT_LONG = 0
-app = Flask(__name__, template_folder="templates")
 deflat, deflng = 0, 0
 default_step = 0.001
 access_token = None
@@ -43,15 +55,43 @@ gyms = []
 pokestops = []
 numbertoteam = {0: "Gym", 1: "Instinct", 2: "Mystic", 3: "Valor"} # At least I'm pretty sure that's it. I could be wrong and then I'd be displaying the wrong owner team of gyms.
 
-# you can set key as config
-app.config['GOOGLEMAPS_KEY'] = "AIzaSyAZzeHhs-8JZ7i18MjFuM35dJHq70n3Hx4"
-# you can also pass key here
-GoogleMaps(app, key="AIzaSyAZzeHhs-8JZ7i18MjFuM35dJHq70n3Hx4")
+
+# stuff for in-background search thread
+search_thread = None
+exit_requested = False  # main thread sets to True when Flask is trying to quit, background thread checks
+
+
+def check_exit():
+    """
+    Call this function in the body of any slow or infinite loops
+    so that if Flask or the user is trying to exit, we can signal
+    the background thread to exit
+    TODO: doesn't work reliably, exit_requested is set in main thread but not seen by background thread
+    :return: None
+    """
+
+    if exit_requested:
+        sys.exit(0)
+
+
+def debug(message):
+    if DEBUG:
+        print('[-] {}'.format(message))
+
+
+def time_left(ms):
+    s = ms / 1000
+    m, s = divmod(s, 60)
+    h, m = divmod(m, 60)
+    return h, m, s
+
 
 def encode(cellid):
     output = []
     encoder._VarintEncoder()(output.append, cellid)
     return ''.join(output)
+
+
 def getNeighbors():
     origin = CellId.from_lat_lng(LatLng.from_degrees(FLOAT_LAT, FLOAT_LONG)).parent(15)
     walk = [origin.id()]
@@ -64,12 +104,37 @@ def getNeighbors():
         next = next.next()
         prev = prev.prev()
     return walk
+
+
 def f2i(float):
-  return struct.unpack('<Q', struct.pack('<d', float))[0]
+    return struct.unpack('<Q', struct.pack('<d', float))[0]
+
+
 def f2h(float):
-  return hex(struct.unpack('<Q', struct.pack('<d', float))[0])
+    return hex(struct.unpack('<Q', struct.pack('<d', float))[0])
+
+
 def h2f(hex):
-  return struct.unpack('<d', struct.pack('<Q', int(hex,16)))[0]
+    return struct.unpack('<d', struct.pack('<Q', int(hex, 16)))[0]
+
+
+def retrying_set_location(location_name):
+    """
+    Continue trying to get co-ords from Google Location until we have them
+    :param location_name: string to pass to Location API
+    :return: None
+    """
+    while True:
+        check_exit()
+
+        try:
+            set_location(location_name)
+            return
+        except (GeocoderTimedOut, GeocoderServiceError) as e:
+            debug("retrying_set_location: geocoder exception ({}), retrying".format(str(e)))
+        time.sleep(1)
+
+
 def set_location(location_name):
     geolocator = GoogleV3()
     loc = geolocator.geocode(location_name)
@@ -78,65 +143,85 @@ def set_location(location_name):
     global deflat
     global deflng
     deflat, deflng = loc.latitude, loc.longitude
-    set_location_coords(loc.latitude, loc.longitude, loc.altitude) 
+    set_location_coords(loc.latitude, loc.longitude, loc.altitude)
+
+
 def set_location_coords(lat, long, alt):
     global COORDS_LATITUDE, COORDS_LONGITUDE, COORDS_ALTITUDE
     global FLOAT_LAT, FLOAT_LONG
     FLOAT_LAT = lat
     FLOAT_LONG = long
-    COORDS_LATITUDE = f2i(lat) # 0x4042bd7c00000000 # f2i(lat)
-    COORDS_LONGITUDE = f2i(long) # 0xc05e8aae40000000 #f2i(long)
+    COORDS_LATITUDE = f2i(lat)  # 0x4042bd7c00000000 # f2i(lat)
+    COORDS_LONGITUDE = f2i(long)  # 0xc05e8aae40000000 #f2i(long)
     COORDS_ALTITUDE = f2i(alt)
+
+
 def get_location_coords():
     return (COORDS_LATITUDE, COORDS_LONGITUDE, COORDS_ALTITUDE)
-def api_req(api_endpoint, access_token, *mehs, **kw):
-    try:
-        p_req = pokemon_pb2.RequestEnvelop()
-        p_req.rpc_id = 1469378659230941192
 
-        p_req.unknown1 = 2
 
-        p_req.latitude, p_req.longitude, p_req.altitude = get_location_coords()
+def retrying_api_req(api_endpoint, access_token, *args, **kwargs):
+    while True:
+        check_exit()
 
-        p_req.unknown12 = 989
-
-        if 'useauth' not in kw or not kw['useauth']:
-            p_req.auth.provider = 'ptc'
-            p_req.auth.token.contents = access_token
-            p_req.auth.token.unknown13 = 14
-        else:
-            p_req.unknown11.unknown71 = kw['useauth'].unknown71
-            p_req.unknown11.unknown72 = kw['useauth'].unknown72
-            p_req.unknown11.unknown73 = kw['useauth'].unknown73
-
-        for meh in mehs:
-            p_req.MergeFrom(meh)
-
-        protobuf = p_req.SerializeToString()
-
-        r = SESSION.post(api_endpoint, data=protobuf, verify=False)
-
-        p_ret = pokemon_pb2.ResponseEnvelop()
-        p_ret.ParseFromString(r.content)
-
-        if DEBUG:
-            print("REQUEST:")
-            print(p_req)
-            print("Response:")
-            print(p_ret)
-            print("\n\n")
+        try:
+            response = api_req(api_endpoint, access_token, *args, **kwargs)
+            if response:
+                return response
+            debug("retrying_api_req: api_req returned None, retrying")
+        except (InvalidURL, ConnectionError) as e:
+            debug("retrying_api_req: request error ({}), retrying".format(str(e)))
         time.sleep(1)
-        return p_ret
-    except Exception, e:
-        if DEBUG:
-            print(e)
-        return None
-def get_api_endpoint(access_token, api = API_URL):
-    p_ret = get_profile(access_token, api, None)
-    try:
-        return ('https://%s/rpc' % p_ret.api_url)
-    except:
-        return None
+
+
+def api_req(api_endpoint, access_token, *args, **kwargs):
+    p_req = pokemon_pb2.RequestEnvelop()
+    p_req.rpc_id = 1469378659230941192
+
+    p_req.unknown1 = 2
+
+    p_req.latitude, p_req.longitude, p_req.altitude = get_location_coords()
+
+    p_req.unknown12 = 989
+
+    if 'useauth' not in kwargs or not kwargs['useauth']:
+        p_req.auth.provider = 'ptc'
+        p_req.auth.token.contents = access_token
+        p_req.auth.token.unknown13 = 14
+    else:
+        p_req.unknown11.unknown71 = kwargs['useauth'].unknown71
+        p_req.unknown11.unknown72 = kwargs['useauth'].unknown72
+        p_req.unknown11.unknown73 = kwargs['useauth'].unknown73
+
+    for arg in args:
+        p_req.MergeFrom(arg)
+
+    protobuf = p_req.SerializeToString()
+
+    r = SESSION.post(api_endpoint, data=protobuf, verify=False)
+
+    p_ret = pokemon_pb2.ResponseEnvelop()
+    p_ret.ParseFromString(r.content)
+
+    if VERBOSE_DEBUG:
+        print("REQUEST:")
+        print(p_req)
+        print("Response:")
+        print(p_ret)
+        print("\n\n")
+    time.sleep(0.51)
+    return p_ret
+
+
+def get_api_endpoint(access_token, api=API_URL):
+    profile_response = None
+    while not profile_response or not profile_response.api_url:
+        debug("get_api_endpoint: calling get_profile")
+        profile_response = get_profile(access_token, api, None)
+
+    return ('https://%s/rpc' % profile_response.api_url)
+
+
 def get_profile(access_token, api, useauth, *reqq):
     req = pokemon_pb2.RequestEnvelop()
     req1 = req.requests.add()
@@ -163,10 +248,12 @@ def get_profile(access_token, api, useauth, *reqq):
     req5.type = 5
     if len(reqq) >= 5:
         req5.MergeFrom(reqq[4])
-    return api_req(api, access_token, req, useauth = useauth)
+    return retrying_api_req(api, access_token, req, useauth=useauth)
+
+
 def login_ptc(username, password):
     print('[!] login for: {}'.format(username))
-    head = {'User-Agent': 'niantic'}
+    head = {'User-Agent': 'Niantic App'}
     r = SESSION.get(LOGIN_URL, headers=head)
     if r is None:
         return render_template('nope.html', fullmap=fullmap)
@@ -183,7 +270,7 @@ def login_ptc(username, password):
     ticket = None
     try:
         ticket = re.sub('.*ticket=', '', r1.history[0].headers['Location'])
-    except Exception,e:
+    except Exception as e:
         if DEBUG:
             print(r1.json()['errors'][0])
         return None
@@ -200,7 +287,9 @@ def login_ptc(username, password):
     access_token = re.sub('.*access_token=', '', access_token)
 
     return access_token
-def heartbeat(api_endpoint, access_token, response):
+
+
+def get_heartbeat(api_endpoint, access_token, response):
     m4 = pokemon_pb2.RequestEnvelop.Requests()
     m = pokemon_pb2.RequestEnvelop.MessageSingleInt()
     m.f1 = int(time.time() * 1000)
@@ -233,6 +322,190 @@ def heartbeat(api_endpoint, access_token, response):
     heartbeat = pokemon_pb2.ResponseEnvelop.HeartbeatPayload()
     heartbeat.ParseFromString(payload)
     return heartbeat
+
+
+def main():
+    debug("main")
+
+    pokemonsJSON = json.load(open('pokemon.json'))
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-u", "--username", help="PTC Username", required=True)
+    parser.add_argument("-p", "--password", help="PTC Password", required=True)
+    parser.add_argument("-l", "--location", help="Location", required=True)
+    parser.add_argument("-st", "--step_limit", help="Steps", required=True)
+    parser.add_argument("-d", "--debug", help="Debug Mode", action='store_true')
+    parser.set_defaults(DEBUG=True)
+    args = parser.parse_args()
+    default_location = args.location
+    if args.debug:
+        global DEBUG
+        DEBUG = True
+        print('[!] DEBUG mode on')
+
+    retrying_set_location(args.location)
+
+    access_token = login_ptc(args.username, args.password)
+    if access_token is None:
+        print('[-] Wrong username/password')
+        return
+    print('[+] RPC Session Token: {} ...'.format(access_token[:25]))
+
+    api_endpoint = get_api_endpoint(access_token)
+    if api_endpoint is None:
+        print('[-] RPC server offline')
+        return
+    print('[+] Received API endpoint: {}'.format(api_endpoint))
+
+    profile_response = get_profile(access_token, api_endpoint, None)
+    if profile_response is None:
+        print('[-] Ooops...')
+        raise Exception("Could not get profile")
+
+    print('[+] Login successful')
+
+    payload = profile_response.payload[0]
+    profile = pokemon_pb2.ResponseEnvelop.ProfilePayload()
+    profile.ParseFromString(payload)
+    print('[+] Username: {}'.format(profile.profile.username))
+
+    creation_time = datetime.fromtimestamp(int(profile.profile.creation_time) / 1000)
+    print('[+] You are playing Pokemon Go since: {}'.format(
+        creation_time.strftime('%Y-%m-%d %H:%M:%S'),
+    ))
+
+    for curr in profile.profile.currency:
+        print('[+] {}: {}'.format(curr.type, curr.amount))
+
+    origin = LatLng.from_degrees(FLOAT_LAT, FLOAT_LONG)
+    steps = 0
+    steplimit = int(args.step_limit)
+    pos = 1
+    while steps < steplimit:
+        debug("looping: step {} of {}".format(steps, steplimit))
+
+        check_exit()
+
+        original_lat = FLOAT_LAT
+        original_long = FLOAT_LONG
+        parent = CellId.from_lat_lng(LatLng.from_degrees(FLOAT_LAT, FLOAT_LONG)).parent(15)
+        h = get_heartbeat(api_endpoint, access_token, profile_response)
+        hs = [h]
+        seen = set([])
+        for child in parent.children():
+            latlng = LatLng.from_point(Cell(child).get_center())
+            set_location_coords(latlng.lat().degrees, latlng.lng().degrees, 0)
+            hs.append(get_heartbeat(api_endpoint, access_token, profile_response))
+        set_location_coords(original_lat, original_long, 0)
+        visible = []
+        for hh in hs:
+            try:
+                for cell in hh.cells:
+                    for wild in cell.WildPokemon:
+                        hash = wild.SpawnPointId + ':' + str(wild.pokemon.PokemonId)
+                        if (hash not in seen):
+                            visible.append(wild)
+                            seen.add(hash)
+                    if cell.Fort:
+                        for Fort in cell.Fort:
+                            if Fort.Enabled == True:
+                                if Fort.GymPoints:
+                                    gyms.append([Fort.Team, Fort.Latitude, Fort.Longitude])
+                                elif Fort.FortType:
+                                    pokestops.append([Fort.Latitude, Fort.Longitude])
+            except AttributeError:
+                break
+        for poke in visible:
+            other = LatLng.from_degrees(poke.Latitude, poke.Longitude)
+            diff = other - origin
+            # print(diff)
+            difflat = diff.lat().degrees
+            difflng = diff.lng().degrees
+            time_to_hidden = poke.TimeTillHiddenMs
+            left = '%d hours %d minutes %d seconds' % time_left(time_to_hidden)
+            label = '%s [%s remaining]' % (pokemonsJSON[poke.pokemon.PokemonId - 1]['Name'], left)
+            pokemons.append([poke.pokemon.PokemonId, label, poke.Latitude, poke.Longitude])
+
+        offset = (steps*default_step)
+        if pos is 1:
+            set_location_coords(latlng.lat().degrees + offset, latlng.lng().degrees - offset, 0)
+        elif pos is 2:
+            set_location_coords(latlng.lat().degrees + offset, latlng.lng().degrees + offset, 0)
+        elif pos is 3:
+            set_location_coords(latlng.lat().degrees - offset, latlng.lng().degrees - offset, 0)
+        elif pos is 4:
+            set_location_coords(latlng.lat().degrees - offset, latlng.lng().degrees + offset, 0)
+            pos = 0
+            steps += 1
+        pos += 1
+        print "Completed:", ((steps + (pos * .25) - .25) / steplimit) * 100, "%"
+
+        register_background_thread()
+
+
+def register_background_thread(initial_registration=False):
+    """
+    Start a background thread to search for Pokemon
+    while Flask is still able to serve requests for the map
+    :param initial_registration: True if first registration and thread should start immediately, False if it's being called by the finishing thread to schedule a refresh
+    :return: None
+    """
+
+    debug("register_background_thread called")
+    global search_thread
+
+    atexit.register(interrupt)
+
+    if initial_registration:
+        if not werkzeug.serving.is_running_from_reloader():
+            debug("register_background_thread: not running inside Flask so not starting thread")
+            return
+        if search_thread:
+            debug("register_background_thread: initial registration requested but thread already running")
+            return
+
+        debug("register_background_thread: initial registration")
+
+        search_thread = threading.Thread(target=main)
+        search_thread.daemon = True
+        search_thread.name = "search_thread"
+        search_thread.start()
+
+    else:
+        debug("register_background_thread: queueing")
+
+        search_thread = threading.Timer(30, main)  # delay, in seconds
+        search_thread.daemon = True
+        search_thread.name = "search_thread"
+        search_thread.start()
+
+
+def interrupt():
+    '''
+    Called if user presses ^C or Flask is exiting
+    :return: None
+    '''
+    global search_thread
+    global exit_requested
+
+    debug("interrupt: asking background thread to exit")
+    exit_requested = True
+    try:
+        search_thread.cancel()
+    except AttributeError:
+        pass
+
+
+def create_app():
+    app = Flask(__name__, template_folder="templates")
+    app.config['GOOGLEMAPS_KEY'] = GOOGLEMAPS_KEY
+
+    GoogleMaps(app, key=GOOGLEMAPS_KEY)
+    return app
+
+
+app = create_app()
+
+
 @app.route('/')
 def fullmap():
     main()
@@ -279,108 +552,7 @@ def fullmap():
     )
     return render_template('example_fullmap.html', fullmap=fullmap)
 
-def main():
-    pokemonsJSON = json.load(open('pokemon.json'))
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-u", "--username", help="PTC Username", required=True)
-    parser.add_argument("-p", "--password", help="PTC Password", required=True)
-    parser.add_argument("-l", "--location", help="Location", required=True)
-    parser.add_argument("-st", "--step_limit", help="Steps", required=True)
-    parser.add_argument("-d", "--debug", help="Debug Mode", action='store_true')
-    parser.set_defaults(DEBUG=True)
-    args = parser.parse_args()
-    default_location = args.location
-    if args.debug:
-        global DEBUG
-        DEBUG = True
-        print('[!] DEBUG mode on')
-
-    set_location(args.location)
-
-    access_token = login_ptc(args.username, args.password)
-    if access_token is None:
-        print('[-] Wrong username/password')
-        return
-    print('[+] RPC Session Token: {} ...'.format(access_token[:25]))
-
-    api_endpoint = get_api_endpoint(access_token)
-    if api_endpoint is None:
-        print('[-] RPC server offline')
-        return
-    print('[+] Received API endpoint: {}'.format(api_endpoint))
-
-    response = get_profile(access_token, api_endpoint, None)
-    if response is not None:
-        print('[+] Login successful')
-
-        payload = response.payload[0]
-        profile = pokemon_pb2.ResponseEnvelop.ProfilePayload()
-        profile.ParseFromString(payload)
-        print('[+] Username: {}'.format(profile.profile.username))
-
-        creation_time = datetime.fromtimestamp(int(profile.profile.creation_time)/1000)
-        print('[+] You are playing Pokemon Go since: {}'.format(
-            creation_time.strftime('%Y-%m-%d %H:%M:%S'),
-        ))
-
-        for curr in profile.profile.currency:
-            print('[+] {}: {}'.format(curr.type, curr.amount))
-    else:
-        print('[-] Ooops...')
-    origin = LatLng.from_degrees(FLOAT_LAT, FLOAT_LONG)
-    steps = 0
-    steplimit = int(args.step_limit)
-    pos = 1
-    while steps<steplimit:
-        original_lat = FLOAT_LAT
-        original_long = FLOAT_LONG
-        parent = CellId.from_lat_lng(LatLng.from_degrees(FLOAT_LAT, FLOAT_LONG)).parent(15)
-        h = heartbeat(api_endpoint, access_token, response)
-        hs = [h]
-        seen = set([])
-        for child in parent.children():
-            latlng = LatLng.from_point(Cell(child).get_center())
-            set_location_coords(latlng.lat().degrees, latlng.lng().degrees, 0)
-            hs.append(heartbeat(api_endpoint, access_token, response))
-        set_location_coords(original_lat, original_long, 0)
-        visible = []
-        for hh in hs:
-            try:
-                for cell in hh.cells:
-                    for wild in cell.WildPokemon:
-                        hash = wild.SpawnPointId + ':' + str(wild.pokemon.PokemonId)
-                        if (hash not in seen):
-                            visible.append(wild)
-                            seen.add(hash)
-                    if cell.Fort:
-                        for Fort in cell.Fort:
-                            if Fort.Enabled == True:
-                                if Fort.GymPoints:
-                                    gyms.append([Fort.Team, Fort.Latitude, Fort.Longitude])
-                                elif Fort.FortType:
-                                    pokestops.append([Fort.Latitude, Fort.Longitude])
-            except AttributeError:
-                break
-        for poke in visible:
-            other = LatLng.from_degrees(poke.Latitude, poke.Longitude)
-            diff = other - origin
-            # print(diff)
-            difflat = diff.lat().degrees
-            difflng = diff.lng().degrees
-            pokemons.append([poke.pokemon.PokemonId, pokemonsJSON[poke.pokemon.PokemonId - 1]['Name'], poke.Latitude, poke.Longitude])
-        offset = (steps*default_step)
-        if pos is 1:
-            set_location_coords(latlng.lat().degrees+offset, latlng.lng().degrees-offset, 0)
-        elif pos is 2:
-            set_location_coords(latlng.lat().degrees+offset, latlng.lng().degrees+offset, 0)
-        elif pos is 3:
-            set_location_coords(latlng.lat().degrees-offset, latlng.lng().degrees-offset, 0)
-        elif pos is 4:
-            set_location_coords(latlng.lat().degrees-offset, latlng.lng().degrees+offset, 0)
-            pos = 0
-            steps+=1
-        pos += 1
-        print "Completed:",((steps+(pos*.25)-.25)/steplimit)*100,"%"
 
 if __name__ == "__main__":
+    register_background_thread(initial_registration=True)
     app.run(debug=True)

--- a/example.py
+++ b/example.py
@@ -2,8 +2,7 @@
 
 from flask import Flask, render_template
 from flask_googlemaps import GoogleMaps
-from flask_googlemaps import Map, icons
-import math
+from flask_googlemaps import Map
 import requests
 import re
 import struct
@@ -237,7 +236,13 @@ def login_ptc(username, password):
     r = SESSION.get(LOGIN_URL, headers=head)
     if r is None:
         return render_template('nope.html', fullmap=fullmap)
-    jdata = json.loads(r.content)
+
+    try:
+        jdata = json.loads(r.content)
+    except ValueError as e:
+        debug("login_ptc: could not decode JSON from {}".format(r.content))
+        return None
+
     data = {
         'lt': jdata['lt'],
         'execution': jdata['execution'],
@@ -415,7 +420,7 @@ def main():
             pos = 0
             steps += 1
         pos += 1
-        print "Completed:", ((steps + (pos * .25) - .25) / steplimit) * 100, "%"
+        print("Completed:", ((steps + (pos * .25) - .25) / steplimit) * 100, "%")
 
         register_background_thread()
 
@@ -464,7 +469,6 @@ app = create_app()
 
 @app.route('/')
 def fullmap():
-    main()
     pokeMarkers = []
     for pokemon in pokemons:
         currLat, currLon = pokemon[-2], pokemon[-1]


### PR DESCRIPTION
This isn't 100% ready for merge but I wanted to share work-in-progress (especially since it's late here). The main thing this does is run the search code as a background thread, so you can reload the map page as often as you like and instantly see whatever the current results are.  The other big thing it does is retry all network requests on failure, so when the servers are being flaky like they are right now, the search still goes on.  Also, some formatting clean-ups.