### PR TITLE
Fix map style drop down location and add satellite

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1952,3 +1952,7 @@ body {
         border-left: 0;
         margin-left: 0;
         padding-left: 0; } }
+
+.gm-style-mtc {
+    margin-top: '+=55px';
+}

--- a/static/map.js
+++ b/static/map.js
@@ -22,6 +22,7 @@ function initMap() {
           position: google.maps.ControlPosition.RIGHT_TOP,
           mapTypeIds: [
               google.maps.MapTypeId.ROADMAP,
+              google.maps.MapTypeId.SATELLITE,
               'dark_style',
               'style_light2',
               'style_pgo']


### PR DESCRIPTION
<!-- Please note, we are no longer accepting pull requests for master branch -->
This pull request includes a

- [x] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

-move the style drop down 55px down so its out of the way of the nav bar
-add satellite mode

If this is related to an existing ticket, include a link to it as well.
https://github.com/AHAAAAAAA/PokemonGo-Map/issues/991