### PR TITLE
fix for Gone! pokemon not being removed from map

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -145,7 +145,7 @@ GetNewPokemons = function(stamp) {
     lastStamp = dObj.getTime();
     
     $.each(markers, function(i, item){
-        if (item.disapear <= lastStamp - (dObj.getTimezoneOffset() * 60000))        
+        if (item.disapear <= lastStamp)        
             item.m.setMap(null);        
     });
 };


### PR DESCRIPTION
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- No longer need the timezone correction when checking for disappeared pokemon to remove from map. All times are now UTC.

https://github.com/AHAAAAAAA/PokemonGo-Map/issues/700

