### PR TITLE
Center the map on the origin location

### DIFF
--- a/example.py
+++ b/example.py
@@ -777,8 +777,8 @@ def raw_data():
 def config():
     """ Gets the settings for the Google Maps via REST"""
     center = {
-        'lat': FLOAT_LAT,
-        'lng': FLOAT_LONG,
+        'lat': origin_lat,
+        'lng': origin_lon,
         'zoom': 15,
         'identifier': "fullmap"
     }


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Before it was centering on the last quadrant looked up, now this centers on the original location.