### PR TITLE
Fixed Locale for Pokemon names

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -12,7 +12,6 @@ from datetime import datetime, timedelta
 
 from . import config
 
-
 def parse_unicode(bytestring):
     decoded_string = bytestring.decode(sys.getfilesystemencoding())
     return decoded_string
@@ -68,13 +67,25 @@ def insert_mock_data(location, num_pokemons):
                        longitude=locations[i][1],
                        disappear_time=disappear_time)
 
+import logging
+log = logging.getLogger(__name__)
 
 def get_pokemon_name(pokemon_id):
     if not hasattr(get_pokemon_name, 'names'):
+        args = get_args()
+        locale = config['LOCALE']
+
+        if args.locale:
+            for file in os.listdir(config['LOCALES_DIR']):
+                # log.info('LOCALE: {}'.format(file))
+                if args.locale in file:
+                    locale = args.locale
+                    break
+
         file_path = os.path.join(
             config['ROOT_PATH'],
             config['LOCALES_DIR'],
-            'pokemon.{}.json'.format(config['LOCALE']))
+            'pokemon.{}.json'.format(locale))
 
         with open(file_path, 'r') as f:
             get_pokemon_name.names = json.loads(f.read())

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -67,9 +67,6 @@ def insert_mock_data(location, num_pokemons):
                        longitude=locations[i][1],
                        disappear_time=disappear_time)
 
-import logging
-log = logging.getLogger(__name__)
-
 def get_pokemon_name(pokemon_id):
     if not hasattr(get_pokemon_name, 'names'):
         args = get_args()

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -8,14 +8,18 @@ import re
 import uuid
 import os
 import json
+import logging
 from datetime import datetime, timedelta
 
 from . import config
 
+log = logging.getLogger(__name__)
+
+pokeNamesLocale = config['LOCALE']
+
 def parse_unicode(bytestring):
     decoded_string = bytestring.decode(sys.getfilesystemencoding())
     return decoded_string
-
 
 def get_args():
     # fuck PEP8
@@ -45,6 +49,22 @@ def get_args():
     if args.password is None:
         args.password = getpass.getpass()
 
+    # set locale
+    if args.locale:
+        global pokeNamesLocale
+        isValid = False
+        for file in os.listdir(config['LOCALES_DIR']):
+            lang = re.search('\.(.*?)\.', file).group(1)
+            if args.locale in lang:
+                isValid = True
+                pokeNamesLocale = args.locale
+                log.debug('Locale set to {}'.format(pokeNamesLocale))
+                break
+        if not isValid:
+            log.debug('Locale argument is invalid. Locale set to {}'.format(pokeNamesLocale))
+    else: # argument was an empty string
+        log.debug('Locale argument is invalid. Locale set to {}'.format(pokeNamesLocale))
+
     return args
 
 
@@ -68,21 +88,12 @@ def insert_mock_data(location, num_pokemons):
                        disappear_time=disappear_time)
 
 def get_pokemon_name(pokemon_id):
+    global pokeNamesLocale
     if not hasattr(get_pokemon_name, 'names'):
-        args = get_args()
-        locale = config['LOCALE']
-
-        if args.locale:
-            for file in os.listdir(config['LOCALES_DIR']):
-                # log.info('LOCALE: {}'.format(file))
-                if args.locale in file:
-                    locale = args.locale
-                    break
-
         file_path = os.path.join(
             config['ROOT_PATH'],
             config['LOCALES_DIR'],
-            'pokemon.{}.json'.format(locale))
+            'pokemon.{}.json'.format(pokeNamesLocale))
 
         with open(file_path, 'r') as f:
             get_pokemon_name.names = json.loads(f.read())


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Implemented locale change if -L parameter is specified
- If locale parameter is invalid or unspecified, the locale defaults to config locale

If this is related to an existing ticket, include a link to it as well.
[#510](https://github.com/AHAAAAAAA/PokemonGo-Map/issues/510)

