### PR TITLE
Added bypass for geocoder if raw lat,lng values are inputted

### DIFF
--- a/example.py
+++ b/example.py
@@ -130,14 +130,22 @@ def retrying_set_location(location_name):
 
 
 def set_location(location_name):
-    geolocator = GoogleV3()
-    loc = geolocator.geocode(location_name)
-    print('[!] Your given location: {}'.format(loc.address.encode('utf-8')))
-    print('[!] lat/long/alt: {} {} {}'.format(loc.latitude, loc.longitude, loc.altitude))
     global deflat
     global deflng
-    deflat, deflng = loc.latitude, loc.longitude
-    set_location_coords(loc.latitude, loc.longitude, loc.altitude)
+    geolocator = GoogleV3()
+    prog = re.compile('^(\-?\d+(\.\d+)?),\s*(\-?\d+(\.\d+)?)$')
+    if (prog.match(location_name)):
+        deflat, deflng = [float(x) for x in location_name.split(",")]
+        alt = 0
+    else:
+        loc = geolocator.geocode(location_name)
+        deflat = loc.latitude
+        deflng = loc.longitude
+        alt = loc.altitude
+        print('[!] Your given location: {}'.format(loc.address.encode('utf-8')))
+
+    print('[!] lat/long/alt: {} {} {}'.format(deflat, deflng, alt))
+    set_location_coords(deflat, deflng, alt)
 
 
 def set_location_coords(lat, long, alt):


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- If the user inputs raw latitude or longitude coordinates (e.g "48.405703, -123.350780"), `set_location` will now recognize this and not call the geocoder API. This is useful if users reach the rate limit for the API, or just useful in minimizing API calls in general.

