### PR TITLE
Update map.js for optional URL passed locations

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -63,6 +63,18 @@ var selectedStyle = 'light';
 
 function initMap() {
 
+    // Add support for URL passed locations.
+    var latitude = getParameterByName('lat');
+    var longitude = getParameterByName('long');
+
+    if (latitude) {
+	var pos = {
+	    lat: latitude,
+	    lng: longitude
+	};
+	center_lat = latitude;  // Override default lat/lang if passed via URL. /?lat=42.3152924&long=-83.0367337
+	center_lng = longitude;
+    }
 
     map = new google.maps.Map(document.getElementById('map'), {
         center: {
@@ -115,6 +127,16 @@ function initMap() {
 
     initSidebar();
 };
+
+function getParameterByName(name, url) {
+    if (!url) url = window.location.href;
+    name = name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+}
 
 function initSidebar() {
     $('#gyms-switch').prop('checked', localStorage.showGyms === 'true');

--- a/static/map.js
+++ b/static/map.js
@@ -68,12 +68,8 @@ function initMap() {
     var longitude = getParameterByName('long');
 
     if (latitude) {
-	var pos = {
-	    lat: latitude,
-	    lng: longitude
-	};
-	center_lat = latitude;  // Override default lat/lang if passed via URL. /?lat=42.3152924&long=-83.0367337
-	center_lng = longitude;
+	center_lat = parseFloat(latitude);  // Override default lat/lang if passed via URL. /?lat=42.3152924&long=-83.0367337
+	center_lng = parseFloat(longitude);
     }
 
     map = new google.maps.Map(document.getElementById('map'), {


### PR DESCRIPTION
<!-- Please note, we are no longer accepting pull requests for master branch -->
This pull request includes a

- [1 ] New feature

The following changes were made

- Enabled optional URL parameters for geo positioning.
- Allows Location Aware apps to load the URL dynamically
- Does not change the default behaviour
- Uses lat and lang querystring parameters (?lat=42.3152924&long=-83.0367337)



I've build a location aware Android app that can pass the location into the map.js to allow for live map location detection (without HTTPS on the server end).  This change doesn't change the default functionality, merely adds optional URL lat & long params.

Added function getParameterByName(), and a few lines in initMap().