### PR TITLE
Multithreaded Pokemon searching

### DIFF
--- a/example.py
+++ b/example.py
@@ -630,7 +630,7 @@ def main():
             t = threading.Thread(target=step,args=(x, y, dx, dy, stepcount))
             threads.append(t)
             t.start()
-            if(len(threads) > 25):
+            if(len(threads) == 25):
                 print("Thread cap reached, waiting for responses...")
                 for i in range(25):
                     threads[i].join()

--- a/example.py
+++ b/example.py
@@ -632,7 +632,7 @@ def main():
             t.start()
             if(len(threads) == 25):
                 print("Thread cap reached, waiting for responses...")
-                for i in range(25):
+                for i in range(len(threads)):
                     threads[i].join()
                     count = count + 1
                     print('Completed: ' + str(((count) + pos * .25 - .25) / (steplimit2) * 100) + '%')


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

I've added support for multithreaded requests as suggested in #357, which greatly speeds up the process. I have 15-step maps running in the time a 6-step map took before multithreading. To run with multithreading, add -mt to your arguments.

