### PR TITLE
Map: Add fullscreen toggle.

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -67,6 +67,7 @@ function initMap() {
             lng: center_lng
         },
         zoom: 16,
+        fullscreenControl: true,
         streetViewControl: false,
 		mapTypeControl: true,
 		mapTypeControlOptions: {


### PR DESCRIPTION
<!-- Please note, we are no longer accepting pull requests for master branch -->
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

```diff
diff --git a/static/map.js b/static/map.js
index 9be4a60..c4f8e7a 100644
--- a/static/map.js
+++ b/static/map.js
@@ -67,6 +67,7 @@ function initMap() {
             lng: center_lng
         },
         zoom: 16,
+        fullscreenControl: true,
         streetViewControl: false,
                mapTypeControl: true,
                mapTypeControlOptions: {
```

If this is related to an existing ticket, include a link to it as well.

  This toggle is slightly different than just F11'ing
  as it remove the header bar and shows nothing but the
  map.