### PR TITLE
Ignore the correct dist directory outputted by Grunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 *.db
 *.sass-cache
 credentials.json
-dist/
+static/dist/
 node_modules/


### PR DESCRIPTION
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- changed .gitignore to ignore "static/dist/" instead of "dist/"