### PR TITLE
Move --only --ignore to run earlier

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -9,7 +9,8 @@ from base64 import b64encode
 
 from .utils import get_pokemon_name
 
-
+from pogom.utils import get_args
+args = get_args()
 db = SqliteDatabase('pogom.db')
 log = logging.getLogger(__name__)
 
@@ -20,9 +21,6 @@ class BaseModel(Model):
 
 
 class Pokemon(BaseModel):
-    IGNORE = None
-    ONLY = None
-
     # We are base64 encoding the ids delivered by the api
     # because they are too big for sqlite to handle
     encounter_id = CharField(primary_key=True)
@@ -44,12 +42,6 @@ class Pokemon(BaseModel):
             p['pokemon_name'] = get_pokemon_name(p['pokemon_id'])
             pokemon_name = p['pokemon_name'].lower()
             pokemon_id = str(p['pokemon_id'])
-            if cls.IGNORE:
-                if pokemon_name in cls.IGNORE or pokemon_id in cls.IGNORE:
-                    continue
-            if cls.ONLY:
-                if pokemon_name not in cls.ONLY and pokemon_id not in cls.ONLY:
-                    continue
             pokemons.append(p)
 
         return pokemons
@@ -87,6 +79,14 @@ def parse_map(map_dict):
     cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
     for cell in cells:
         for p in cell.get('wild_pokemons', []):
+            pokemon_name = get_pokemon_name(p['pokemon_data']['pokemon_id'])
+            pokemon_id = str(p['pokemon_data']['pokemon_id'])
+            if args.ignore:
+                if pokemon_name in args.ignore or pokemon_id in args.ignore:
+                    continue
+            if args.only:
+                if pokemon_name not in args.only and pokemon_id not in args.only:
+                    continue
             pokemons[p['encounter_id']] = {
                 'encounter_id': b64encode(str(p['encounter_id'])),
                 'spawnpoint_id': p['spawnpoint_id'],


### PR DESCRIPTION
## Description
Move --ignore and --only "down" , don't save it in to the db at all since we don't need it.

## Motivation and Context
Increase performance. This is also part of:https://github.com/AHAAAAAAA/PokemonGo-Map/pull/631
We do not need to save Pokemons that we do not need in to the db, since they will be ignored when get_active() executes. This will make the query[] shorter by X amount less iterations, where X is number of ignored Pokemons. 

## How Has This Been Tested?
- [ ] Testing
Pokemon servers are currently down, but ran some test in https://github.com/AHAAAAAAA/PokemonGo-Map/pull/631 before.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.