### PR TITLE
Add Scanned Area markers onto the map

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -40,7 +40,7 @@ class Pogom(Flask):
             d['gyms'] = Gym.get_all()
 
         if request.args.get('scanned', 'true') == 'true':
-            d['scanned'] = ScannedLocation.get_all()
+            d['scanned'] = ScannedLocation.get_recent()
 
         return jsonify(d)
 

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from s2sphere import *
 
 from . import config
-from .models import Pokemon, Gym, Pokestop
+from .models import Pokemon, Gym, Pokestop, ScannedLocation
 
 
 class Pogom(Flask):
@@ -38,6 +38,9 @@ class Pogom(Flask):
 
         if request.args.get('gyms', 'true') == 'true':
             d['gyms'] = Gym.get_all()
+
+        if request.args.get('scanned', 'true') == 'true':
+            d['scanned'] = ScannedLocation.get_all()
 
         return jsonify(d)
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -82,7 +82,20 @@ class ScannedLocation(BaseModel):
     longitude = FloatField()
     last_modified = DateTimeField()
 
-def parse_map(map_dict, iteration_num, step, step_location):
+    @classmethod
+    def get_recent(cls):
+        query = (ScannedLocation
+                 .select()
+                 .where(ScannedLocation.last_modified >= (datetime.utcnow() - timedelta(minutes=15)))
+                 .dicts())
+
+        scans = []
+        for s in query:
+            scans.append(s)
+
+        return scans
+
+def parse_map(map_dict, step_location, step_location):
     pokemons = {}
     pokestops = {}
     gyms = {}

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -95,7 +95,7 @@ class ScannedLocation(BaseModel):
 
         return scans
 
-def parse_map(map_dict, step_location, step_location):
+def parse_map(map_dict, iteration_num, step, step_location):
     pokemons = {}
     pokestops = {}
     gyms = {}

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -5,6 +5,7 @@ import logging
 from peewee import Model, SqliteDatabase, InsertQuery, IntegerField,\
                    CharField, FloatField, BooleanField, DateTimeField
 from datetime import datetime
+from datetime import timedelta
 from base64 import b64encode
 
 from .utils import get_pokemon_name, get_args
@@ -75,11 +76,17 @@ class Gym(BaseModel):
     longitude = FloatField()
     last_modified = DateTimeField()
 
+class ScannedLocation(BaseModel):
+    scanned_id = CharField(primary_key=True)
+    latitude = FloatField()
+    longitude = FloatField()
+    last_modified = DateTimeField()
 
-def parse_map(map_dict, iteration_num, step):
+def parse_map(map_dict, iteration_num, step, step_location):
     pokemons = {}
     pokestops = {}
     gyms = {}
+    scanned = {}
 
     cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
     for cell in cells:
@@ -143,6 +150,15 @@ def parse_map(map_dict, iteration_num, step):
         log.info("Upserting {} gyms".format(len(gyms)))
         bulk_upsert(Gym, gyms)
 
+    scanned[0] = {
+        'scanned_id': str(step_location[0])+','+str(step_location[1]),
+        'latitude': step_location[0],
+        'longitude': step_location[1],
+        'last_modified': datetime.utcnow(),
+    }
+
+    bulk_upsert(ScannedLocation, scanned)
+
 def bulk_upsert(cls, data):
     num_rows = len(data.values())
     i = 0
@@ -157,5 +173,5 @@ def bulk_upsert(cls, data):
 
 def create_tables():
     db.connect()
-    db.create_tables([Pokemon, Pokestop, Gym], safe=True)
+    db.create_tables([Pokemon, Pokestop, Gym, ScannedLocation], safe=True)
     db.close()

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -130,7 +130,7 @@ def search(args, i):
             response_dict = send_map_request(api, step_location)
             if response_dict:
                 try:
-                    parse_map(response_dict, i, step)
+                    parse_map(response_dict, i, step, step_location)
                 except KeyError:
                     log.error('Scan step {:d} failed. Response dictionary key error.'.format(step))
                     failed_consecutive += 1

--- a/static/map.js
+++ b/static/map.js
@@ -379,6 +379,14 @@ function clearStaleMarkers() {
             delete map_pokemons[key];
         }
     });
