### PR TITLE
Adding docker compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+flask:
+    image: python:2.7-onbuild
+    ports:
+        - "5000:5000"
+    volumes:
+        - .:/usr/src/app
+    working_dir: /usr/src/app
+    entrypoint: |
+        bash -c 'bash -s <<EOF
+        pip install -r requirements.txt
+        python example.py -a google -u "XXXXXXX" -p "YYYYYY" -l "ZZZZZZZZ" -st 10 --host 0.0.0.0
+        EOF'


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [X] New feature
- [ ] Translation

The following changes were made

- Added docker configuration to help spin up new environments without worrying about python/pip/etc versions. 

related to #904 #599 both of which use a Dockerfile, this solution utilizes the docker compose tool instead.