### PR TITLE
Fix "AttributeError: lat and lng required" when using coordinates as …

### DIFF
--- a/example.py
+++ b/example.py
@@ -176,6 +176,7 @@ def set_location(location_name):
     if prog.match(location_name):
         local_lat, local_lng = [float(x) for x in location_name.split(",")]
         alt = 0
+        origin_lat, origin_lon = local_lat, local_lng
     else:
         loc = geolocator.geocode(location_name)
         origin_lat, origin_lon = local_lat, local_lng = loc.latitude, loc.longitude


### PR DESCRIPTION
This pull request includes a

- [*] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Assign value to origin_lat and origin_lon global variables when coordinates are used for location

Previously, origin_lat and origin_lon was not set, causing an Attribute error when accessing the webpage.