### PR TITLE
Force auth service argument to be lowercase

### DIFF
--- a/example.py
+++ b/example.py
@@ -432,7 +432,7 @@ def get_token(service, username, password):
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-a', '--auth_service', help='Auth Service', default='ptc')
+        '-a', '--auth_service', type=str.lower, help='Auth Service', default='ptc')
     parser.add_argument('-u', '--username', help='Username', required=True)
     parser.add_argument('-p', '--password', help='Password', required=False)
     parser.add_argument(


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Force the auth service argument to be lowercase to help avoid user input errors
-
-

If this is related to an existing ticket, include a link to it as well.

