### PR TITLE
check for 'undefined' value in map_style

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -68,7 +68,9 @@ function initMap() {
         localStorage['map_style'] = this.mapTypeId;
     });
 
-    localStorage['map_style'] = localStorage['map_style'] || 'roadmap';
+    if (!localStorage['map_style'] || localStorage['map_style'] === 'undefined') {
+        localStorage['map_style'] = 'roadmap';
+    }
 
     map.setMapTypeId(localStorage['map_style']);
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made:
At some point the string 'undefined' was being written to map_style, causing maps to not load. This adds an additional check for that value

Fixes #1154 and may be the cause behind #1059, #1165