### PR TITLE
Fixed auth loop (#1025)

### DIFF
--- a/pogom/pgoapi/pgoapi.py
+++ b/pogom/pgoapi/pgoapi.py
@@ -163,13 +163,14 @@ class PGoApi:
         if 'api_url' in response:
             self._api_endpoint = ('https://{}/rpc'.format(response['api_url']))
             self.log.debug('Setting API endpoint to: %s', self._api_endpoint)
-        else:
-            self.log.error('Login failed - unexpected server response!')
-            return False
         
         if 'auth_ticket' in response:
             auth_ticket = response['auth_ticket']
             self._auth_provider.set_ticket([auth_ticket['expire_timestamp_ms'], auth_ticket['start'], auth_ticket['end']])
+
+        else:
+            self.log.error('Login failed - unexpected server response!')
+            return False
         
         self.log.info('Finished RPC login sequence (app simulation)')
         self.log.info('Login process completed') 

--- a/pogom/pgoapi/pgoapi.py
+++ b/pogom/pgoapi/pgoapi.py
@@ -164,7 +164,7 @@ class PGoApi:
             self._api_endpoint = ('https://{}/rpc'.format(response['api_url']))
             self.log.debug('Setting API endpoint to: %s', self._api_endpoint)
         
-        if 'auth_ticket' in response:
+        elif 'auth_ticket' in response:
             auth_ticket = response['auth_ticket']
             self._auth_provider.set_ticket([auth_ticket['expire_timestamp_ms'], auth_ticket['start'], auth_ticket['end']])
 


### PR DESCRIPTION
<!-- Please note, we are no longer accepting pull requests for master branch -->
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Rearranged the auth error reporting order in pgoapi.py

Explanation:
When pgoapi.py received a response that didn't have api_url, it automatically returned False instead of checking if auth_ticket was recieved.  By moving the error message after the auth_ticket check, the loop is fixed.

If this is related to an existing ticket, include a link to it as well.

https://github.com/AHAAAAAAA/PokemonGo-Map/issues/1025
