### PR TITLE
Removed trailing comma for valid JSON

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -2,5 +2,5 @@
     "auth_service": "google",
     "username": "example@gmail.com",
     "password": "password11!!",
-    "location": "New York",
+    "location": "New York"
 }


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Removed the final trailing comma in the config.json.example.  Final trailing commas in JSON are invalid, and thus pokemap.py was failing.

