### PR TITLE
pgoapi: handle ConnectionError exception on _auth_provider.login()

### DIFF
--- a/pogom/pgoapi/pgoapi.py
+++ b/pogom/pgoapi/pgoapi.py
@@ -140,9 +140,13 @@ class PGoApi:
             raise AuthException("Invalid authentication provider - only ptc/google available.")
             
         self.log.debug('Auth provider: %s', provider)
-        
-        if not self._auth_provider.login(username, password):
-            self.log.info('Login process failed') 
+
+        try:
+            if not self._auth_provider.login(username, password):
+                self.log.info('Login process failed')
+                return False
+        except requests.ConnectionError as e:
+            self.log.info(e)
             return False
         
         self.log.info('Starting RPC login sequence (app simulation)')
@@ -174,4 +178,3 @@ class PGoApi:
         self.log.info('Login process completed') 
         
         return True
-        


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

```
2016-07-21 02:34:06,848 [  _internal] [   INFO]  * Running on http://[::]:5000/ (Press CTRL+C to quit)
Exception in thread search_thread:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/stilwellt/projects/pokemongo/PokemonGo-Map/pogom/search.py", line 94, in search_loop
    search(args)
  File "/home/stilwellt/projects/pokemongo/PokemonGo-Map/pogom/search.py", line 69, in search
    login(args, position)
  File "/home/stilwellt/projects/pokemongo/PokemonGo-Map/pogom/search.py", line 50, in login
    while not api.login(args.auth_service, args.username, args.password):
  File "/home/stilwellt/projects/pokemongo/PokemonGo-Map/pogom/pgoapi/pgoapi.py", line 144, in login
    if not self._auth_provider.login(username, password):
  File "/home/stilwellt/projects/pokemongo/PokemonGo-Map/pogom/pgoapi/auth_ptc.py", line 82, in login
    r2 = self._session.post(self.PTC_LOGIN_OAUTH, data=data1)
  File "/usr/lib/python2.7/site-packages/requests/sessions.py", line 518, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/usr/lib/python2.7/site-packages/requests/sessions.py", line 475, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python2.7/site-packages/requests/sessions.py", line 585, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python2.7/site-packages/requests/adapters.py", line 453, in send
    raise ConnectionError(err, request=request)
ConnectionError: ('Connection aborted.', BadStatusLine("''",))
```