### PR TITLE
Allow Google Maps API key to be given via a command-line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,22 @@ Building off [Mila432](https://github.com/Mila432/Pokemon_Go_API)'s PokemonGo AP
 # Usage
 `python example.py -a authService -u myUsername -p myPassword -l "Boulder, CO" -st 5`
 
-| Flag                            | Description                                               | Required | 
-|---------------------------------|-----------------------------------------------------------|----------| 
-| `-a`                            | Auth Service (ptc or google)                              |          | 
-| `-u`                            | Username                                                  | ✓        | 
-| `-p`                            | Password                                                  | ✓        | 
-| `-l`                            | Any location Google Maps can understand                   | ✓        | 
-| `-st`                           | Steps to take                                             | ✓        | 
-| `-ar` `--auto_refresh` `seconds`| Enables auto page reload. Value in seconds                |          | 
-| `-i` `--ignore`                 | Comma-separated list of Pokémon to ignore                 |          | 
-| `-o` `--only`                   | Comma-separated list of Pokemon to search for exclusively |          | 
-| `-dp` `--display-pokestop`      | Display pokestop                                          |          | 
-| `-dg` `--display-gym`           | Display gym                                               |          | 
-| `-H` `--host`                   | Set web server listening host                             |          | 
+| Flag                            | Description                                               | Required |
+|---------------------------------|-----------------------------------------------------------|----------|
+| `-a`                            | Auth Service (ptc or google)                              |          |
+| `-u`                            | Username                                                  | ✓        |
+| `-p`                            | Password                                                  | ✓        |
+| `-l`                            | Any location Google Maps can understand                   | ✓        |
+| `-st`                           | Steps to take                                             | ✓        |
+| `-ar` `--auto_refresh` `seconds`| Enables auto page reload. Value in seconds                |          |
+| `-i` `--ignore`                 | Comma-separated list of Pokémon to ignore                 |          |
+| `-o` `--only`                   | Comma-separated list of Pokemon to search for exclusively |          |
+| `-dp` `--display-pokestop`      | Display pokestop                                          |          |
+| `-dg` `--display-gym`           | Display gym                                               |          |
+| `-H` `--host`                   | Set web server listening host                             |          |
 | `-P` `--port`                   | Set web server listening port                             |          |
 |`-L` `--locale`                  | Locale for Pokemon names: en (default), fr, de            |          |
+| `-K` `--google-maps-api-key`    | A Google Maps API key, obtainable at goo.gl/sM7D6w.       |          |
 
 _Note:
 5 steps is approximately a 1.2km radius. More than 10 is redundant (you usually can't walk that far before despawn anyway)_

--- a/credentials.json
+++ b/credentials.json
@@ -1,7 +1,6 @@
 {
-	"ptc_client_secret"	: "w8ScCUXJQc6kXKw8FiOhd8Fixzht18Dq3PEVkUCP5ZPxtgyWsbTvWHFLm2wNY0JR",
-	"android_id"		: "9774d56d682e549c",
-	"service"			: "audience:server:client_id:848232511240-7so421jotr2609rmqakceuu1luuq0ptb.apps.googleusercontent.com",
-	"client_sig"		: "321187995bc7cdc2b5fc91b11a96e2baa8602c62",
-	"gmaps_key"			: "AIzaSyAZzeHhs-8JZ7i18MjFuM35dJHq70n3Hx4"
+	"ptc_client_secret": "w8ScCUXJQc6kXKw8FiOhd8Fixzht18Dq3PEVkUCP5ZPxtgyWsbTvWHFLm2wNY0JR",
+	"android_id": "9774d56d682e549c",
+	"service": "audience:server:client_id:848232511240-7so421jotr2609rmqakceuu1luuq0ptb.apps.googleusercontent.com",
+	"client_sig": "321187995bc7cdc2b5fc91b11a96e2baa8602c62"
 }

--- a/example.py
+++ b/example.py
@@ -51,8 +51,6 @@ PTC_CLIENT_SECRET = credentials.get('ptc_client_secret', None)
 ANDROID_ID = credentials.get('android_id', None)
 SERVICE = credentials.get('service', None)
 CLIENT_SIG = credentials.get('client_sig', None)
-GOOGLEMAPS_KEY = credentials.get('gmaps_key', None)
-
 SESSION = requests.session()
 SESSION.headers.update({'User-Agent': 'Niantic App'})
 SESSION.verify = False
@@ -488,8 +486,16 @@ def get_args():
         "--locale",
         help="Locale for Pokemon names: en (default), fr, de",
         default="en")
+    parser.add_argument(
+    '-K',
+    '--google-maps-api-key',
+    help='A Google Maps API key, obtainable at https://console.developers.google.com/apis/api/maps_backend/overview.',
+    default="AIzaSyAZzeHhs-8JZ7i18MjFuM35dJHq70n3Hx4"
+    )
     parser.set_defaults(DEBUG=True)
     return parser.parse_args()
+
+GOOGLEMAPS_KEY = get_args().google_maps_api_key
 
 @memoize
 def login(args):


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Google Maps API key can now be supplied via a command line argument.

Fixes #183.