### PR TITLE
Make the /mobile page more accesibility friendly

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -74,7 +74,7 @@ class Pogom(Flask):
                 'name': pokemon['pokemon_name'],
                 'card_dir': direction,
                 'distance': int(origin_point.get_distance(pokemon_point).radians * 6366468.241830914),
-                'time_to_disappear': '%dm %ds' % (divmod((pokemon['disappear_time']-datetime.utcnow()).seconds, 60)),
+                'time_to_disappear': '%dmin %dsec' % (divmod((pokemon['disappear_time']-datetime.utcnow()).seconds, 60)),
                 'latitude': pokemon['latitude'],
                 'longitude': pokemon['longitude']
             }

--- a/static/css/mobile.css
+++ b/static/css/mobile.css
@@ -1,0 +1,22 @@
+table {
+    color: #333;
+    font-family: Helvetica, Arial, sans-serif;
+    border-collapse: collapse;
+    border-spacing: 0;
+}
+
+td, th {
+    border: 1px solid #CCC;
+    height: 30px;
+    padding: 3px 7px;
+}
+
+th {
+    background: #F3F3F3;
+    font-weight: bold;
+}
+
+td {
+    background: #FAFAFA;
+    text-align: center;
+}

--- a/templates/mobile_list.html
+++ b/templates/mobile_list.html
@@ -1,15 +1,36 @@
-<table border="1">
+<!DOCTYPE html>
+<html lang=en>
+    <head>
+        <title>Pokemon List</title>
+        <meta content="width=device-width,initial-scale=1,maximum-scale=1" name=viewport>
+    </head>
+    <body>
+        <h1>Pokemon List</h1>
+
+        <link rel="stylesheet" href="/static/css/mobile.css" type="text/css" />
+
+        <table>
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Time Remaining</th>
+                    <th>Direction from Origin</th>
+                    <th>Map Link</th>
+                </tr>
+            </thead>
+            <tbody>
 {% for pokemon in pokemon_list %}
-<tr>
-<td>
-<a href='geo:0,0?q={{pokemon.latitude}},{{pokemon.longitude}}({{pokemon.name}})'>
-<img height='60' width='80' src='static/pixel_icons/{{pokemon.id}}.png'>
-</a>
-</td>
-<td>{{pokemon.time_to_disappear}}</td>
-<td>{{pokemon.distance}}m ({{pokemon.card_dir}})</td>
-</tr>
+                <tr>
+                    <td><img height='60' width='80' src='static/pixel_icons/{{pokemon.id}}.png' alt="{{pokemon.name}}" /></td>
+                    <td>{{pokemon.time_to_disappear}}</td>
+                    <td>{{pokemon.distance}}m ({{pokemon.card_dir}})</td>
+                    <td><a href='geo:0,0?q={{pokemon.latitude}},{{pokemon.longitude}}({{pokemon.name}})'>Open Map</td>
+                </tr>
 {% endfor %}
-<tr><td></td><td><b>low priority</b></td><td></td></tr>
-</table>
-<a href='geo:0,0?q={{origin_lat}},{{origin_lng}}(origin)'>scan origin</a>
+            </tbody>
+        </table>
+
+        <a href='geo:0,0?q={{origin_lat}},{{origin_lng}}(origin)'>open map @ scan origin</a>
+
+    </body>
+</html>


### PR DESCRIPTION
For a friend with vision issues, this patch will make the mobile page more accessible:

 - pokemon names will have voiceover support
 - columns have headings for clarity
 - "time remaining" is properly pronounce by siri

I also jazzed up the styles for us sighted folks a bit too.

Before:
![2016-07-22 14 22 57](https://cloud.githubusercontent.com/assets/131800/17071741/4cdda9e0-5018-11e6-8313-2fdb42c45302.png)

After:
![2016-07-22 14 22 36](https://cloud.githubusercontent.com/assets/131800/17071743/4e30b85a-5018-11e6-86bb-a805bd244568.png)

_I may have "done wrong" by the CSS setup for this though..._