### PR TITLE
Basic Auth - HTTP - User / Pass from credentials or line args Enable from line args. 

### DIFF
--- a/credentials.example.json
+++ b/credentials.example.json
@@ -1,3 +1,5 @@
 {
 	"gmaps_key" : ""
+	"auth_user" : ""
+	"auth_pass" : ""
 }

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -23,6 +23,8 @@ def get_args():
     # fuck PEP8
     parser = argparse.ArgumentParser()
     parser.add_argument('-ae', '--auth_enable', help ='Basic Auth', action='store_true', default=False)
+    parser.add_argument('-au', '--auth_user', type=str, help='Auth User')
+    parser.add_argument('-ap', '--auth_pass', type=str, help='Auth Password')
     parser.add_argument('-a', '--auth-service', type=str.lower, help='Auth Service', default='ptc')
     parser.add_argument('-u', '--username', help='Username', required=True)
     parser.add_argument('-p', '--password', help='Password', required=False)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -22,6 +22,7 @@ def parse_unicode(bytestring):
 def get_args():
     # fuck PEP8
     parser = argparse.ArgumentParser()
+    parser.add_argument('-ae', '--auth_enable', help ='Basic Auth', action='store_true', default=False)
     parser.add_argument('-a', '--auth-service', type=str.lower, help='Auth Service', default='ptc')
     parser.add_argument('-u', '--username', help='Username', required=True)
     parser.add_argument('-p', '--password', help='Password', required=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ requests==2.10.0
 s2sphere==0.2.4
 gpsoauth==0.3.0
 protobuf-to-dict==0.1.0
+Flask-BasicAuth==0.2.0

--- a/runserver.py
+++ b/runserver.py
@@ -12,6 +12,8 @@ from pogom.utils import get_args, insert_mock_data, load_credentials
 from pogom.search import search_loop
 from pogom.models import create_tables, Pokemon
 from pogom.pgoapi.utilities import get_pos_by_name
+from flask_basicauth import BasicAuth
+
 
 log = logging.getLogger(__name__)
 
@@ -58,6 +60,13 @@ if __name__ == '__main__':
         insert_mock_data(args.location, 6)
 
     app = Pogom(__name__)
+    
+    app.config['BASIC_AUTH_USERNAME'] = 'pokemon'
+    app.config['BASIC_AUTH_PASSWORD'] = 'pokemon'
+
+    basic_auth = BasicAuth(app)
+    app.config['BASIC_AUTH_FORCE'] = True
+
     config['ROOT_PATH'] = app.root_path
     if args.gmaps_key is not None:
         config['GMAPS_KEY'] = args.gmaps_key

--- a/runserver.py
+++ b/runserver.py
@@ -60,10 +60,15 @@ if __name__ == '__main__':
         insert_mock_data(args.location, 6)
 
     app = Pogom(__name__)
+    if args.auth_user is not None: 
+        app.config['BASIC_AUTH_USERNAME'] = args.auth_user
+    else:
+        app.config['BASIC_AUTH_USERNAME'] = load_credentials(os.path.dirname(os.path.realpath(__file__)))['auth_user'] 
+    if args.auth_pass is not None:
+        app.config['BASIC_AUTH_PASSWORD'] = args.auth_pass
+    else:
+        app.config['BASIC_AUTH_PASSWORD'] = load_credentials(os.path.dirname(os.path.realpath(__file__)))['auth_pass']
     
-    app.config['BASIC_AUTH_USERNAME'] = 'pokemon'
-    app.config['BASIC_AUTH_PASSWORD'] = 'pokemon'
-
     basic_auth = BasicAuth(app)
     
     if  args.auth_enable:

--- a/runserver.py
+++ b/runserver.py
@@ -65,7 +65,9 @@ if __name__ == '__main__':
     app.config['BASIC_AUTH_PASSWORD'] = 'pokemon'
 
     basic_auth = BasicAuth(app)
-    app.config['BASIC_AUTH_FORCE'] = True
+    
+    if  args.auth_enable:
+        app.config['BASIC_AUTH_FORCE'] = True
 
     config['ROOT_PATH'] = app.root_path
     if args.gmaps_key is not None:


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ x ] New feature
- [ ] Translation

The following changes were made

- Added basic_auth
- Added argument --auth-enable , -ae  
- Added argument --auth-user, -au
- Added argument --auth-pass -ap
- Can add basic auth user to credentials.json or line args.  
- Added prerequisites to requirements.txt 

