### PR TITLE
Fix bug where lured Pokestops disappear after 10 seconds

### DIFF
--- a/example.py
+++ b/example.py
@@ -873,6 +873,7 @@ def get_pokemarkers():
             pokeMarkers.append({
                 'type': 'lured_stop',
                 'key': stop_key,
+                'disappear_time': -1,
                 'icon': 'static/forts/PstopLured.png',
                 'lat': stop[0],
                 'lng': stop[1],

--- a/templates/example_fullmap.html
+++ b/templates/example_fullmap.html
@@ -161,6 +161,10 @@
                             console.log("Warning: object with identical key has different coordinates please report bug", key);
                             needs_replacing = true;
                         }
+                        if (markerCache[key].item.type != item["type"] || (item["infobox"] != null && markerCache[key].item["infobox"] != null && item["infobox"] != markerCache[key].item["infobox"])) {
+                            (function(_marker){setTimeout(_marker.setMap(null), 500)})(markerCache[key].marker);
+                            needs_replacing = true;
+						}
                         if(!needs_replacing){
                             continue;
                         }


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Fixes https://github.com/AHAAAAAAA/PokemonGo-Map/issues/269
- Previously, the disappear_time was unset for lured pokestops, causing a task to remove it from the map to run after 10 seconds.
- The changes to example_fullmap.html also handle the case where a lure expires or a new lure is used, forcing the map icon to refresh.