### PR TITLE
Handle authptc exception

### DIFF
--- a/pogom/pgoapi/auth_ptc.py
+++ b/pogom/pgoapi/auth_ptc.py
@@ -51,7 +51,12 @@ class AuthPtc(Auth):
         head = {'User-Agent': 'niantic'}
         r = self._session.get(self.PTC_LOGIN_URL, headers=head)
         
-        jdata = json.loads(r.content)
+        try:
+            jdata = json.loads(r.content)
+        except ValueError as e:
+            self.log.error('{}... server seems to be down :('.format(str(e)))
+            return False
+            
         data = {
             'lt': jdata['lt'],
             'execution': jdata['execution'],


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix

The following changes were made

- Sometimes when the servers are down r = self._session.get(self.PTC_LOGIN_URL, headers=head) may not receive proper json data to be loaded in jdata = json.loads(r.content), this may leave the login() hanging without retries. Just added a handle for the ValueError exception so we can safely return False from login().

> Traceback (most recent call last):
>   File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 810, in __bootstrap_inner
>     self.run()
>   File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 763, in run
>     self.__target(*self.__args, **self.__kwargs)
>   File "/Dev/Projects/PokemonGo-Map/pogom/search.py", line 106, in search_loop
>     search(args, i)
>   File "/Dev/Projects/PokemonGo-Map/pogom/search.py", line 67, in search
>     login(args, position)
>   File "/Dev/Projects/PokemonGo-Map/pogom/search.py", line 48, in login
>     while not api.login(args.auth_service, args.username, args.password):
>   File "/Dev/PokemonGo-Map/pogom/pgoapi/pgoapi.py", line 144, in login
>     if not self._auth_provider.login(username, password):
>   File "/Dev/Projects/PokemonGo-Map/pogom/pgoapi/auth_ptc.py", line 54, in login
>     jdata = json.loads(r.content)
>   File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 338, in loads
>     return _default_decoder.decode(s)
>   File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py", line 366, in decode
>     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
>   File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py", line 384, in raw_decode
>     raise ValueError("No JSON object could be decoded")
> ValueError: No JSON object could be decoded

