### PR TITLE
Enforce password length limit

### DIFF
--- a/example.py
+++ b/example.py
@@ -250,7 +250,9 @@ def login_ptc(username, password):
         return None
 
     # Maximum password length is 15 (sign in page enforces this limit, API does not)
-    password = password[:15]
+    if len(password) > 15:
+        print('[!] Trimming password to 15 characters')
+        password = password[:15]
 
     data = {
         'lt': jdata['lt'],

--- a/example.py
+++ b/example.py
@@ -248,10 +248,10 @@ def login_ptc(username, password):
     except ValueError as e:
         debug("login_ptc: could not decode JSON from {}".format(r.content))
         return None
-    
+
     # Maximum password length is 15 (sign in page enforces this limit, API does not)
     password = password[:15]
-    
+
     data = {
         'lt': jdata['lt'],
         'execution': jdata['execution'],

--- a/example.py
+++ b/example.py
@@ -248,7 +248,10 @@ def login_ptc(username, password):
     except ValueError as e:
         debug("login_ptc: could not decode JSON from {}".format(r.content))
         return None
-
+    
+    # Maximum password length is 15 (sign in page enforces this limit, API does not)
+    password = password[:15]
+    
     data = {
         'lt': jdata['lt'],
         'execution': jdata['execution'],


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- The undocumented maximum password length is now applied. This should fix the issues that some people had while logging in. Previously they would send a password that was too long and get a "wrong password" reply.
