### PR TITLE
Add Dockerfile to allow running in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:2.7-onbuild
+EXPOSE 5000
+ENTRYPOINT ["python", "./example.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,18 @@
-FROM python:2.7-onbuild
+FROM python:2.7-alpine
+
+# ca-certificates is needed because without it, pip fails to install packages due to a certificate failure
+# build-base contains gcc, which is needed during the installation of the pycryptodomex pip package
+RUN apk add --update ca-certificates build-base
+
+# default port the app runs on
 EXPOSE 5000
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
 ENTRYPOINT ["python", "./example.py"]
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /usr/src/app


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Add a Dockerfile to build a Docker container running Python and the map application
- Update README to include instructions on how to use the application in Docker