### PR TITLE
Fixed auth ticket

### DIFF
--- a/pogom/pgoapi/pgoapi.py
+++ b/pogom/pgoapi/pgoapi.py
@@ -168,7 +168,8 @@ class PGoApi:
             return False
         
         if 'auth_ticket' in response:
-            self._auth_provider.set_ticket(response['auth_ticket'].values())
+            auth_ticket = response['auth_ticket']
+            self._auth_provider.set_ticket([auth_ticket['expire_timestamp_ms'], auth_ticket['start'], auth_ticket['end']])
         
         self.log.info('Finished RPC login sequence (app simulation)')
         self.log.info('Login process completed') 


### PR DESCRIPTION
<!-- Please note, we are no longer accepting pull requests for master branch -->
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Fixed the order of params when calling set_ticket

Running locally the order of params is always (?) correct but when running on Heroku most of the times the order is wrong. This PR should fix the issue.
I'm not a Python guy so I don't know if there is a better way to do what I did.

If this is related to an existing ticket, include a link to it as well.
#965
#1141
#1071
#1205 
#1240 