+    
+    $.each(map_scanned, function(key, value) {
+        //If older than 15mins remove
+        if (map_scanned[key]['last_modified'] < (new Date().getTime() - 15 * 60 * 1000)) {
+            map_scanned[key].marker.setMap(null);
+            delete map_scanned[key];
+        }
+    });
 };
 
 function updateMap() {
@@ -454,13 +462,7 @@ function updateMap() {
             }
 
             if (item.scanned_id in map_scanned) {
-                // if team has changed, create new marker (new icon)
-                if (map_scanned[item.scanned_id].last_modified != item.last_modified) {
-                    map_scanned[item.scanned_id].marker.setMap(null);
-                    map_scanned[item.scanned_id].marker = setupScannedMarker(item);
-                }else{
-                    map_scanned[item.scanned_id].marker.setOptions({fillColor: getColorByDate(item.last_modified)});
-                }
+                map_scanned[item.scanned_id].marker.setOptions({fillColor: getColorByDate(item.last_modified)});
             }
             else { // add marker to map and item to dict
                 if (item.marker) item.marker.setMap(null);

--- a/static/map.js
+++ b/static/map.js
@@ -120,7 +120,8 @@ function initSidebar() {
     $('#gyms-switch').prop('checked', localStorage.showGyms === 'true');
     $('#pokemon-switch').prop('checked', localStorage.showPokemon === 'true');
     $('#pokestops-switch').prop('checked', localStorage.showPokestops === 'true');
-
+    $('#scanned-switch').prop('checked', localStorage.showScanned === 'true');
+    
     var input = document.getElementById('next-location');
     var searchBox = new google.maps.places.SearchBox(input);
 
@@ -235,10 +236,22 @@ function pokestopLabel(lured, last_modified, active_pokemon_id, latitude, longit
     return str;
 }
 
+function scannedLabel(last_modified) {
+    scanned_date = new Date(last_modified)
+    var pad = function (number) { return number <= 99 ? ("0" + number).slice(-2) : number; }
+
+    var contentstring = `
+        <div>
+            Scanned at ${pad(scanned_date.getHours())}:${pad(scanned_date.getMinutes())}:${pad(scanned_date.getSeconds())}
+        </div>`;
+    return contentstring;
+};
+
 // Dicts
 map_pokemons = {} // Pokemon
 map_gyms = {} // Gyms
 map_pokestops = {} // Pokestops
+map_scanned = {} // Pokestops
 var gym_types = ["Uncontested", "Mystic", "Valor", "Instinct"];
 
 function setupPokemonMarker(item) {
@@ -300,6 +313,39 @@ function setupPokestopMarker(item) {
     return marker;
 };
 
+function getColorByDate(value){
+    //Changes the Color from Red to green over 15 mins
+    var diff = (Date.now() - value) / 1000 / 60 / 15;
+
+    if(diff > 1){
+        diff = 1;
+    }
+
+    //value from 0 to 1 - Green to Red
+    var hue=((1-diff)*120).toString(10);
+    return ["hsl(",hue,",100%,50%)"].join("");
+}
+
+function setupScannedMarker(item) {
+    var mapCenter = new google.maps.LatLng(item.latitude, item.longitude);
+
+    var marker = new google.maps.Circle({
+        map: map,
+        center: mapCenter,
+        radius: 100,    // 10 miles in metres
+        fillColor: getColorByDate(item.last_modified),
+        strokeWeight: 1
+    });
+    // circle.bindTo('center', marker, 'position');
+
+    marker.infoWindow = new google.maps.InfoWindow({
+        content: scannedLabel(item.last_modified)
+    });
+
+    addListeners(marker);
+    return marker;
+};
+
 function addListeners(marker) {
     marker.addListener('click', function() {
         marker.infoWindow.open(map, marker);
@@ -340,6 +386,7 @@ function updateMap() {
     localStorage.showPokemon = localStorage.showPokemon || true;
     localStorage.showGyms = localStorage.showGyms || true;
     localStorage.showPokestops = localStorage.showPokestops || true;
+    localStorage.showScanned = localStorage.showScanned || true;
 
     $.ajax({
         url: "raw_data",
@@ -347,7 +394,8 @@ function updateMap() {
         data: {
             'pokemon': localStorage.showPokemon,
             'pokestops': localStorage.showPokestops,
-            'gyms': localStorage.showGyms
+            'gyms': localStorage.showGyms,
+            'scanned': localStorage.showScanned
         },
         dataType: "json"
     }).done(function(result) {
@@ -400,6 +448,28 @@ function updateMap() {
 
         });
 
+        $.each(result.scanned, function(i, item) {
+            if (!localStorage.showScanned) {
+                return false;
+            }
+
+            if (item.scanned_id in map_scanned) {
+                // if team has changed, create new marker (new icon)
+                if (map_scanned[item.scanned_id].last_modified != item.last_modified) {
+                    map_scanned[item.scanned_id].marker.setMap(null);
+                    map_scanned[item.scanned_id].marker = setupScannedMarker(item);
+                }else{
+                    map_scanned[item.scanned_id].marker.setOptions({fillColor: getColorByDate(item.last_modified)});
+                }
+            }
+            else { // add marker to map and item to dict
+                if (item.marker) item.marker.setMap(null);
+                item.marker = setupScannedMarker(item);
+                map_scanned[item.scanned_id] = item;
+            }
+
+        });
+
         clearStaleMarkers();
     });
 };
@@ -440,6 +510,19 @@ $('#pokestops-switch').change(function() {
             map_pokestops[key].marker.setMap(null);
         });
         map_pokestops = {}
+    }
+});
+
+
+$('#scanned-switch').change(function() {
+    localStorage["showScanned"] = this.checked;
+    if (this.checked) {
+        updateMap();
+    } else {
+        $.each(map_scanned, function(key, value) {
+            map_scanned[key].marker.setMap(null);
+        });
+        map_scanned = {}
     }
 });
 

--- a/static/map.js
+++ b/static/map.js
@@ -327,22 +327,22 @@ function getColorByDate(value){
 }
 
 function setupScannedMarker(item) {
-    var mapCenter = new google.maps.LatLng(item.latitude, item.longitude);
+    var circleCenter = new google.maps.LatLng(item.latitude, item.longitude);
 
     var marker = new google.maps.Circle({
         map: map,
-        center: mapCenter,
+        center: circleCenter,
         radius: 100,    // 10 miles in metres
         fillColor: getColorByDate(item.last_modified),
         strokeWeight: 1
     });
-    // circle.bindTo('center', marker, 'position');
 
-    marker.infoWindow = new google.maps.InfoWindow({
-        content: scannedLabel(item.last_modified)
-    });
+    // marker.infoWindow = new google.maps.InfoWindow({
+    //     content: scannedLabel(item.last_modified),
+    //     position: circleCenter
+    // });
 
-    addListeners(marker);
+    //addListeners(marker);
     return marker;
 };
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -49,9 +49,9 @@
 				<div class="onoffswitch">
 					<input id="pokemon-switch" type="checkbox" name="pokemon-switch" class="onoffswitch-checkbox" checked/>
 					<label class="onoffswitch-label" for="pokemon-switch">
-	          <span class="switch-label" data-on="On" data-off="Off"></span>
-	          <span class="switch-handle"></span>
-	        </label>
+			        	<span class="switch-label" data-on="On" data-off="Off"></span>
+			        	<span class="switch-handle"></span>
+			        </label>
 				</div>
 			</div>
 			<div class="switch-container">
@@ -59,9 +59,9 @@
 				<div class="onoffswitch">
 					<input id="gyms-switch" type="checkbox" name="gyms-switch" class="onoffswitch-checkbox" checked/>
 					<label class="onoffswitch-label" for="gyms-switch">
-	          <span class="switch-label" data-on="On" data-off="Off"></span>
-	          <span class="switch-handle"></span>
-	        </label>
+			        	<span class="switch-label" data-on="On" data-off="Off"></span>
+			        	<span class="switch-handle"></span>
+			        </label>
 				</div>
 			</div>
 			<div class="switch-container">
@@ -69,6 +69,16 @@
 				<div class="onoffswitch">
 					<input id="pokestops-switch" type="checkbox" name="pokestops-switch" class="onoffswitch-checkbox" checked/>
 					<label class="onoffswitch-label" for="pokestops-switch">
+						<span class="switch-label" data-on="On" data-off="Off"></span>
+						<span class="switch-handle"></span>
+					</label>
+				</div>
+			</div>
+			<div class="switch-container">
+				<h3>Scanned Locations</h3>
+				<div class="onoffswitch">
+					<input id="scanned-switch" type="checkbox" name="scanned-switch" class="onoffswitch-checkbox" checked/>
+					<label class="onoffswitch-label" for="scanned-switch">
 						<span class="switch-label" data-on="On" data-off="Off"></span>
 						<span class="switch-handle"></span>
 					</label>


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

This adds a new option on the map that shows what areas have been scanned (100m Radius around the requested LatLng sent to the API)

The circles are colored between Green and Red depending on how recent the area was updated. Green for 0 mins and Red for >= 15 mins

![scanned locations](https://cloud.githubusercontent.com/assets/1560723/17044348/30628648-4fb7-11e6-8d81-692096f1b262.png)

I will raise a separate issue but this has shown up a possible problem with the search stepping of 0.0025 in search.py as can be seen in the image above.

Edit - A better image now we are using the Hex grid:

![big hex](https://cloud.githubusercontent.com/assets/1560723/17073212/98bc6d1c-5066-11e6-9903-fdb25c0d15dc.png)
