### PR TITLE
added werkzeug version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ s2sphere==0.2.4
 flask==0.11.1
 gpsoauth==0.3.0
 coveralls==1.1
+werkzeug==0.11.10


### PR DESCRIPTION
This pull request includes a

- [x ] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- added a werkzeug version requirement in requirements.txt , the issue occurs if an older version of werkzeug was previously installed that is less than 0.10.x which has a new method signature: `werkzeug.serving.is_running_from_reloader()`

If this is related to an existing ticket, include a link to it as well.
