### PR TITLE
handle IndexError for missing response.payload in get_heartbeat()

### DIFF
--- a/example.py
+++ b/example.py
@@ -411,9 +411,12 @@ def get_heartbeat(service,
                            m4,
                            pokemon_pb2.RequestEnvelop.Requests(),
                            m5, )
-    if response is None:
+
+    try:
+        payload = response.payload[0]
+    except (AttributeError, IndexError):
         return
-    payload = response.payload[0]
+
     heartbeat = pokemon_pb2.ResponseEnvelop.HeartbeatPayload()
     heartbeat.ParseFromString(payload)
     return heartbeat


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- handle IndexError exception for missing response.payload in get_heartbeat()

Retrying or better handling is probably preferable, but this should work for now to hotfix the crash. We're already handling a missing response in the same way anyway.

fixes #257, fixes #258