### PR TITLE
Add 'Get Directions' to label

### DIFF
--- a/example.py
+++ b/example.py
@@ -796,18 +796,9 @@ def get_pokemarkers():
             'disappear_time']).strftime("%H:%M:%S")
 
         LABEL_TMPL = u'''
-<div style='position:float; top:0;left:0;'>
-    <small>
-        <a href='http://www.pokemon.com/us/pokedex/{id}'
-           target='_blank'
-           title='View in Pokedex'>
-          #{id}
-        </a>
-    </small>
-    <span> - </span>
-    <b>{name}</b>
-</div>
-<div>disappears at {disappear_time_formatted} <span class='label-countdown' disappears-at='{disappear_time}'></span></div>
+<div><b>{name}</b><span> - </span><small><a href='http://www.pokemon.com/us/pokedex/{id}' target='_blank' title='View in Pokedex'>#{id}</a></small></div>
+<div>Disappears at - {disappear_time_formatted} <span class='label-countdown' disappears-at='{disappear_time}'></span></div>
+<div><a href='https://www.google.com/maps/dir/Current+Location/{lat},{lng}' target='_blank' title='View in Maps'>Get Directions</a></div>
 '''
         label = LABEL_TMPL.format(**pokemon)
         #  NOTE: `infobox` field doesn't render multiple line string in frontend


### PR DESCRIPTION
This pull request includes a:

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made:

- Add link to google maps directions
- Move index to right of Pokemon name

If this is related to an existing ticket, include a link to it as well.

- https://github.com/AHAAAAAAA/PokemonGo-Map/pull/173