### PR TITLE
Reduce docker image size by > 50%

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,15 +17,15 @@ ENTRYPOINT ["python", "./runserver.py", "--host", "0.0.0.0"]
 # Set default options when container is run without any command line arguments
 CMD ["-h"]
 
-# build-base contains gcc, which is needed during the installation of the pycryptodomex pip package
-RUN apk add --no-cache \
-    build-base ca-certificates
+# add certificates to talk to the internets
+RUN apk add --no-cache ca-certificates
 
 # Copy Python requirements so we only rebuild deps if they have changed
 COPY requirements.txt /usr/src/app/
 
-# Install all prerequisites
-RUN pip install --no-cache-dir -r requirements.txt \
+# Install all prerequisites (build base used for gcc of some python modules)
+RUN apk add --no-cache build-base \
+ && pip install --no-cache-dir -r requirements.txt \
  && apk del build-base
 
 # Add the rest of the app code


### PR DESCRIPTION
By wrapping the build tools installation and removal in the same
layer, we can prevent the download of that weight in a previous
layer.

```
before ...  242.70 MB
after  ...   94.93 MB
```

Contributing layers, and the fix:

```
$ docker history before
IMAGE               CREATED             CREATED BY                                      SIZE
49fc4fec61cf        4 minutes ago       /bin/sh -c #(nop) COPY dir:a35abf98d7e251057f   2.808 MB
af74caea7748        4 minutes ago       /bin/sh -c pip install --no-cache-dir -r requ   34.93 MB
698d746acb8c        6 minutes ago       /bin/sh -c #(nop) COPY file:e9ce3df02e968ddde   257 B
e1f6a843f2f2        6 minutes ago       /bin/sh -c apk add --no-cache     build-base    148.5 MB
<missing>           2 days ago          /bin/sh -c set -ex  && apk add --no-cache --v   51.65 MB
<missing>           4 weeks ago         /bin/sh -c #(nop) ADD file:852e9d0cb9d906535a   4.799 MB

$ docker history after
IMAGE               CREATED              CREATED BY                                      SIZE
92939ad7153c        About a minute ago   /bin/sh -c #(nop) COPY dir:d14755e414af926414   2.808 MB
334b7b6d7852        About a minute ago   /bin/sh -c apk add --no-cache build-base  &&    34.93 MB
2ea7e1be38b9        3 minutes ago        /bin/sh -c #(nop) COPY file:e9ce3df02e968ddde   257 B
d629c2deeedf        3 minutes ago        /bin/sh -c apk add --no-cache ca-certificates   746.4 kB
<missing>           2 days ago           /bin/sh -c set -ex  && apk add --no-cache --v   51.65 MB
<missing>           4 weeks ago          /bin/sh -c #(nop) ADD file:852e9d0cb9d906535a   4.799 MB
```

(Removed some 0byte lines from the history output for clarity)