### PR TITLE
Fix for scanner drift (fixes #229 and #231)

### DIFF
--- a/example.py
+++ b/example.py
@@ -600,11 +600,15 @@ def main():
         print('Completed: ' + str(
             (step + pos * .25 - .25) / (steplimit**2) * 100) + '%')
 
-    if (NEXT_LAT and NEXT_LONG
-        and NEXT_LAT != FLOAT_LAT
-        and NEXT_LONG != FLOAT_LONG):
+    global NEXT_LAT, NEXT_LONG
+    if (NEXT_LAT and NEXT_LONG and
+            (NEXT_LAT != FLOAT_LAT or NEXT_LONG != FLOAT_LONG)):
         print('Update to next location %f, %f' % (NEXT_LAT, NEXT_LONG))
         set_location_coords(NEXT_LAT, NEXT_LONG, 0)
+        NEXT_LAT = 0
+        NEXT_LONG = 0
+    else:
+        set_location_coords(origin_lat, origin_lon, 0)
 
     register_background_thread()
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

1. Quickfix for scanner slowly drifting away from starting location:
  reset location to original at the end of looping steps

2. Also fix updating to the next location feature:
  don't update repeatedly and allow to change latitude or longitude separately (not only both)

Fixes #229: Coordinate checking slowly moves towards the right, away from starting point
Fixes #231: Scanned are slowly drifts away from starting location
Relates to #202: Map center shifts to SE after refresh