### PR TITLE
Add support for a Heroku Deploy button

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python runserver.py -u "$USERNAME" -p "$PASSWORD" -l "$LOCATION" -st $STEP_COUNT $EXTRA_ARGS -H 0.0.0.0 -P $PORT
+web: python runserver.py -u "$USERNAME" -p "$PASSWORD" -l "$LOCATION" -st $STEP_COUNT -H 0.0.0.0 -P $PORT -k $GMAPS_KEY $EXTRA_ARGS 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Live visualization of all the pokemon (with option to show gyms and pokestops) in your area. This is a proof of concept that we can load all the pokemon visible nearby given a location. Currently runs on a Flask server displaying a Google Maps with markers on it.
 
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://github.com/AHAAAAAAA/PokemonGo-Map/wiki/Heroku-Deployment)
+
 [Official Website] (https://jz6.github.io/PoGoMap/)
 
 ![Map](https://raw.githubusercontent.com/AHAAAAAAA/PokemonGo-Map/master/static/cover.png)

--- a/app.json
+++ b/app.json
@@ -13,12 +13,15 @@
     "LOCATION": {
       "description": "Location on which the map should be centered. This can be an address, co-ordinates or anything that Google Maps accepts."
     },
+    "GMAPS_KEY": {
+      "description": "A Google Maps API key for this application."
+    },
     "STEP_COUNT": {
       "description": "The number of steps to take.",
       "value": "5"
     },
     "EXTRA_ARGS": {
-      "description": "Any extra arguments that you want to pass to run_server.py.",
+      "description": "Any extra arguments that you want to pass to runserver.py.",
       "required": false
     }
   }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,25 @@
+{
+  "name": "PokemonGo Map",
+  "description": "Live visualization of all the Pokémon (with option to show gyms and pokéstops) in an area on Pokémon Go.",
+  "repository": "https://github.com/AHAAAAAAA/PokemonGo-Map",
+  "keywords": ["pokemon", "pokemon go"],
+  "env": {
+    "USERNAME": {
+      "description": "Your username to login to the specified authentication service."
+    },
+    "PASSWORD": {
+      "description": "Your username to login to the specified authentication service."
+    },
+    "LOCATION": {
+      "description": "Location on which the map should be centered. This can be an address, co-ordinates or anything that Google Maps accepts."
+    },
+    "STEP_COUNT": {
+      "description": "The number of steps to take.",
+      "value": "5"
+    },
+    "EXTRA_ARGS": {
+      "description": "Any extra arguments that you want to pass to run_server.py.",
+      "required": false
+    }
+  }
+}


### PR DESCRIPTION
This expands on the great work already performed by @Chlodochar on #682 and makes deployments to Heroku easier.

It adds a an [app.json](https://devcenter.heroku.com/articles/app-json-schema) to the repository that describes the environment under which this project needs to run on Heroku.  This means that I was also able to add a [Heroku Deploy Button](https://devcenter.heroku.com/articles/heroku-button) and let people easily set up their own map on their own Heroku accounts.

When deploying I found that the Google Maps API Key was mandatory to get the app running, so modified the Procfile to support this change.

Wasn't 100% on what process to follow when I wanted to pull request an already open pull request, but this seemed like the most sensible.

![heroku_button_example](https://cloud.githubusercontent.com/assets/179072/17032028/132b8b80-4f6f-11e6-9013-226717284ace.png)