### PR TITLE
Don't kick the server while it's down

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 
 TIMESTAMP = '\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000'
 REQ_SLEEP = 1
+failed_consecutive = 0
 api = PGoApi()
 
 
@@ -81,8 +82,13 @@ def search(args):
 
         try:
             parse_map(response_dict)
+            failed_consecutive = 0
         except KeyError:
             log.error('Scan step failed. Response dictionary key error.')
+            failed_consecutive += 1
+            if(failed_consecutive >= 10):
+            	log.error('Niantic servers under heavy load. Waiting before trying again')
+            	time.sleep(15)
 
         log.info('Completed {:5.2f}% of scan.'.format(float(i) / num_steps**2*100))
         i += 1

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -87,7 +87,7 @@ def search(args):
             failed_consecutive += 1
             if(failed_consecutive >= 10):
                 log.error('Niantic servers under heavy load. Waiting before trying again')
-            	time.sleep(15)
+            	time.sleep(5)
         failed_consecutive = 0
         log.info('Completed {:5.2f}% of scan.'.format(float(i) / num_steps**2*100))
         i += 1

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -85,7 +85,7 @@ def search(args):
         except KeyError:
             log.error('Scan step failed. Response dictionary key error.')
             failed_consecutive += 1
-            if(failed_consecutive >= 10):
+            if(failed_consecutive >= 5):
                 log.error('Niantic servers under heavy load. Waiting before trying again')
             	time.sleep(5)
         failed_consecutive = 0

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -82,14 +82,13 @@ def search(args):
 
         try:
             parse_map(response_dict)
-            failed_consecutive = 0
         except KeyError:
             log.error('Scan step failed. Response dictionary key error.')
             failed_consecutive += 1
             if(failed_consecutive >= 10):
-            	log.error('Niantic servers under heavy load. Waiting before trying again')
+                log.error('Niantic servers under heavy load. Waiting before trying again')
             	time.sleep(15)
-
+        failed_consecutive = 0
         log.info('Completed {:5.2f}% of scan.'.format(float(i) / num_steps**2*100))
         i += 1
         time.sleep(REQ_SLEEP)


### PR DESCRIPTION
<!-- Please note, we are no longer accepting pull requests for master branch -->
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- When the search thread detects that the server is down, wait a bit before trying again. There are so many people running this that we are now probably a not insignificant chunk of Niantic traffic; we don't need to keep punching the servers repeatedly while they are trying to come back up.

This will also shut up the dozens of issues about the response dictionary key error. ;)

