### PR TITLE
Added "Locale" to README and example.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Building off [Mila432](https://github.com/Mila432/Pokemon_Go_API)'s PokemonGo AP
 | -dg, --display-gym  | Display gym                   |
 | -H, --host  | Set web server listening host    |
 | -P, --port  | Set web server listening port    |
+| -L, --locale   | Locale for Pokemon names: en (default), fr, de    |
 
 Note:
 5 steps is approximately a 1.2km radius. More than 10 is redundant (you usually can't walk that far before despawn anyway)

--- a/example.py
+++ b/example.py
@@ -474,7 +474,7 @@ def get_args():
     parser.add_argument(
         "-L",
         "--locale",
-        help="Locale for Pokemon names: en (default), fr",
+        help="Locale for Pokemon names: en (default), fr, de",
         default="en")
     parser.set_defaults(DEBUG=True)
     return parser.parse_args()


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [x] Translation

The following changes were made

-Added locale to README
-Added de in locale definition(example.py)

Related to: https://github.com/AHAAAAAAA/PokemonGo-Map/pull/187

