### PR TITLE
add theme-color meta tag

### DIFF
--- a/templates/map.html
+++ b/templates/map.html
@@ -8,6 +8,7 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="black">
 		<meta name="apple-mobile-web-app-title" content="PokeMap">
 		<meta name="mobile-web-app-capable" content="yes">
+		<meta name="theme-color" content="#3b3b3b">
 
 		<!-- Fav- & Apple-Touch-Icons -->
 		<!-- Favicon -->


### PR DESCRIPTION
<!-- Please note, we are no longer accepting pull requests for master branch -->
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- This change set's mobile Chrome's UI to the same color as the header using the [`theme-color meta tag`](https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android?hl=en), similar to what the `apple-mobile-web-app-status-bar-style` meta tag already does for IOS.

