### PR TITLE
Add an option to runserver.py that enables CORS

### DIFF
--- a/Easy Setup/requirements.txt
+++ b/Easy Setup/requirements.txt
@@ -13,3 +13,4 @@ requests==2.10.0
 s2sphere==0.2.4
 gpsoauth==0.3.0
 protobuf-to-dict==0.1.0
+flask-cors==2.1.2

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -37,6 +37,7 @@ def get_args():
     parser.add_argument('-d', '--debug', help='Debug Mode', action='store_true')
     parser.add_argument('-m', '--mock', help='Mock mode. Starts the web server but not the background thread.', action='store_true', default=False)
     parser.add_argument('-k', '--google-maps-key', help='Google Maps Javascript API Key', default=None, dest='gmaps_key')
+    parser.add_argument('-C', '--cors', help='Enable CORS on web server', action='store_true', default=False)
     parser.set_defaults(DEBUG=False)
     args = parser.parse_args()
     if args.password is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ requests==2.10.0
 s2sphere==0.2.4
 gpsoauth==0.3.0
 protobuf-to-dict==0.1.0
+flask-cors==2.1.2

--- a/runserver.py
+++ b/runserver.py
@@ -5,6 +5,7 @@ import os
 import logging
 
 from threading import Thread
+from flask_cors import CORS, cross_origin
 
 from pogom import config
 from pogom.app import Pogom
@@ -55,6 +56,10 @@ if __name__ == '__main__':
         insert_mock_data()
 
     app = Pogom(__name__)
+
+    if args.cors:
+        CORS(app);
+
     config['ROOT_PATH'] = app.root_path
     if args.gmaps_key is not None:
         config['GMAPS_KEY'] = args.gmaps_key


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Adds a dependency on flask-cors
- Adds a cli flag of `-C, --cors` which if add adds flask cors to the app
- This allows clients running on a different host to access the api

If this is related to an existing ticket, include a link to it as well.