### PR TITLE
Fix localStorage options always defaulting to `true`

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -234,10 +234,9 @@ function clearStaleMarkers() {
 };
 
 function updateMap() {
-    
-    localStorage.showPokemon = localStorage.showPokemon || true;
-    localStorage.showGyms = localStorage.showGyms || true;
-    localStorage.showPokestops = localStorage.showPokestops || true;
+    localStorage.showPokemon = typeof localStorage.showPokemon !== 'undefined' ? localStorage.showPokemon : true;
+    localStorage.showGyms = typeof localStorage.showGyms !== 'undefined' ? localStorage.showGyms : true;
+    localStorage.showPokestops = typeof localStorage.showPokestops !== 'undefined' ? localStorage.showPokestops : true;
 
     $.ajax({
         url: "raw_data",


### PR DESCRIPTION
<!-- Please note, we are no longer accepting pull requests for master branch -->
This pull request includes a

- [X ] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made:

Check if `localStorage` var is explicitly undefined, otherwise when you turn off switch, it will always default to true


If this is related to an existing ticket, include a link to it as well.

