### PR TITLE
Add accurate Pokestop labels

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -12,11 +12,14 @@ document.addEventListener("DOMContentLoaded", function () {
 var $selectExclude = $("#exclude-pokemon");
 var $selectNotify = $("#notify-pokemon");
 
+var idToPokemon = {};
+
 $.getJSON("static/locales/pokemon." + document.documentElement.lang + ".json").done(function(data) {
     var pokeList = []
 
     $.each(data, function(key, value) {
         pokeList.push( { id: key, text: value } );
+        idToPokemon[key] = value;
     });
 
     JSON.parse(readCookie("remember_select_exclude"));
@@ -136,10 +139,11 @@ function initSidebar() {
     });
 }
 
+var pad = function (number) { return number <= 99 ? ("0" + number).slice(-2) : number; }
+
 
 function pokemonLabel(name, disappear_time, id, latitude, longitude) {
     disappear_date = new Date(disappear_time)
-    var pad = function (number) { return number <= 99 ? ("0" + number).slice(-2) : number; }
 
     var contentstring = `
         <div>
@@ -157,7 +161,7 @@ function pokemonLabel(name, disappear_time, id, latitude, longitude) {
                     target='_blank' title='View in Maps'>Get directions</a>
         </div>`;
     return contentstring;
-};
+}
 
 function gymLabel(team_name, team_id, gym_points) {
     var gym_color = ["0, 0, 0, .4", "74, 138, 202, .6", "240, 68, 58, .6", "254, 217, 40, .6"];
@@ -178,6 +182,52 @@ function gymLabel(team_name, team_id, gym_points) {
             </div>
             <div>Prestige: ${gym_points}</div>
             </center></div>`;
+    }
+
+    return str;
+}
+
+function pokestopLabel(lured, last_modified, active_pokemon_id, latitude, longitude) {
+    var str;
+    if (lured) {
+        var active_pokemon = idToPokemon[active_pokemon_id];
+
+        var last_modified_date = new Date(last_modified);
+        var current_date = new Date();
+
+        var time_until_expire = current_date.getTime() - last_modified_date.getTime();
+
+        var expire_date = new Date(current_date.getTime() + time_until_expire);
+        var expire_time = expire_date.getTime();
+
+        str = `
+            <div>
+                <b>Lured Pokéstop</b>
+            </div>
+            <div>
+                Lured Pokémon: ${active_pokemon}
+                <span> - </span>
+                <small>
+                    <a href='http://www.pokemon.com/us/pokedex/${active_pokemon_id}' target='_blank' title='View in Pokedex'>#${active_pokemon_id}</a>
+                </small>
+            </div>
+            <div>
+                Lure expires at ${pad(expire_date.getHours())}:${pad(expire_date.getMinutes())}:${pad(expire_date.getSeconds())}
+                <span class='label-countdown' disappears-at='${expire_time}'>(00m00s)</span></div>
+            <div>
+            <div>
+                <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}'
+                        target='_blank' title='View in Maps'>Get directions</a>
+            </div>`;
+    } else {
+        str = `
+            <div>
+                <b>Pokéstop</b>
+            </div>
+            <div>
+                <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}'
+                        target='_blank' title='View in Maps'>Get directions</a>
+            </div>`;
     }
 
     return str;
@@ -241,7 +291,7 @@ function setupPokestopMarker(item) {
     });
 
     marker.infoWindow = new google.maps.InfoWindow({
-        content: "I'm a Pokéstop, and soon enough I'll tell you more things about me."
+        content: pokestopLabel(!!item.lure_expiration, item.last_modified, item.active_pokemon_id, item.latitude, item.longitude)
     });
 
     addListeners(marker);


### PR DESCRIPTION
<!-- Please note, we are no longer accepting pull requests for master branch -->
This pull request includes a

- [X] Bug fix
- [X] New feature
- [ ] Translation

The following changes were made

- Show expiration time for Lured Pokéstops
- Show directions from current location to Pokéstop
- Show Pokémon lured by that Pokéstop

Similar to #1006, but instead of using `lure_expiration`, which doesn't seem to be working properly, it uses `current_time - last_lured` to get the exact time until it expires.
