### PR TITLE
show unhidden pokemons notifications in browser

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -120,6 +120,7 @@ function initSidebar() {
     $('#gyms-switch').prop('checked', localStorage.showGyms === 'true');
     $('#pokemon-switch').prop('checked', localStorage.showPokemon === 'true');
     $('#pokestops-switch').prop('checked', localStorage.showPokestops === 'true');
+    $('#hidden-switch').prop('checked', localStorage.notifyNonHidden === 'true');
 
     var input = document.getElementById('next-location');
     var searchBox = new google.maps.places.SearchBox(input);
@@ -255,6 +256,8 @@ function setupPokemonMarker(item) {
     });
     
     if (notifiedPokemon.indexOf(item.pokemon_id) > -1) {
+        sendNotification('A wild ' + item.pokemon_name + ' appeared!', 'Click to load map', 'static/icons/' + item.pokemon_id + '.png')
+    } else if (excludedPokemon.indexOf(item.pokemon_id) == -1 && localStorage.notifyNonHidden) {
         sendNotification('A wild ' + item.pokemon_name + ' appeared!', 'Click to load map', 'static/icons/' + item.pokemon_id + '.png')
     }
 
@@ -440,6 +443,10 @@ $('#pokestops-switch').change(function() {
         });
         map_pokestops = {}
     }
+});
+
+$('#hidden-switch').change(function() {
+    localStorage["notifyNonHidden"] = this.checked;
 });
 
 var updateLabelDiffTime = function() {

--- a/templates/map.html
+++ b/templates/map.html
@@ -74,6 +74,16 @@
 					</label>
 				</div>
 			</div>
+			<div class="switch-container">
+               <h3>Notify unhidden Pokémon</h3>
+               <div class="onoffswitch">
+                   <input id="hidden-switch" type="checkbox" name="hidden-switch" class="onoffswitch-checkbox" checked/>
+                   <label class="onoffswitch-label" for="hidden-switch">
+                       <span class="switch-label" data-on="On" data-off="Off"></span>
+                       <span class="switch-handle"></span>
+                   </label>
+               </div>
+           </div>
 			<!-- <button id="trigger-overlay">Test overlay</button> -->
 			<div>
 				<label for="exclude-pokemon">


### PR DESCRIPTION

This pull request includes a

- [Browser notifications of unhidden Pokemon ] New feature

The following changes were made

- Compare pokemon found against excluded Pokemon name list (found in sidebar), if Pokemon found does not exist in excluded list, send out notification to browser
- Toggle for this located in sidebar
