### PR TITLE
Generate new pokemon_pb2.py

### DIFF
--- a/pokemon_pb2.py
+++ b/pokemon_pb2.py
@@ -18,7 +18,7 @@ _sym_db = _symbol_database.Default()
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='pokemon.proto',
   package='',
-  serialized_pb=_b('\n\rpokemon.proto\"\xc5\x06\n\x0eRequestEnvelop\x12\x10\n\x08unknown1\x18\x01 \x02(\x05\x12\x0e\n\x06rpc_id\x18\x03 \x01(\x03\x12*\n\x08requests\x18\x04 \x03(\x0b\x32\x18.RequestEnvelop.Requests\x12*\n\x08unknown6\x18\x06 \x01(\x0b\x32\x18.RequestEnvelop.Unknown6\x12\x10\n\x08latitude\x18\x07 \x01(\x06\x12\x11\n\tlongitude\x18\x08 \x01(\x06\x12\x10\n\x08\x61ltitude\x18\t \x01(\x06\x12&\n\x04\x61uth\x18\n \x01(\x0b\x32\x18.RequestEnvelop.AuthInfo\x12\x1f\n\tunknown11\x18\x0b \x01(\x0b\x32\x0c.UnknownAuth\x12\x11\n\tunknown12\x18\x0c \x01(\x03\x1a)\n\x08Requests\x12\x0c\n\x04type\x18\x01 \x02(\x05\x12\x0f\n\x07message\x18\x02 \x01(\x0c\x1a$\n\x13MessageSingleString\x12\r\n\x05\x62ytes\x18\x01 \x02(\x0c\x1a\x1e\n\x10MessageSingleInt\x12\n\n\x02\x66\x31\x18\x01 \x02(\x03\x1a(\n\x0eMessageTwoInts\x12\n\n\x02\x66\x31\x18\x01 \x02(\x03\x12\n\n\x02\x66\x35\x18\x05 \x02(\x03\x1a@\n\x0bMessageQuad\x12\n\n\x02\x66\x31\x18\x01 \x02(\x0c\x12\n\n\x02\x66\x32\x18\x02 \x02(\x0c\x12\x0b\n\x03lat\x18\x03 \x02(\x06\x12\x0c\n\x04long\x18\x04 \x02(\x06\x1a\x16\n\x03Wat\x12\x0f\n\x04lols\x18\x80\x80\x80@ \x03(\x03\x1aI\n\x08Unknown3\x12\x10\n\x08unknown4\x18\x01 \x02(\x0c\x12\x10\n\x08unknown2\x18\x02 \x01(\x0c\x12\x0b\n\x03lat\x18\x03 \x01(\x06\x12\x0c\n\x04long\x18\x04 \x01(\x06\x1ao\n\x08Unknown6\x12\x10\n\x08unknown1\x18\x01 \x02(\x05\x12\x33\n\x08unknown2\x18\x02 \x02(\x0b\x32!.RequestEnvelop.Unknown6.Unknown2\x1a\x1c\n\x08Unknown2\x12\x10\n\x08unknown1\x18\x01 \x02(\x0c\x1au\n\x08\x41uthInfo\x12\x10\n\x08provider\x18\x01 \x02(\t\x12+\n\x05token\x18\x02 \x02(\x0b\x32\x1c.RequestEnvelop.AuthInfo.JWT\x1a*\n\x03JWT\x12\x10\n\x08\x63ontents\x18\x01 \x02(\t\x12\x11\n\tunknown13\x18\x02 \x02(\x05\"F\n\x0bUnknownAuth\x12\x11\n\tunknown71\x18\x01 \x01(\x0c\x12\x11\n\tunknown72\x18\x02 \x01(\x03\x12\x11\n\tunknown73\x18\x03 \x01(\x0c\"\xac\x13\n\x0fResponseEnvelop\x12\x10\n\x08unknown1\x18\x01 \x02(\x05\x12\x10\n\x08unknown2\x18\x02 \x01(\x03\x12\x0f\n\x07\x61pi_url\x18\x03 \x01(\t\x12+\n\x08unknown6\x18\x06 \x01(\x0b\x32\x19.ResponseEnvelop.Unknown6\x12\x1e\n\x08unknown7\x18\x07 \x01(\x0b\x32\x0c.UnknownAuth\x12\x0f\n\x07payload\x18\x64 \x03(\x0c\x1ap\n\x08Unknown6\x12\x10\n\x08unknown1\x18\x01 \x02(\x05\x12\x34\n\x08unknown2\x18\x02 \x02(\x0b\x32\".ResponseEnvelop.Unknown6.Unknown2\x1a\x1c\n\x08Unknown2\x12\x10\n\x08unknown1\x18\x01 \x02(\x0c\x1a\x41\n\x10HeartbeatPayload\x12-\n\x05\x63\x65lls\x18\x01 \x03(\x0b\x32\x1e.ResponseEnvelop.ClientMapCell\x1a\xe9\x03\n\rClientMapCell\x12\x10\n\x08S2CellId\x18\x01 \x02(\x04\x12\x12\n\nAsOfTimeMs\x18\x02 \x02(\x03\x12/\n\x04\x46ort\x18\x03 \x03(\x0b\x32!.ResponseEnvelop.PokemonFortProto\x12:\n\nSpawnPoint\x18\x04 \x03(\x0b\x32&.ResponseEnvelop.ClientSpawnPointProto\x12\x36\n\x0bWildPokemon\x18\x05 \x03(\x0b\x32!.ResponseEnvelop.WildPokemonProto\x12\x17\n\x0fIsTruncatedList\x18\x07 \x01(\x08\x12=\n\x0b\x46ortSummary\x18\x08 \x03(\x0b\x32(.ResponseEnvelop.PokemonSummaryFortProto\x12\x43\n\x13\x44\x65\x63imatedSpawnPoint\x18\t \x03(\x0b\x32&.ResponseEnvelop.ClientSpawnPointProto\x12\x34\n\nMapPokemon\x18\n \x03(\x0b\x32 .ResponseEnvelop.MapPokemonProto\x12:\n\rNearbyPokemon\x18\x0b \x03(\x0b\x32#.ResponseEnvelop.NearbyPokemonProto\x1ah\n\x0bWildPokemon\x12\x10\n\x08UniqueId\x18\x01 \x02(\t\x12\x11\n\tPokemonId\x18\x02 \x02(\t\x12\x34\n\x07pokemon\x18\x0b \x03(\x0b\x32#.ResponseEnvelop.NearbyPokemonProto\x1a\x92\x01\n\x0fMapPokemonProto\x12\x14\n\x0cSpawnpointId\x18\x01 \x02(\t\x12\x13\n\x0b\x45ncounterId\x18\x02 \x02(\x04\x12\x15\n\rPokedexTypeId\x18\x03 \x02(\x05\x12\x18\n\x10\x45xpirationTimeMs\x18\x04 \x02(\x03\x12\x10\n\x08Latitude\x18\x05 \x02(\x01\x12\x11\n\tLongitude\x18\x06 \x02(\x01\x1a\xe7\x02\n\x10PokemonFortProto\x12\x0e\n\x06\x46ortId\x18\x01 \x02(\t\x12\x16\n\x0eLastModifiedMs\x18\x02 \x02(\x03\x12\x10\n\x08Latitude\x18\x03 \x02(\x01\x12\x11\n\tLongitude\x18\x04 \x02(\x01\x12\x0c\n\x04Team\x18\x05 \x02(\x05\x12\x16\n\x0eGuardPokemonId\x18\x06 \x02(\x05\x12\x19\n\x11GuardPokemonLevel\x18\x07 \x02(\x05\x12\x0f\n\x07\x45nabled\x18\x08 \x02(\x08\x12\x10\n\x08\x46ortType\x18\t \x02(\x05\x12\x11\n\tGymPoints\x18\n \x02(\x03\x12\x12\n\nIsInBattle\x18\x0b \x02(\x08\x12\x37\n\rActivePokemon\x18\r \x01(\x0b\x32 .ResponseEnvelop.MapPokemonProto\x12\x1a\n\x12\x43ooldownCompleteMs\x18\x0e \x02(\x03\x12\x0f\n\x07Sponsor\x18\x0f \x02(\x05\x12\x15\n\rRenderingType\x18\x10 \x01(\x05\x1am\n\x17PokemonSummaryFortProto\x12\x15\n\rFortSummaryId\x18\x01 \x02(\t\x12\x16\n\x0eLastModifiedMs\x18\x02 \x02(\x03\x12\x10\n\x08Latitude\x18\x03 \x02(\x01\x12\x11\n\tLongitude\x18\x04 \x02(\x01\x1a<\n\x15\x43lientSpawnPointProto\x12\x10\n\x08Latitude\x18\x02 \x02(\x01\x12\x11\n\tLongitude\x18\x03 \x02(\x01\x1a\xfa\x01\n\x10WildPokemonProto\x12\x13\n\x0b\x45ncounterId\x18\x01 \x01(\x04\x12\x16\n\x0eLastModifiedMs\x18\x02 \x01(\x03\x12\x10\n\x08Latitude\x18\x03 \x01(\x01\x12\x11\n\tLongitude\x18\x04 \x01(\x01\x12\x14\n\x0cSpawnPointId\x18\x05 \x01(\t\x12:\n\x07pokemon\x18\x07 \x01(\x0b\x32).ResponseEnvelop.WildPokemonProto.Pokemon\x12\x18\n\x10TimeTillHiddenMs\x18\x0b \x01(\x05\x1a(\n\x07Pokemon\x12\n\n\x02Id\x18\x01 \x01(\x04\x12\x11\n\tPokemonId\x18\x02 \x01(\x05\x1aX\n\x12NearbyPokemonProto\x12\x15\n\rPokedexNumber\x18\x01 \x01(\x05\x12\x16\n\x0e\x44istanceMeters\x18\x02 \x01(\x02\x12\x13\n\x0b\x45ncounterId\x18\x03 \x01(\x04\x1aM\n\x0eProfilePayload\x12\x10\n\x08unknown1\x18\x01 \x02(\x05\x12)\n\x07profile\x18\x02 \x01(\x0b\x32\x18.ResponseEnvelop.Profile\x1a\xa8\x03\n\x07Profile\x12\x15\n\rcreation_time\x18\x01 \x02(\x03\x12\x10\n\x08username\x18\x02 \x01(\t\x12\x0c\n\x04team\x18\x05 \x01(\x05\x12\x10\n\x08tutorial\x18\x07 \x01(\x0c\x12\x36\n\x06\x61vatar\x18\x08 \x01(\x0b\x32&.ResponseEnvelop.Profile.AvatarDetails\x12\x14\n\x0cpoke_storage\x18\t \x01(\x05\x12\x14\n\x0citem_storage\x18\n \x01(\x05\x12\x11\n\tunknown11\x18\x0b \x01(\t\x12\x11\n\tunknown12\x18\x0c \x01(\t\x12\x11\n\tunknown13\x18\r \x01(\t\x12\x33\n\x08\x63urrency\x18\x0e \x03(\x0b\x32!.ResponseEnvelop.Profile.Currency\x1aX\n\rAvatarDetails\x12\x10\n\x08unknown2\x18\x02 \x01(\x05\x12\x10\n\x08unknown3\x18\x03 \x01(\x05\x12\x10\n\x08unknown9\x18\t \x01(\x05\x12\x11\n\tunknown10\x18\n \x01(\x05\x1a(\n\x08\x43urrency\x12\x0c\n\x04type\x18\x01 \x02(\t\x12\x0e\n\x06\x61mount\x18\x02 \x01(\x05')
+  serialized_pb=_b('\n\rpokemon.proto\"\xc7\x04\n\x0eRequestEnvelop\x12\x10\n\x08unknown1\x18\x01 \x02(\x05\x12\x0e\n\x06rpc_id\x18\x03 \x01(\x03\x12*\n\x08requests\x18\x04 \x03(\x0b\x32\x18.RequestEnvelop.Requests\x12*\n\x08unknown6\x18\x06 \x01(\x0b\x32\x18.RequestEnvelop.Unknown6\x12\x10\n\x08latitude\x18\x07 \x01(\x06\x12\x11\n\tlongitude\x18\x08 \x01(\x06\x12\x10\n\x08\x61ltitude\x18\t \x01(\x06\x12&\n\x04\x61uth\x18\n \x01(\x0b\x32\x18.RequestEnvelop.AuthInfo\x12\x11\n\tunknown12\x18\x0c \x01(\x03\x1a\x43\n\x08Requests\x12\x0c\n\x04type\x18\x01 \x02(\x05\x12)\n\x07message\x18\x02 \x01(\x0b\x32\x18.RequestEnvelop.Unknown3\x1a\x1c\n\x08Unknown3\x12\x10\n\x08unknown4\x18\x01 \x02(\t\x1ao\n\x08Unknown6\x12\x10\n\x08unknown1\x18\x01 \x02(\x05\x12\x33\n\x08unknown2\x18\x02 \x02(\x0b\x32!.RequestEnvelop.Unknown6.Unknown2\x1a\x1c\n\x08Unknown2\x12\x10\n\x08unknown1\x18\x01 \x02(\x0c\x1au\n\x08\x41uthInfo\x12\x10\n\x08provider\x18\x01 \x02(\t\x12+\n\x05token\x18\x02 \x02(\x0b\x32\x1c.RequestEnvelop.AuthInfo.JWT\x1a*\n\x03JWT\x12\x10\n\x08\x63ontents\x18\x01 \x02(\t\x12\x11\n\tunknown13\x18\x02 \x02(\x05\"\xf7\x07\n\x0fResponseEnvelop\x12\x10\n\x08unknown1\x18\x01 \x02(\x05\x12\x10\n\x08unknown2\x18\x02 \x01(\x03\x12\x0f\n\x07\x61pi_url\x18\x03 \x01(\t\x12+\n\x08unknown6\x18\x06 \x01(\x0b\x32\x19.ResponseEnvelop.Unknown6\x12+\n\x08unknown7\x18\x07 \x01(\x0b\x32\x19.ResponseEnvelop.Unknown7\x12)\n\x07payload\x18\x64 \x03(\x0b\x32\x18.ResponseEnvelop.Payload\x1ap\n\x08Unknown6\x12\x10\n\x08unknown1\x18\x01 \x02(\x05\x12\x34\n\x08unknown2\x18\x02 \x02(\x0b\x32\".ResponseEnvelop.Unknown6.Unknown2\x1a\x1c\n\x08Unknown2\x12\x10\n\x08unknown1\x18\x01 \x02(\x0c\x1a\x43\n\x08Unknown7\x12\x11\n\tunknown71\x18\x01 \x01(\x0c\x12\x11\n\tunknown72\x18\x02 \x01(\x03\x12\x11\n\tunknown73\x18\x03 \x01(\x0c\x1a\x46\n\x07Payload\x12\x10\n\x08unknown1\x18\x01 \x02(\x05\x12)\n\x07profile\x18\x02 \x01(\x0b\x32\x18.ResponseEnvelop.Profile\x1a\xaa\x04\n\x07Profile\x12\x15\n\rcreation_time\x18\x01 \x02(\x03\x12\x10\n\x08username\x18\x02 \x01(\t\x12\x0c\n\x04team\x18\x05 \x01(\x05\x12\x10\n\x08tutorial\x18\x07 \x01(\x0c\x12\x36\n\x06\x61vatar\x18\x08 \x01(\x0b\x32&.ResponseEnvelop.Profile.AvatarDetails\x12\x14\n\x0cpoke_storage\x18\t \x01(\x05\x12\x14\n\x0citem_storage\x18\n \x01(\x05\x12\x38\n\x0b\x64\x61ily_bonus\x18\x0b \x01(\x0b\x32#.ResponseEnvelop.Profile.DailyBonus\x12\x11\n\tunknown12\x18\x0c \x01(\x0c\x12\x11\n\tunknown13\x18\r \x01(\x0c\x12\x33\n\x08\x63urrency\x18\x0e \x03(\x0b\x32!.ResponseEnvelop.Profile.Currency\x1aX\n\rAvatarDetails\x12\x10\n\x08unknown2\x18\x02 \x01(\x05\x12\x10\n\x08unknown3\x18\x03 \x01(\x05\x12\x10\n\x08unknown9\x18\t \x01(\x05\x12\x11\n\tunknown10\x18\n \x01(\x05\x1aY\n\nDailyBonus\x12\x1e\n\x16NextCollectTimestampMs\x18\x01 \x01(\x03\x12+\n#NextDefenderBonusCollectTimestampMs\x18\x02 \x01(\x03\x1a(\n\x08\x43urrency\x12\x0c\n\x04type\x18\x01 \x02(\t\x12\x0e\n\x06\x61mount\x18\x02 \x01(\x05')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -41,8 +41,8 @@ _REQUESTENVELOP_REQUESTS = _descriptor.Descriptor(
       options=None),
     _descriptor.FieldDescriptor(
       name='message', full_name='RequestEnvelop.Requests.message', index=1,
-      number=2, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b(""),
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -57,181 +57,8 @@ _REQUESTENVELOP_REQUESTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=305,
-  serialized_end=346,
-)
-
-_REQUESTENVELOP_MESSAGESINGLESTRING = _descriptor.Descriptor(
-  name='MessageSingleString',
-  full_name='RequestEnvelop.MessageSingleString',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='bytes', full_name='RequestEnvelop.MessageSingleString.bytes', index=0,
-      number=1, type=12, cpp_type=9, label=2,
-      has_default_value=False, default_value=_b(""),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=348,
-  serialized_end=384,
-)
-
-_REQUESTENVELOP_MESSAGESINGLEINT = _descriptor.Descriptor(
-  name='MessageSingleInt',
-  full_name='RequestEnvelop.MessageSingleInt',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='f1', full_name='RequestEnvelop.MessageSingleInt.f1', index=0,
-      number=1, type=3, cpp_type=2, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=386,
-  serialized_end=416,
-)
-
-_REQUESTENVELOP_MESSAGETWOINTS = _descriptor.Descriptor(
-  name='MessageTwoInts',
-  full_name='RequestEnvelop.MessageTwoInts',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='f1', full_name='RequestEnvelop.MessageTwoInts.f1', index=0,
-      number=1, type=3, cpp_type=2, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='f5', full_name='RequestEnvelop.MessageTwoInts.f5', index=1,
-      number=5, type=3, cpp_type=2, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=418,
-  serialized_end=458,
-)
-
-_REQUESTENVELOP_MESSAGEQUAD = _descriptor.Descriptor(
-  name='MessageQuad',
-  full_name='RequestEnvelop.MessageQuad',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='f1', full_name='RequestEnvelop.MessageQuad.f1', index=0,
-      number=1, type=12, cpp_type=9, label=2,
-      has_default_value=False, default_value=_b(""),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='f2', full_name='RequestEnvelop.MessageQuad.f2', index=1,
-      number=2, type=12, cpp_type=9, label=2,
-      has_default_value=False, default_value=_b(""),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='lat', full_name='RequestEnvelop.MessageQuad.lat', index=2,
-      number=3, type=6, cpp_type=4, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='long', full_name='RequestEnvelop.MessageQuad.long', index=3,
-      number=4, type=6, cpp_type=4, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=460,
-  serialized_end=524,
-)
-
-_REQUESTENVELOP_WAT = _descriptor.Descriptor(
-  name='Wat',
-  full_name='RequestEnvelop.Wat',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='lols', full_name='RequestEnvelop.Wat.lols', index=0,
-      number=134217728, type=3, cpp_type=2, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=526,
-  serialized_end=548,
+  serialized_start=272,
+  serialized_end=339,
 )
 
 _REQUESTENVELOP_UNKNOWN3 = _descriptor.Descriptor(
@@ -243,29 +70,8 @@ _REQUESTENVELOP_UNKNOWN3 = _descriptor.Descriptor(
   fields=[
     _descriptor.FieldDescriptor(
       name='unknown4', full_name='RequestEnvelop.Unknown3.unknown4', index=0,
-      number=1, type=12, cpp_type=9, label=2,
-      has_default_value=False, default_value=_b(""),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='unknown2', full_name='RequestEnvelop.Unknown3.unknown2', index=1,
-      number=2, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b(""),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='lat', full_name='RequestEnvelop.Unknown3.lat', index=2,
-      number=3, type=6, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='long', full_name='RequestEnvelop.Unknown3.long', index=3,
-      number=4, type=6, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
+      number=1, type=9, cpp_type=9, label=2,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -280,8 +86,8 @@ _REQUESTENVELOP_UNKNOWN3 = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=550,
-  serialized_end=623,
+  serialized_start=341,
+  serialized_end=369,
 )
 
 _REQUESTENVELOP_UNKNOWN6_UNKNOWN2 = _descriptor.Descriptor(
@@ -309,8 +115,8 @@ _REQUESTENVELOP_UNKNOWN6_UNKNOWN2 = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=708,
-  serialized_end=736,
+  serialized_start=454,
+  serialized_end=482,
 )
 
 _REQUESTENVELOP_UNKNOWN6 = _descriptor.Descriptor(
@@ -345,8 +151,8 @@ _REQUESTENVELOP_UNKNOWN6 = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=625,
-  serialized_end=736,
+  serialized_start=371,
+  serialized_end=482,
 )
 
 _REQUESTENVELOP_AUTHINFO_JWT = _descriptor.Descriptor(
@@ -381,8 +187,8 @@ _REQUESTENVELOP_AUTHINFO_JWT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=813,
-  serialized_end=855,
+  serialized_start=559,
+  serialized_end=601,
 )
 
 _REQUESTENVELOP_AUTHINFO = _descriptor.Descriptor(
@@ -417,8 +223,8 @@ _REQUESTENVELOP_AUTHINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=738,
-  serialized_end=855,
+  serialized_start=484,
+  serialized_end=601,
 )
 
 _REQUESTENVELOP = _descriptor.Descriptor(
@@ -485,14 +291,7 @@ _REQUESTENVELOP = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='unknown11', full_name='RequestEnvelop.unknown11', index=8,
-      number=11, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='unknown12', full_name='RequestEnvelop.unknown12', index=9,
+      name='unknown12', full_name='RequestEnvelop.unknown12', index=8,
       number=12, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -501,7 +300,7 @@ _REQUESTENVELOP = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_REQUESTENVELOP_REQUESTS, _REQUESTENVELOP_MESSAGESINGLESTRING, _REQUESTENVELOP_MESSAGESINGLEINT, _REQUESTENVELOP_MESSAGETWOINTS, _REQUESTENVELOP_MESSAGEQUAD, _REQUESTENVELOP_WAT, _REQUESTENVELOP_UNKNOWN3, _REQUESTENVELOP_UNKNOWN6, _REQUESTENVELOP_AUTHINFO, ],
+  nested_types=[_REQUESTENVELOP_REQUESTS, _REQUESTENVELOP_UNKNOWN3, _REQUESTENVELOP_UNKNOWN6, _REQUESTENVELOP_AUTHINFO, ],
   enum_types=[
   ],
   options=None,
@@ -510,51 +309,7 @@ _REQUESTENVELOP = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=18,
-  serialized_end=855,
-)
-
-
-_UNKNOWNAUTH = _descriptor.Descriptor(
-  name='UnknownAuth',
-  full_name='UnknownAuth',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='unknown71', full_name='UnknownAuth.unknown71', index=0,
-      number=1, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b(""),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='unknown72', full_name='UnknownAuth.unknown72', index=1,
-      number=2, type=3, cpp_type=2, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='unknown73', full_name='UnknownAuth.unknown73', index=2,
-      number=3, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b(""),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=857,
-  serialized_end=927,
+  serialized_end=601,
 )
 
 
@@ -583,8 +338,8 @@ _RESPONSEENVELOP_UNKNOWN6_UNKNOWN2 = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=708,
-  serialized_end=736,
+  serialized_start=454,
+  serialized_end=482,
 )
 
 _RESPONSEENVELOP_UNKNOWN6 = _descriptor.Descriptor(
@@ -619,583 +374,35 @@ _RESPONSEENVELOP_UNKNOWN6 = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1096,
-  serialized_end=1208,
+  serialized_start=809,
+  serialized_end=921,
 )
 
-_RESPONSEENVELOP_HEARTBEATPAYLOAD = _descriptor.Descriptor(
-  name='HeartbeatPayload',
-  full_name='ResponseEnvelop.HeartbeatPayload',
+_RESPONSEENVELOP_UNKNOWN7 = _descriptor.Descriptor(
+  name='Unknown7',
+  full_name='ResponseEnvelop.Unknown7',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='cells', full_name='ResponseEnvelop.HeartbeatPayload.cells', index=0,
-      number=1, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=1210,
-  serialized_end=1275,
-)
-
-_RESPONSEENVELOP_CLIENTMAPCELL = _descriptor.Descriptor(
-  name='ClientMapCell',
-  full_name='ResponseEnvelop.ClientMapCell',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='S2CellId', full_name='ResponseEnvelop.ClientMapCell.S2CellId', index=0,
-      number=1, type=4, cpp_type=4, label=2,
-      has_default_value=False, default_value=0,
+      name='unknown71', full_name='ResponseEnvelop.Unknown7.unknown71', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='AsOfTimeMs', full_name='ResponseEnvelop.ClientMapCell.AsOfTimeMs', index=1,
-      number=2, type=3, cpp_type=2, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='Fort', full_name='ResponseEnvelop.ClientMapCell.Fort', index=2,
-      number=3, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='SpawnPoint', full_name='ResponseEnvelop.ClientMapCell.SpawnPoint', index=3,
-      number=4, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='WildPokemon', full_name='ResponseEnvelop.ClientMapCell.WildPokemon', index=4,
-      number=5, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='IsTruncatedList', full_name='ResponseEnvelop.ClientMapCell.IsTruncatedList', index=5,
-      number=7, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='FortSummary', full_name='ResponseEnvelop.ClientMapCell.FortSummary', index=6,
-      number=8, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='DecimatedSpawnPoint', full_name='ResponseEnvelop.ClientMapCell.DecimatedSpawnPoint', index=7,
-      number=9, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='MapPokemon', full_name='ResponseEnvelop.ClientMapCell.MapPokemon', index=8,
-      number=10, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='NearbyPokemon', full_name='ResponseEnvelop.ClientMapCell.NearbyPokemon', index=9,
-      number=11, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=1278,
-  serialized_end=1767,
-)
-
-_RESPONSEENVELOP_WILDPOKEMON = _descriptor.Descriptor(
-  name='WildPokemon',
-  full_name='ResponseEnvelop.WildPokemon',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='UniqueId', full_name='ResponseEnvelop.WildPokemon.UniqueId', index=0,
-      number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='PokemonId', full_name='ResponseEnvelop.WildPokemon.PokemonId', index=1,
-      number=2, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='pokemon', full_name='ResponseEnvelop.WildPokemon.pokemon', index=2,
-      number=11, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=1769,
-  serialized_end=1873,
-)
-
-_RESPONSEENVELOP_MAPPOKEMONPROTO = _descriptor.Descriptor(
-  name='MapPokemonProto',
-  full_name='ResponseEnvelop.MapPokemonProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='SpawnpointId', full_name='ResponseEnvelop.MapPokemonProto.SpawnpointId', index=0,
-      number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='EncounterId', full_name='ResponseEnvelop.MapPokemonProto.EncounterId', index=1,
-      number=2, type=4, cpp_type=4, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='PokedexTypeId', full_name='ResponseEnvelop.MapPokemonProto.PokedexTypeId', index=2,
-      number=3, type=5, cpp_type=1, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='ExpirationTimeMs', full_name='ResponseEnvelop.MapPokemonProto.ExpirationTimeMs', index=3,
-      number=4, type=3, cpp_type=2, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='Latitude', full_name='ResponseEnvelop.MapPokemonProto.Latitude', index=4,
-      number=5, type=1, cpp_type=5, label=2,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='Longitude', full_name='ResponseEnvelop.MapPokemonProto.Longitude', index=5,
-      number=6, type=1, cpp_type=5, label=2,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=1876,
-  serialized_end=2022,
-)
-
-_RESPONSEENVELOP_POKEMONFORTPROTO = _descriptor.Descriptor(
-  name='PokemonFortProto',
-  full_name='ResponseEnvelop.PokemonFortProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='FortId', full_name='ResponseEnvelop.PokemonFortProto.FortId', index=0,
-      number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='LastModifiedMs', full_name='ResponseEnvelop.PokemonFortProto.LastModifiedMs', index=1,
-      number=2, type=3, cpp_type=2, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='Latitude', full_name='ResponseEnvelop.PokemonFortProto.Latitude', index=2,
-      number=3, type=1, cpp_type=5, label=2,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='Longitude', full_name='ResponseEnvelop.PokemonFortProto.Longitude', index=3,
-      number=4, type=1, cpp_type=5, label=2,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='Team', full_name='ResponseEnvelop.PokemonFortProto.Team', index=4,
-      number=5, type=5, cpp_type=1, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='GuardPokemonId', full_name='ResponseEnvelop.PokemonFortProto.GuardPokemonId', index=5,
-      number=6, type=5, cpp_type=1, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='GuardPokemonLevel', full_name='ResponseEnvelop.PokemonFortProto.GuardPokemonLevel', index=6,
-      number=7, type=5, cpp_type=1, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='Enabled', full_name='ResponseEnvelop.PokemonFortProto.Enabled', index=7,
-      number=8, type=8, cpp_type=7, label=2,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='FortType', full_name='ResponseEnvelop.PokemonFortProto.FortType', index=8,
-      number=9, type=5, cpp_type=1, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='GymPoints', full_name='ResponseEnvelop.PokemonFortProto.GymPoints', index=9,
-      number=10, type=3, cpp_type=2, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='IsInBattle', full_name='ResponseEnvelop.PokemonFortProto.IsInBattle', index=10,
-      number=11, type=8, cpp_type=7, label=2,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='ActivePokemon', full_name='ResponseEnvelop.PokemonFortProto.ActivePokemon', index=11,
-      number=13, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='CooldownCompleteMs', full_name='ResponseEnvelop.PokemonFortProto.CooldownCompleteMs', index=12,
-      number=14, type=3, cpp_type=2, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='Sponsor', full_name='ResponseEnvelop.PokemonFortProto.Sponsor', index=13,
-      number=15, type=5, cpp_type=1, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='RenderingType', full_name='ResponseEnvelop.PokemonFortProto.RenderingType', index=14,
-      number=16, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=2025,
-  serialized_end=2384,
-)
-
-_RESPONSEENVELOP_POKEMONSUMMARYFORTPROTO = _descriptor.Descriptor(
-  name='PokemonSummaryFortProto',
-  full_name='ResponseEnvelop.PokemonSummaryFortProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='FortSummaryId', full_name='ResponseEnvelop.PokemonSummaryFortProto.FortSummaryId', index=0,
-      number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='LastModifiedMs', full_name='ResponseEnvelop.PokemonSummaryFortProto.LastModifiedMs', index=1,
-      number=2, type=3, cpp_type=2, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='Latitude', full_name='ResponseEnvelop.PokemonSummaryFortProto.Latitude', index=2,
-      number=3, type=1, cpp_type=5, label=2,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='Longitude', full_name='ResponseEnvelop.PokemonSummaryFortProto.Longitude', index=3,
-      number=4, type=1, cpp_type=5, label=2,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=2386,
-  serialized_end=2495,
-)
-
-_RESPONSEENVELOP_CLIENTSPAWNPOINTPROTO = _descriptor.Descriptor(
-  name='ClientSpawnPointProto',
-  full_name='ResponseEnvelop.ClientSpawnPointProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='Latitude', full_name='ResponseEnvelop.ClientSpawnPointProto.Latitude', index=0,
-      number=2, type=1, cpp_type=5, label=2,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='Longitude', full_name='ResponseEnvelop.ClientSpawnPointProto.Longitude', index=1,
-      number=3, type=1, cpp_type=5, label=2,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=2497,
-  serialized_end=2557,
-)
-
-_RESPONSEENVELOP_WILDPOKEMONPROTO_POKEMON = _descriptor.Descriptor(
-  name='Pokemon',
-  full_name='ResponseEnvelop.WildPokemonProto.Pokemon',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='Id', full_name='ResponseEnvelop.WildPokemonProto.Pokemon.Id', index=0,
-      number=1, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='PokemonId', full_name='ResponseEnvelop.WildPokemonProto.Pokemon.PokemonId', index=1,
-      number=2, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=2770,
-  serialized_end=2810,
-)
-
-_RESPONSEENVELOP_WILDPOKEMONPROTO = _descriptor.Descriptor(
-  name='WildPokemonProto',
-  full_name='ResponseEnvelop.WildPokemonProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='EncounterId', full_name='ResponseEnvelop.WildPokemonProto.EncounterId', index=0,
-      number=1, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='LastModifiedMs', full_name='ResponseEnvelop.WildPokemonProto.LastModifiedMs', index=1,
+      name='unknown72', full_name='ResponseEnvelop.Unknown7.unknown72', index=1,
       number=2, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='Latitude', full_name='ResponseEnvelop.WildPokemonProto.Latitude', index=2,
-      number=3, type=1, cpp_type=5, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='Longitude', full_name='ResponseEnvelop.WildPokemonProto.Longitude', index=3,
-      number=4, type=1, cpp_type=5, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='SpawnPointId', full_name='ResponseEnvelop.WildPokemonProto.SpawnPointId', index=4,
-      number=5, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='pokemon', full_name='ResponseEnvelop.WildPokemonProto.pokemon', index=5,
-      number=7, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='TimeTillHiddenMs', full_name='ResponseEnvelop.WildPokemonProto.TimeTillHiddenMs', index=6,
-      number=11, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[_RESPONSEENVELOP_WILDPOKEMONPROTO_POKEMON, ],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=2560,
-  serialized_end=2810,
-)
-
-_RESPONSEENVELOP_NEARBYPOKEMONPROTO = _descriptor.Descriptor(
-  name='NearbyPokemonProto',
-  full_name='ResponseEnvelop.NearbyPokemonProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='PokedexNumber', full_name='ResponseEnvelop.NearbyPokemonProto.PokedexNumber', index=0,
-      number=1, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='DistanceMeters', full_name='ResponseEnvelop.NearbyPokemonProto.DistanceMeters', index=1,
-      number=2, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='EncounterId', full_name='ResponseEnvelop.NearbyPokemonProto.EncounterId', index=2,
-      number=3, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
+      name='unknown73', full_name='ResponseEnvelop.Unknown7.unknown73', index=2,
+      number=3, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -1210,26 +417,26 @@ _RESPONSEENVELOP_NEARBYPOKEMONPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2812,
-  serialized_end=2900,
+  serialized_start=923,
+  serialized_end=990,
 )
 
-_RESPONSEENVELOP_PROFILEPAYLOAD = _descriptor.Descriptor(
-  name='ProfilePayload',
-  full_name='ResponseEnvelop.ProfilePayload',
+_RESPONSEENVELOP_PAYLOAD = _descriptor.Descriptor(
+  name='Payload',
+  full_name='ResponseEnvelop.Payload',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='unknown1', full_name='ResponseEnvelop.ProfilePayload.unknown1', index=0,
+      name='unknown1', full_name='ResponseEnvelop.Payload.unknown1', index=0,
       number=1, type=5, cpp_type=1, label=2,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='profile', full_name='ResponseEnvelop.ProfilePayload.profile', index=1,
+      name='profile', full_name='ResponseEnvelop.Payload.profile', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -1246,8 +453,8 @@ _RESPONSEENVELOP_PROFILEPAYLOAD = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2902,
-  serialized_end=2979,
+  serialized_start=992,
+  serialized_end=1062,
 )
 
 _RESPONSEENVELOP_PROFILE_AVATARDETAILS = _descriptor.Descriptor(
@@ -1296,8 +503,44 @@ _RESPONSEENVELOP_PROFILE_AVATARDETAILS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3276,
-  serialized_end=3364,
+  serialized_start=1398,
+  serialized_end=1486,
+)
+
+_RESPONSEENVELOP_PROFILE_DAILYBONUS = _descriptor.Descriptor(
+  name='DailyBonus',
+  full_name='ResponseEnvelop.Profile.DailyBonus',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='NextCollectTimestampMs', full_name='ResponseEnvelop.Profile.DailyBonus.NextCollectTimestampMs', index=0,
+      number=1, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='NextDefenderBonusCollectTimestampMs', full_name='ResponseEnvelop.Profile.DailyBonus.NextDefenderBonusCollectTimestampMs', index=1,
+      number=2, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1488,
+  serialized_end=1577,
 )
 
 _RESPONSEENVELOP_PROFILE_CURRENCY = _descriptor.Descriptor(
@@ -1332,8 +575,8 @@ _RESPONSEENVELOP_PROFILE_CURRENCY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3366,
-  serialized_end=3406,
+  serialized_start=1579,
+  serialized_end=1619,
 )
 
 _RESPONSEENVELOP_PROFILE = _descriptor.Descriptor(
@@ -1393,23 +636,23 @@ _RESPONSEENVELOP_PROFILE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='unknown11', full_name='ResponseEnvelop.Profile.unknown11', index=7,
-      number=11, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
+      name='daily_bonus', full_name='ResponseEnvelop.Profile.daily_bonus', index=7,
+      number=11, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
       name='unknown12', full_name='ResponseEnvelop.Profile.unknown12', index=8,
-      number=12, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
+      number=12, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
       name='unknown13', full_name='ResponseEnvelop.Profile.unknown13', index=9,
-      number=13, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
+      number=13, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -1423,7 +666,7 @@ _RESPONSEENVELOP_PROFILE = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_RESPONSEENVELOP_PROFILE_AVATARDETAILS, _RESPONSEENVELOP_PROFILE_CURRENCY, ],
+  nested_types=[_RESPONSEENVELOP_PROFILE_AVATARDETAILS, _RESPONSEENVELOP_PROFILE_DAILYBONUS, _RESPONSEENVELOP_PROFILE_CURRENCY, ],
   enum_types=[
   ],
   options=None,
@@ -1431,8 +674,8 @@ _RESPONSEENVELOP_PROFILE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2982,
-  serialized_end=3406,
+  serialized_start=1065,
+  serialized_end=1619,
 )
 
 _RESPONSEENVELOP = _descriptor.Descriptor(
@@ -1479,7 +722,7 @@ _RESPONSEENVELOP = _descriptor.Descriptor(
       options=None),
     _descriptor.FieldDescriptor(
       name='payload', full_name='ResponseEnvelop.payload', index=5,
-      number=100, type=12, cpp_type=9, label=3,
+      number=100, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -1487,7 +730,7 @@ _RESPONSEENVELOP = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_RESPONSEENVELOP_UNKNOWN6, _RESPONSEENVELOP_HEARTBEATPAYLOAD, _RESPONSEENVELOP_CLIENTMAPCELL, _RESPONSEENVELOP_WILDPOKEMON, _RESPONSEENVELOP_MAPPOKEMONPROTO, _RESPONSEENVELOP_POKEMONFORTPROTO, _RESPONSEENVELOP_POKEMONSUMMARYFORTPROTO, _RESPONSEENVELOP_CLIENTSPAWNPOINTPROTO, _RESPONSEENVELOP_WILDPOKEMONPROTO, _RESPONSEENVELOP_NEARBYPOKEMONPROTO, _RESPONSEENVELOP_PROFILEPAYLOAD, _RESPONSEENVELOP_PROFILE, ],
+  nested_types=[_RESPONSEENVELOP_UNKNOWN6, _RESPONSEENVELOP_UNKNOWN7, _RESPONSEENVELOP_PAYLOAD, _RESPONSEENVELOP_PROFILE, ],
   enum_types=[
   ],
   options=None,
@@ -1495,16 +738,12 @@ _RESPONSEENVELOP = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=930,
-  serialized_end=3406,
+  serialized_start=604,
+  serialized_end=1619,
 )
 
+_REQUESTENVELOP_REQUESTS.fields_by_name['message'].message_type = _REQUESTENVELOP_UNKNOWN3
 _REQUESTENVELOP_REQUESTS.containing_type = _REQUESTENVELOP
-_REQUESTENVELOP_MESSAGESINGLESTRING.containing_type = _REQUESTENVELOP
-_REQUESTENVELOP_MESSAGESINGLEINT.containing_type = _REQUESTENVELOP
-_REQUESTENVELOP_MESSAGETWOINTS.containing_type = _REQUESTENVELOP
-_REQUESTENVELOP_MESSAGEQUAD.containing_type = _REQUESTENVELOP
-_REQUESTENVELOP_WAT.containing_type = _REQUESTENVELOP
 _REQUESTENVELOP_UNKNOWN3.containing_type = _REQUESTENVELOP
 _REQUESTENVELOP_UNKNOWN6_UNKNOWN2.containing_type = _REQUESTENVELOP_UNKNOWN6
 _REQUESTENVELOP_UNKNOWN6.fields_by_name['unknown2'].message_type = _REQUESTENVELOP_UNKNOWN6_UNKNOWN2
@@ -1515,42 +754,23 @@ _REQUESTENVELOP_AUTHINFO.containing_type = _REQUESTENVELOP
 _REQUESTENVELOP.fields_by_name['requests'].message_type = _REQUESTENVELOP_REQUESTS
 _REQUESTENVELOP.fields_by_name['unknown6'].message_type = _REQUESTENVELOP_UNKNOWN6
 _REQUESTENVELOP.fields_by_name['auth'].message_type = _REQUESTENVELOP_AUTHINFO
-_REQUESTENVELOP.fields_by_name['unknown11'].message_type = _UNKNOWNAUTH
 _RESPONSEENVELOP_UNKNOWN6_UNKNOWN2.containing_type = _RESPONSEENVELOP_UNKNOWN6
 _RESPONSEENVELOP_UNKNOWN6.fields_by_name['unknown2'].message_type = _RESPONSEENVELOP_UNKNOWN6_UNKNOWN2
 _RESPONSEENVELOP_UNKNOWN6.containing_type = _RESPONSEENVELOP
-_RESPONSEENVELOP_HEARTBEATPAYLOAD.fields_by_name['cells'].message_type = _RESPONSEENVELOP_CLIENTMAPCELL
-_RESPONSEENVELOP_HEARTBEATPAYLOAD.containing_type = _RESPONSEENVELOP
-_RESPONSEENVELOP_CLIENTMAPCELL.fields_by_name['Fort'].message_type = _RESPONSEENVELOP_POKEMONFORTPROTO
-_RESPONSEENVELOP_CLIENTMAPCELL.fields_by_name['SpawnPoint'].message_type = _RESPONSEENVELOP_CLIENTSPAWNPOINTPROTO
-_RESPONSEENVELOP_CLIENTMAPCELL.fields_by_name['WildPokemon'].message_type = _RESPONSEENVELOP_WILDPOKEMONPROTO
-_RESPONSEENVELOP_CLIENTMAPCELL.fields_by_name['FortSummary'].message_type = _RESPONSEENVELOP_POKEMONSUMMARYFORTPROTO
-_RESPONSEENVELOP_CLIENTMAPCELL.fields_by_name['DecimatedSpawnPoint'].message_type = _RESPONSEENVELOP_CLIENTSPAWNPOINTPROTO
-_RESPONSEENVELOP_CLIENTMAPCELL.fields_by_name['MapPokemon'].message_type = _RESPONSEENVELOP_MAPPOKEMONPROTO
-_RESPONSEENVELOP_CLIENTMAPCELL.fields_by_name['NearbyPokemon'].message_type = _RESPONSEENVELOP_NEARBYPOKEMONPROTO
-_RESPONSEENVELOP_CLIENTMAPCELL.containing_type = _RESPONSEENVELOP
-_RESPONSEENVELOP_WILDPOKEMON.fields_by_name['pokemon'].message_type = _RESPONSEENVELOP_NEARBYPOKEMONPROTO
-_RESPONSEENVELOP_WILDPOKEMON.containing_type = _RESPONSEENVELOP
-_RESPONSEENVELOP_MAPPOKEMONPROTO.containing_type = _RESPONSEENVELOP
-_RESPONSEENVELOP_POKEMONFORTPROTO.fields_by_name['ActivePokemon'].message_type = _RESPONSEENVELOP_MAPPOKEMONPROTO
-_RESPONSEENVELOP_POKEMONFORTPROTO.containing_type = _RESPONSEENVELOP
-_RESPONSEENVELOP_POKEMONSUMMARYFORTPROTO.containing_type = _RESPONSEENVELOP
-_RESPONSEENVELOP_CLIENTSPAWNPOINTPROTO.containing_type = _RESPONSEENVELOP
-_RESPONSEENVELOP_WILDPOKEMONPROTO_POKEMON.containing_type = _RESPONSEENVELOP_WILDPOKEMONPROTO
-_RESPONSEENVELOP_WILDPOKEMONPROTO.fields_by_name['pokemon'].message_type = _RESPONSEENVELOP_WILDPOKEMONPROTO_POKEMON
-_RESPONSEENVELOP_WILDPOKEMONPROTO.containing_type = _RESPONSEENVELOP
-_RESPONSEENVELOP_NEARBYPOKEMONPROTO.containing_type = _RESPONSEENVELOP
-_RESPONSEENVELOP_PROFILEPAYLOAD.fields_by_name['profile'].message_type = _RESPONSEENVELOP_PROFILE
-_RESPONSEENVELOP_PROFILEPAYLOAD.containing_type = _RESPONSEENVELOP
+_RESPONSEENVELOP_UNKNOWN7.containing_type = _RESPONSEENVELOP
+_RESPONSEENVELOP_PAYLOAD.fields_by_name['profile'].message_type = _RESPONSEENVELOP_PROFILE
+_RESPONSEENVELOP_PAYLOAD.containing_type = _RESPONSEENVELOP
 _RESPONSEENVELOP_PROFILE_AVATARDETAILS.containing_type = _RESPONSEENVELOP_PROFILE
+_RESPONSEENVELOP_PROFILE_DAILYBONUS.containing_type = _RESPONSEENVELOP_PROFILE
 _RESPONSEENVELOP_PROFILE_CURRENCY.containing_type = _RESPONSEENVELOP_PROFILE
 _RESPONSEENVELOP_PROFILE.fields_by_name['avatar'].message_type = _RESPONSEENVELOP_PROFILE_AVATARDETAILS
+_RESPONSEENVELOP_PROFILE.fields_by_name['daily_bonus'].message_type = _RESPONSEENVELOP_PROFILE_DAILYBONUS
 _RESPONSEENVELOP_PROFILE.fields_by_name['currency'].message_type = _RESPONSEENVELOP_PROFILE_CURRENCY
 _RESPONSEENVELOP_PROFILE.containing_type = _RESPONSEENVELOP
 _RESPONSEENVELOP.fields_by_name['unknown6'].message_type = _RESPONSEENVELOP_UNKNOWN6
-_RESPONSEENVELOP.fields_by_name['unknown7'].message_type = _UNKNOWNAUTH
+_RESPONSEENVELOP.fields_by_name['unknown7'].message_type = _RESPONSEENVELOP_UNKNOWN7
+_RESPONSEENVELOP.fields_by_name['payload'].message_type = _RESPONSEENVELOP_PAYLOAD
 DESCRIPTOR.message_types_by_name['RequestEnvelop'] = _REQUESTENVELOP
-DESCRIPTOR.message_types_by_name['UnknownAuth'] = _UNKNOWNAUTH
 DESCRIPTOR.message_types_by_name['ResponseEnvelop'] = _RESPONSEENVELOP
 
 RequestEnvelop = _reflection.GeneratedProtocolMessageType('RequestEnvelop', (_message.Message,), dict(
@@ -1559,41 +779,6 @@ RequestEnvelop = _reflection.GeneratedProtocolMessageType('RequestEnvelop', (_me
     DESCRIPTOR = _REQUESTENVELOP_REQUESTS,
     __module__ = 'pokemon_pb2'
     # @@protoc_insertion_point(class_scope:RequestEnvelop.Requests)
-    ))
-  ,
-
-  MessageSingleString = _reflection.GeneratedProtocolMessageType('MessageSingleString', (_message.Message,), dict(
-    DESCRIPTOR = _REQUESTENVELOP_MESSAGESINGLESTRING,
-    __module__ = 'pokemon_pb2'
-    # @@protoc_insertion_point(class_scope:RequestEnvelop.MessageSingleString)
-    ))
-  ,
-
-  MessageSingleInt = _reflection.GeneratedProtocolMessageType('MessageSingleInt', (_message.Message,), dict(
-    DESCRIPTOR = _REQUESTENVELOP_MESSAGESINGLEINT,
-    __module__ = 'pokemon_pb2'
-    # @@protoc_insertion_point(class_scope:RequestEnvelop.MessageSingleInt)
-    ))
-  ,
-
-  MessageTwoInts = _reflection.GeneratedProtocolMessageType('MessageTwoInts', (_message.Message,), dict(
-    DESCRIPTOR = _REQUESTENVELOP_MESSAGETWOINTS,
-    __module__ = 'pokemon_pb2'
-    # @@protoc_insertion_point(class_scope:RequestEnvelop.MessageTwoInts)
-    ))
-  ,
-
-  MessageQuad = _reflection.GeneratedProtocolMessageType('MessageQuad', (_message.Message,), dict(
-    DESCRIPTOR = _REQUESTENVELOP_MESSAGEQUAD,
-    __module__ = 'pokemon_pb2'
-    # @@protoc_insertion_point(class_scope:RequestEnvelop.MessageQuad)
-    ))
-  ,
-
-  Wat = _reflection.GeneratedProtocolMessageType('Wat', (_message.Message,), dict(
-    DESCRIPTOR = _REQUESTENVELOP_WAT,
-    __module__ = 'pokemon_pb2'
-    # @@protoc_insertion_point(class_scope:RequestEnvelop.Wat)
     ))
   ,
 
@@ -1637,23 +822,11 @@ RequestEnvelop = _reflection.GeneratedProtocolMessageType('RequestEnvelop', (_me
   ))
 _sym_db.RegisterMessage(RequestEnvelop)
 _sym_db.RegisterMessage(RequestEnvelop.Requests)
-_sym_db.RegisterMessage(RequestEnvelop.MessageSingleString)
-_sym_db.RegisterMessage(RequestEnvelop.MessageSingleInt)
-_sym_db.RegisterMessage(RequestEnvelop.MessageTwoInts)
-_sym_db.RegisterMessage(RequestEnvelop.MessageQuad)
-_sym_db.RegisterMessage(RequestEnvelop.Wat)
 _sym_db.RegisterMessage(RequestEnvelop.Unknown3)
 _sym_db.RegisterMessage(RequestEnvelop.Unknown6)
 _sym_db.RegisterMessage(RequestEnvelop.Unknown6.Unknown2)
 _sym_db.RegisterMessage(RequestEnvelop.AuthInfo)
 _sym_db.RegisterMessage(RequestEnvelop.AuthInfo.JWT)
-
-UnknownAuth = _reflection.GeneratedProtocolMessageType('UnknownAuth', (_message.Message,), dict(
-  DESCRIPTOR = _UNKNOWNAUTH,
-  __module__ = 'pokemon_pb2'
-  # @@protoc_insertion_point(class_scope:UnknownAuth)
-  ))
-_sym_db.RegisterMessage(UnknownAuth)
 
 ResponseEnvelop = _reflection.GeneratedProtocolMessageType('ResponseEnvelop', (_message.Message,), dict(
 
@@ -1671,80 +844,17 @@ ResponseEnvelop = _reflection.GeneratedProtocolMessageType('ResponseEnvelop', (_
     ))
   ,
 
-  HeartbeatPayload = _reflection.GeneratedProtocolMessageType('HeartbeatPayload', (_message.Message,), dict(
-    DESCRIPTOR = _RESPONSEENVELOP_HEARTBEATPAYLOAD,
+  Unknown7 = _reflection.GeneratedProtocolMessageType('Unknown7', (_message.Message,), dict(
+    DESCRIPTOR = _RESPONSEENVELOP_UNKNOWN7,
     __module__ = 'pokemon_pb2'
-    # @@protoc_insertion_point(class_scope:ResponseEnvelop.HeartbeatPayload)
+    # @@protoc_insertion_point(class_scope:ResponseEnvelop.Unknown7)
     ))
   ,
 
-  ClientMapCell = _reflection.GeneratedProtocolMessageType('ClientMapCell', (_message.Message,), dict(
-    DESCRIPTOR = _RESPONSEENVELOP_CLIENTMAPCELL,
+  Payload = _reflection.GeneratedProtocolMessageType('Payload', (_message.Message,), dict(
+    DESCRIPTOR = _RESPONSEENVELOP_PAYLOAD,
     __module__ = 'pokemon_pb2'
-    # @@protoc_insertion_point(class_scope:ResponseEnvelop.ClientMapCell)
-    ))
-  ,
-
-  WildPokemon = _reflection.GeneratedProtocolMessageType('WildPokemon', (_message.Message,), dict(
-    DESCRIPTOR = _RESPONSEENVELOP_WILDPOKEMON,
-    __module__ = 'pokemon_pb2'
-    # @@protoc_insertion_point(class_scope:ResponseEnvelop.WildPokemon)
-    ))
-  ,
-
-  MapPokemonProto = _reflection.GeneratedProtocolMessageType('MapPokemonProto', (_message.Message,), dict(
-    DESCRIPTOR = _RESPONSEENVELOP_MAPPOKEMONPROTO,
-    __module__ = 'pokemon_pb2'
-    # @@protoc_insertion_point(class_scope:ResponseEnvelop.MapPokemonProto)
-    ))
-  ,
-
-  PokemonFortProto = _reflection.GeneratedProtocolMessageType('PokemonFortProto', (_message.Message,), dict(
-    DESCRIPTOR = _RESPONSEENVELOP_POKEMONFORTPROTO,
-    __module__ = 'pokemon_pb2'
-    # @@protoc_insertion_point(class_scope:ResponseEnvelop.PokemonFortProto)
-    ))
-  ,
-
-  PokemonSummaryFortProto = _reflection.GeneratedProtocolMessageType('PokemonSummaryFortProto', (_message.Message,), dict(
-    DESCRIPTOR = _RESPONSEENVELOP_POKEMONSUMMARYFORTPROTO,
-    __module__ = 'pokemon_pb2'
-    # @@protoc_insertion_point(class_scope:ResponseEnvelop.PokemonSummaryFortProto)
-    ))
-  ,
-
-  ClientSpawnPointProto = _reflection.GeneratedProtocolMessageType('ClientSpawnPointProto', (_message.Message,), dict(
-    DESCRIPTOR = _RESPONSEENVELOP_CLIENTSPAWNPOINTPROTO,
-    __module__ = 'pokemon_pb2'
-    # @@protoc_insertion_point(class_scope:ResponseEnvelop.ClientSpawnPointProto)
-    ))
-  ,
-
-  WildPokemonProto = _reflection.GeneratedProtocolMessageType('WildPokemonProto', (_message.Message,), dict(
-
-    Pokemon = _reflection.GeneratedProtocolMessageType('Pokemon', (_message.Message,), dict(
-      DESCRIPTOR = _RESPONSEENVELOP_WILDPOKEMONPROTO_POKEMON,
-      __module__ = 'pokemon_pb2'
-      # @@protoc_insertion_point(class_scope:ResponseEnvelop.WildPokemonProto.Pokemon)
-      ))
-    ,
-    DESCRIPTOR = _RESPONSEENVELOP_WILDPOKEMONPROTO,
-    __module__ = 'pokemon_pb2'
-    # @@protoc_insertion_point(class_scope:ResponseEnvelop.WildPokemonProto)
-    ))
-  ,
-
-  NearbyPokemonProto = _reflection.GeneratedProtocolMessageType('NearbyPokemonProto', (_message.Message,), dict(
-    DESCRIPTOR = _RESPONSEENVELOP_NEARBYPOKEMONPROTO,
-    __module__ = 'pokemon_pb2'
-    # @@protoc_insertion_point(class_scope:ResponseEnvelop.NearbyPokemonProto)
-    ))
-  ,
-
-  ProfilePayload = _reflection.GeneratedProtocolMessageType('ProfilePayload', (_message.Message,), dict(
-    DESCRIPTOR = _RESPONSEENVELOP_PROFILEPAYLOAD,
-    __module__ = 'pokemon_pb2'
-    # @@protoc_insertion_point(class_scope:ResponseEnvelop.ProfilePayload)
+    # @@protoc_insertion_point(class_scope:ResponseEnvelop.Payload)
     ))
   ,
 
@@ -1754,6 +864,13 @@ ResponseEnvelop = _reflection.GeneratedProtocolMessageType('ResponseEnvelop', (_
       DESCRIPTOR = _RESPONSEENVELOP_PROFILE_AVATARDETAILS,
       __module__ = 'pokemon_pb2'
       # @@protoc_insertion_point(class_scope:ResponseEnvelop.Profile.AvatarDetails)
+      ))
+    ,
+
+    DailyBonus = _reflection.GeneratedProtocolMessageType('DailyBonus', (_message.Message,), dict(
+      DESCRIPTOR = _RESPONSEENVELOP_PROFILE_DAILYBONUS,
+      __module__ = 'pokemon_pb2'
+      # @@protoc_insertion_point(class_scope:ResponseEnvelop.Profile.DailyBonus)
       ))
     ,
 
@@ -1775,19 +892,11 @@ ResponseEnvelop = _reflection.GeneratedProtocolMessageType('ResponseEnvelop', (_
 _sym_db.RegisterMessage(ResponseEnvelop)
 _sym_db.RegisterMessage(ResponseEnvelop.Unknown6)
 _sym_db.RegisterMessage(ResponseEnvelop.Unknown6.Unknown2)
-_sym_db.RegisterMessage(ResponseEnvelop.HeartbeatPayload)
-_sym_db.RegisterMessage(ResponseEnvelop.ClientMapCell)
-_sym_db.RegisterMessage(ResponseEnvelop.WildPokemon)
-_sym_db.RegisterMessage(ResponseEnvelop.MapPokemonProto)
-_sym_db.RegisterMessage(ResponseEnvelop.PokemonFortProto)
-_sym_db.RegisterMessage(ResponseEnvelop.PokemonSummaryFortProto)
-_sym_db.RegisterMessage(ResponseEnvelop.ClientSpawnPointProto)
-_sym_db.RegisterMessage(ResponseEnvelop.WildPokemonProto)
-_sym_db.RegisterMessage(ResponseEnvelop.WildPokemonProto.Pokemon)
-_sym_db.RegisterMessage(ResponseEnvelop.NearbyPokemonProto)
-_sym_db.RegisterMessage(ResponseEnvelop.ProfilePayload)
+_sym_db.RegisterMessage(ResponseEnvelop.Unknown7)
+_sym_db.RegisterMessage(ResponseEnvelop.Payload)
 _sym_db.RegisterMessage(ResponseEnvelop.Profile)
 _sym_db.RegisterMessage(ResponseEnvelop.Profile.AvatarDetails)
+_sym_db.RegisterMessage(ResponseEnvelop.Profile.DailyBonus)
 _sym_db.RegisterMessage(ResponseEnvelop.Profile.Currency)
 
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Generate new pokemon_pb2.py (same change as https://github.com/tejado/pokemongo-api-demo/commit/e390466e7bd84def6422084afa59ba1863545889) , your pokemon.proto was updated but not the pokemon_pb2.py

If this is related to an existing ticket, include a link to it as well.

