### PR TITLE
Flask host and port command line options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Team icons from [israelvicars](https://github.com/israelvicars/pkmn-go-emoji).
 | -i, --ignore | Comma-separated list of Pokémon to ignore |
 | -dp, --display-pokestop | Display pokestop                   |
 | -dg, --display-gym  | Display gym                   |
+| -H, --host  | Set web server listening host    |
+| -P, --port  | Set web server listening port    |
 
 # FAQ
 

--- a/example.py
+++ b/example.py
@@ -356,14 +356,7 @@ def get_token(name, passw):
     else:
         return global_token
 
-
-def main():
-    debug("main")
-
-    full_path = os.path.realpath(__file__)
-    path, filename = os.path.split(full_path)
-    pokemonsJSON = json.load(open(path + '/pokemon.json'))
-
+def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("-u", "--username", help="PTC Username", required=True)
     parser.add_argument("-p", "--password", help="PTC Password", required=True)
@@ -374,8 +367,19 @@ def main():
     parser.add_argument("-c", "--china", help="Coord Transformer for China", action='store_true')
     parser.add_argument("-dp", "--display-pokestop", help="Display Pokestop", action='store_true', default=False)
     parser.add_argument("-dg", "--display-gym", help="Display Gym", action='store_true', default=False)
+    parser.add_argument("-H", "--host", help="Set web server listening host", default="127.0.0.1")
+    parser.add_argument("-P", "--port", type=int, help="Set web server listening port", default=5000)
     parser.set_defaults(DEBUG=True)
-    args = parser.parse_args()
+    return parser.parse_args()
+
+def main():
+    debug("main")
+
+    full_path = os.path.realpath(__file__)
+    path, filename = os.path.split(full_path)
+    pokemonsJSON = json.load(open(path + '/pokemon.json'))
+
+    args = get_args()
 
     if args.debug:
         global DEBUG
@@ -591,5 +595,6 @@ def fullmap():
 
 
 if __name__ == "__main__":
+    args = get_args()
     register_background_thread(initial_registration=True)
-    app.run(debug=True, threaded=True)
+    app.run(debug=True, threaded=True, host=args.host, port=args.port)


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Created a function called `get_args`, that returns argparse options.
- Added two new command line options `-H --host` and `-P --port`.
- Flask uses the new command line params to set it's listening host and port.
- Updated readme to include these options.

This is related to #36.