### PR TITLE
fix occasional DecodeError crash during message parsing

### DIFF
--- a/example.py
+++ b/example.py
@@ -26,6 +26,7 @@ from datetime import datetime
 import time
 
 from google.protobuf.internal import encoder
+from google.protobuf.message import DecodeError
 from s2sphere import *
 from datetime import datetime
 from geopy.geocoders import GoogleV3
@@ -208,7 +209,7 @@ def retrying_api_req(service, api_endpoint, access_token, *args, **kwargs):
             if response:
                 return response
             debug('retrying_api_req: api_req returned None, retrying')
-        except (InvalidURL, ConnectionError), e:
+        except (InvalidURL, ConnectionError, DecodeError), e:
             debug('retrying_api_req: request error ({}), retrying'.format(
                 str(e)))
         time.sleep(1)


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- handle DecodeError exception

```
Completed: 59.5555555556%
[-] looping: step 135 of 225
Exception in thread search_thread:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "example.py", line 575, in main
    pokemonsJSON, ignore, only)
  File "example.py", line 600, in process_step
    profile_response))
  File "example.py", line 399, in get_heartbeat
    m5, )
  File "example.py", line 304, in get_profile
    return retrying_api_req(service, api, access_token, req, useauth=useauth)
  File "example.py", line 190, in retrying_api_req
    **kwargs)
  File "example.py", line 228, in api_req
    p_ret.ParseFromString(r.content)
  File "/usr/lib/python2.7/site-packages/google/protobuf/message.py", line 186, in ParseFromString
    self.MergeFromString(serialized)
  File "/usr/lib/python2.7/site-packages/google/protobuf/internal/python_message.py", line 844, in MergeFromString
    raise message_mod.DecodeError('Unexpected end-group tag.')
DecodeError: Unexpected end-group tag.
```