### PR TITLE
Bug Fix initmap() is not a function

### DIFF
--- a/templates/map.html
+++ b/templates/map.html
@@ -93,6 +93,6 @@
     var center_lng = {{lng}};
   </script>
 
+	<script type="text/javascript" src="/static/map.js"></script>
   <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&callback=initMap"></script>
-  <script type="text/javascript" src="/static/map.js"></script>
 </html>


### PR DESCRIPTION
## Description
Load map.js before Google callback fires. 

## Motivation and Context
I ran in to issues where the google callback is called before map.js is loaded.

## How Has This Been Tested?
Clear cache and load multiple times

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.