### PR TITLE
Fix for lured stops not disappearing

### DIFF
--- a/example.py
+++ b/example.py
@@ -671,14 +671,17 @@ transform_from_wgs_to_gcj(Location(Fort.Latitude, Fort.Longitude))
 
                             elif Fort.FortType \
                                 and args.display_pokestop:
+                                expire_timestamp = 0
                                 expire_time = 0
                                 if Fort.LureInfo.LureExpiresTimestampMs:
+                                    expire_timestamp = Fort.LureInfo.LureExpiresTimestampMs / 1000.0
                                     expire_time = datetime\
-                                        .fromtimestamp(Fort.LureInfo.LureExpiresTimestampMs / 1000.0)\
+                                        .fromtimestamp(expire_timestamp)\
                                         .strftime("%H:%M:%S")
-                                if (expire_time != 0 or not args.onlylure):
-                                    pokestops[Fort.FortId] = [Fort.Latitude,
-                                                              Fort.Longitude, expire_time]
+                                pokestops[Fort.FortId] = [Fort.Latitude,
+                                                          Fort.Longitude,
+                                                          expire_time,
+                                                          expire_timestamp]
         except AttributeError:
             break
 
@@ -809,6 +812,9 @@ def next_loc():
 
 
 def get_pokemarkers():
+
+    args = get_args()
+
     pokeMarkers = [{
         'icon': icons.dots.red,
         'lat': origin_lat,
@@ -874,13 +880,12 @@ def get_pokemarkers():
             pokeMarkers.append({
                 'type': 'lured_stop',
                 'key': stop_key,
-                'disappear_time': -1,
                 'icon': 'static/forts/PstopLured.png',
                 'lat': stop[0],
                 'lng': stop[1],
                 'infobox': 'Lured Pokestop, expires at ' + stop[2],
             })
-        else:
+        elif not args.onlylure:
             pokeMarkers.append({
                 'type': 'stop',
                 'key': stop_key,

--- a/templates/example_fullmap.html
+++ b/templates/example_fullmap.html
@@ -161,7 +161,7 @@
                             console.log("Warning: object with identical key has different coordinates please report bug", key);
                             needs_replacing = true;
                         }
-                        if (markerCache[key].item.type != item["type"] || (item["infobox"] != null && markerCache[key].item["infobox"] != null && item["infobox"] != markerCache[key].item["infobox"])) {
+                        if (item["type"] == "lured_stop" || (item["infobox"] != null && markerCache[key].item["infobox"] != null && item["infobox"] != markerCache[key].item["infobox"])) {
                             (function(_marker){setTimeout(_marker.setMap(null), 500)})(markerCache[key].marker);
                             needs_replacing = true;
 						}


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Fixes https://github.com/AHAAAAAAA/PokemonGo-Map/issues/359
- Do not set disappear_time for lured pokestops, the new default expiration time is the autorefresh interval + 500ms.
- Store pokestop data regardless of onlylured flag to prevent stale pokestop data from being delivered to the client.
- Instead, filter unlured pokestops right before sending data to the client.
- Caveat: During the time after a lured pokestop expires and the pokestop is refreshed, no icon will be displayed on the client.
- Caveat: Timer still wrong