### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.github
+.gitignore
+credentials.example.json
+node_modules
+Easy\ Setup
+Gruntfile.js
+package.json
+pogom.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,6 @@
 
 FROM python:2.7-alpine
 
-# ca-certificates is needed because without it, pip fails to install packages due to a certificate failure
-# build-base contains gcc, which is needed during the installation of the pycryptodomex pip package
-RUN apk add --no-cache \
-    ca-certificates \
-    build-base
-
 # default port the app runs on
 EXPOSE 5000
 
@@ -18,7 +12,16 @@ WORKDIR /usr/src/app
 
 ENTRYPOINT ["python", "./runserver.py"]
 
+# Copy Python requirements so we only rebuild deps if they have changed
 COPY requirements.txt /usr/src/app/
-RUN pip install --no-cache-dir -r requirements.txt
 
+# ca-certificates is needed because without it, pip fails to install packages due to a certificate failure
+# build-base contains gcc, which is needed during the installation of the pycryptodomex pip package
+RUN apk add --no-cache \
+    ca-certificates \
+    build-base \
+ && pip install --no-cache-dir -r requirements.txt \
+ && apk del build-base
+
+# Add the rest of the app code
 COPY . /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+# Basic docker image for PokemonGo-Map
+# Usage:
+#   docker build -t pokemongo-map .
+#   docker run -d -P pokemongo-map --host 0.0.0.0 -a ptc -u YOURUSERNAME -p YOURPASSWORD -l "Seattle, WA" -st 10 --google-maps-key CHECKTHEWIKI
+
 FROM python:2.7-alpine
 
 # ca-certificates is needed because without it, pip fails to install packages due to a certificate failure

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,19 @@
-FROM python:2.7-onbuild
+FROM python:2.7-alpine
+
+# ca-certificates is needed because without it, pip fails to install packages due to a certificate failure
+# build-base contains gcc, which is needed during the installation of the pycryptodomex pip package
+RUN apk add --update ca-certificates build-base
+
+# default port the app runs on
 EXPOSE 5000
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
 ENTRYPOINT ["python", "./runserver.py"]
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,9 @@ FROM python:2.7-alpine
 
 # ca-certificates is needed because without it, pip fails to install packages due to a certificate failure
 # build-base contains gcc, which is needed during the installation of the pycryptodomex pip package
-RUN apk add --update \
+RUN apk add --no-cache \
     ca-certificates \
-    build-base \
-    && rm -rf /var/cache/apk/*
+    build-base
 
 # default port the app runs on
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:2.7-onbuild
+EXPOSE 5000
+ENTRYPOINT ["python", "./runserver.py"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@
 
 FROM python:2.7-alpine
 
+# keep this near the top of the file since we'll always need this
+# ca-certificates is needed because without it, pip fails to install packages due to a certificate failure
+RUN apk add --no-cache \
+    ca-certificates
+
 # default port the app runs on
 EXPOSE 5000
 
@@ -15,10 +20,8 @@ ENTRYPOINT ["python", "./runserver.py"]
 # Copy Python requirements so we only rebuild deps if they have changed
 COPY requirements.txt /usr/src/app/
 
-# ca-certificates is needed because without it, pip fails to install packages due to a certificate failure
 # build-base contains gcc, which is needed during the installation of the pycryptodomex pip package
 RUN apk add --no-cache \
-    ca-certificates \
     build-base \
  && pip install --no-cache-dir -r requirements.txt \
  && apk del build-base

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apk add --update ca-certificates build-base
 # default port the app runs on
 EXPOSE 5000
 
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ENTRYPOINT ["python", "./runserver.py"]
@@ -16,4 +15,3 @@ COPY requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /usr/src/app
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ FROM python:2.7-alpine
 
 # ca-certificates is needed because without it, pip fails to install packages due to a certificate failure
 # build-base contains gcc, which is needed during the installation of the pycryptodomex pip package
-RUN apk add --update ca-certificates build-base
+RUN apk add --update \
+    ca-certificates \
+    build-base \
+    && rm -rf /var/cache/apk/*
 
 # default port the app runs on
 EXPOSE 5000


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Added `Dockerfile` to allow running in a container

The `credentials.json` file isn't included, so specifying a Google Maps key on the CLI using the `-k` argument is necessary.

This PR is based on my original PR #309, updated to point at the `develop` branch.