### PR TITLE
Created a config file using YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 .idea
+conf/settings.yaml

--- a/conf/settings.example.yaml
+++ b/conf/settings.example.yaml
@@ -1,0 +1,15 @@
+auth_service: None # Options are None or ptc or google
+username: 'MyUsername' # Your username
+password: 'MySuperStrongPassword' # Your password
+location: 'Boulder, CO' # Any location Google Maps can understand
+step_limit: 5 # Steps to take
+display_pokestop: False # True or False
+display_gym: False # True or False
+ignore: None # [ 13, 16 ] # Pokenon to ignore
+only: None # [ 150, 151 ] # The only pokemon that should be displayed
+locale: 'en' # The language to use
+auto_refresh: None # integer value in seconds example: 30
+china: False  # True or False
+debug: False # Enable debugging True or False
+host: '127.0.0.1' # The host address the web server should bind to
+port: 5000 # The port that the web server should bind to

--- a/conf/settings.example.yaml
+++ b/conf/settings.example.yaml
@@ -5,8 +5,8 @@ location: 'Boulder, CO' # Any location Google Maps can understand
 step_limit: 5 # Steps to take
 display_pokestop: False # True or False
 display_gym: False # True or False
-ignore: None # [ 13, 16 ] # Pokenon to ignore
-only: None # [ 150, 151 ] # The only pokemon that should be displayed
+ignore: None # [ 'weedle', 'pidgey' ] # Pokenon to ignore
+only: None # [ 'mew', 'mewtwo' ] # The only pokemon that should be displayed
 locale: 'en' # The language to use
 auto_refresh: None # integer value in seconds example: 30
 china: False  # True or False

--- a/dict2object.py
+++ b/dict2object.py
@@ -1,0 +1,6 @@
+class Dict2Object(dict):
+    def __getattr__(self, name):
+        value = self[name]
+        if isinstance(value, dict):
+            value = Dict2Object(value)
+        return value

--- a/example.py
+++ b/example.py
@@ -11,6 +11,7 @@ import re
 import sys
 import struct
 import json
+import yaml
 import time
 import requests
 import argparse
@@ -35,6 +36,7 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from requests.adapters import ConnectionError
 from requests.models import InvalidURL
 from transform import *
+from dict2object import Dict2Object
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
@@ -436,60 +438,67 @@ def get_token(service, username, password):
 
 
 def get_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '-a', '--auth_service', help='Auth Service', default='ptc')
-    parser.add_argument('-u', '--username', help='Username', required=True)
-    parser.add_argument('-p', '--password', help='Password', required=False)
-    parser.add_argument(
-        '-l', '--location', type=parse_unicode, help='Location', required=True)
-    parser.add_argument('-st', '--step_limit', help='Steps', required=True)
-    group = parser.add_mutually_exclusive_group(required=False)
-    group.add_argument(
-        '-i', '--ignore', help='Pokemon to ignore (comma separated)')
-    group.add_argument(
-        '-o', '--only', help='Only look for these pokemon (comma separated)')
-    parser.add_argument(
-        '-d', '--debug', help='Debug Mode', action='store_true')
-    parser.add_argument(
-        '-c',
-        '--china',
-        help='Coord Transformer for China',
-        action='store_true')
-    parser.add_argument(
-        "-ar",
-        "--auto_refresh",
-        help="Enables an autorefresh that behaves the same as a page reload. Needs an integer value for the amount of seconds")
-    parser.add_argument(
-        '-dp',
-        '--display-pokestop',
-        help='Display Pokestop',
-        action='store_true',
-        default=False)
-    parser.add_argument(
-        '-dg',
-        '--display-gym',
-        help='Display Gym',
-        action='store_true',
-        default=False)
-    parser.add_argument(
-        '-H',
-        '--host',
-        help='Set web server listening host',
-        default='127.0.0.1')
-    parser.add_argument(
-        '-P',
-        '--port',
-        type=int,
-        help='Set web server listening port',
-        default=5000)
-    parser.add_argument(
-        "-L",
-        "--locale",
-        help="Locale for Pokemon names: en (default), fr, de",
-        default="en")
-    parser.set_defaults(DEBUG=True)
-    return parser.parse_args()
+    config_file = os.path.join(os.path.dirname(__file__), 'conf/settings.yaml')
+    if os.path.isfile(config_file):
+        config_data = open(config_file)
+        config = yaml.safe_load(config_data)
+        args = Dict2Object(config)
+        return args
+    else:
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            '-a', '--auth_service', help='Auth Service', default='ptc')
+        parser.add_argument('-u', '--username', help='Username', required=True)
+        parser.add_argument('-p', '--password', help='Password', required=False)
+        parser.add_argument(
+            '-l', '--location', type=parse_unicode, help='Location', required=True)
+        parser.add_argument('-st', '--step_limit', help='Steps', required=True)
+        group = parser.add_mutually_exclusive_group(required=False)
+        group.add_argument(
+            '-i', '--ignore', help='Pokemon to ignore (comma separated)')
+        group.add_argument(
+            '-o', '--only', help='Only look for these pokemon (comma separated)')
+        parser.add_argument(
+            '-d', '--debug', help='Debug Mode', action='store_true')
+        parser.add_argument(
+            '-c',
+            '--china',
+            help='Coord Transformer for China',
+            action='store_true')
+        parser.add_argument(
+            "-ar",
+            "--auto_refresh",
+            help="Enables an autorefresh that behaves the same as a page reload. Needs an integer value for the amount of seconds")
+        parser.add_argument(
+            '-dp',
+            '--display-pokestop',
+            help='Display Pokestop',
+            action='store_true',
+            default=False)
+        parser.add_argument(
+            '-dg',
+            '--display-gym',
+            help='Display Gym',
+            action='store_true',
+            default=False)
+        parser.add_argument(
+            '-H',
+            '--host',
+            help='Set web server listening host',
+            default='127.0.0.1')
+        parser.add_argument(
+            '-P',
+            '--port',
+            type=int,
+            help='Set web server listening port',
+            default=5000)
+        parser.add_argument(
+            "-L",
+            "--locale",
+            help="Locale for Pokemon names: en (default), fr, de",
+            default="en")
+        parser.set_defaults(DEBUG=True)
+        return parser.parse_args()
 
 @memoize
 def login(args):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ flask==0.11.1
 gpsoauth==0.3.0
 coveralls==1.1
 werkzeug==0.11.10
+pyyaml==3.11


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [X] New feature
- [ ] Translation

The following changes were made

- The `get_args` function looks for a config file at `conf/settings.yaml`. If it finds the file, a custom class converts the config to an object and that is returned and used exactly the same way as the `parse_args` object. If a config file is not found arguments are loaded from the command line.
- Added PyYAML 3.11 to the requirements.
- Added example settings file
- Updated gitignore to ignore `conf/settings.yaml`

