### PR TITLE
Add ability to delay next scan by X seconds

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -93,4 +93,6 @@ def search_loop(args):
     while True:
         search(args)
         log.info("Scanning complete.")
-        time.sleep(1)
+        if args.scan_delay > 1:
+            log.info('Waiting {:d} seconds before beginning new scan.'.format(args.scan_delay))
+        time.sleep(args.scan_delay)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -27,6 +27,7 @@ def get_args():
     parser.add_argument('-p', '--password', help='Password', required=False)
     parser.add_argument('-l', '--location', type=parse_unicode, help='Location, can be an address or coordinates', required=True)
     parser.add_argument('-st', '--step-limit', help='Steps', required=True, type=int)
+    parser.add_argument('-sd', '--scan-delay', help='Time delay before beginning new scan', required=False, type=int, default=1)
     parser.add_argument('-H', '--host', help='Set web server listening host', default='127.0.0.1')
     parser.add_argument('-P', '--port', type=int, help='Set web server listening port', default=5000)
     parser.add_argument('-L', '--locale', help='Locale for Pokemon names: default en, check'


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

* Adds an optional `--scan-delay` (`-sd`) argument that delays `search_loop` execution by the specified number of seconds
* Default delay is 1 second (unchanged)
* Outputs the delay time after a completed search if delay time is not default

___

Nobody likes argument hell but this seems like a simple no brainer. 

For people like me who want to have PokemonGo-Map running in the background and check on it only every once in a while starting a scan immediately after the previous one isn't necessary (since I'm only looking at it every 5-10 minutes) and only contributes to strain on niantic servers without any real benefit to myself. This PR makes it easy to spread out time between scans.