### PR TITLE
Add what we are trying to login to

### DIFF
--- a/pogom/pgoapi/auth_ptc.py
+++ b/pogom/pgoapi/auth_ptc.py
@@ -46,8 +46,8 @@ class AuthPtc(Auth):
 
     def login(self, username, password):
 
-        self.log.info('Login for: %s', username)
-        
+        self.log.info('PTC login for: %s', username)
+
         head = {'User-Agent': 'niantic'}
         r = self._session.get(self.PTC_LOGIN_URL, headers=head)
         

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -49,15 +49,15 @@ def generate_location_steps(initial_location, num_steps):
 
 
 def login(args, position):
-    log.info('Attempting login.')
+    log.info('Attempting login to Pokemon Go.')
 
     api.set_position(*position)
 
     while not api.login(args.auth_service, args.username, args.password):
-        log.info('Login failed. Trying again.')
+        log.info('Failed to login to Pokemon Go. Trying again.')
         time.sleep(REQ_SLEEP)
 
-    log.info('Login successful.')
+    log.info('Login to Pokemon Go successful.')
 
 
 def search(args):
@@ -68,7 +68,7 @@ def search(args):
         remaining_time = api._auth_provider._ticket_expire/1000 - time.time()
 
         if remaining_time > 60:
-            log.info("Skipping login process since already logged in for another {:.2f} seconds".format(remaining_time))
+            log.info("Skipping Pokemon Go login process since already logged in for another {:.2f} seconds".format(remaining_time))
         else:
             login(args, position)
     else:


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation
- [x] Minor logging improvements

The following changes were made

- Add what we are trying to login to

Was a little confusing to me when I saw the following logs:

```
2016-07-20 18:18:08,801 [auth_google] [   INFO] Google login for: blah@gmail.com
2016-07-20 18:18:09,258 [auth_google] [   INFO] Google Login successful.
2016-07-20 18:18:09,403 [    rpc_api] [WARNING] Unexpected HTTP server response - needs 200 got 502
2016-07-20 18:18:09,406 [     search] [   INFO] Login failed. Trying again.
```