### PR TITLE
Fix clicking on notify pokemon label opening exclude pokemon dropdown

### DIFF
--- a/templates/map.html
+++ b/templates/map.html
@@ -82,7 +82,7 @@
 	      		</label>
 			</div>
 			<div style="margin-top: 25px;">
-				<label for="exclude-pokemon">
+				<label for="notify-pokemon">
 					<h3>Notify of Pokémon</h3>
 					<select id="notify-pokemon" multiple="multiple"></select>
 				</label>


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

Fixed the 'for' attribute on label to select correct element.

If this is related to an existing ticket, include a link to it as well.

