### PR TITLE
Fixed issue that javascript gives errors because there is no element …

### DIFF
--- a/templates/map.html
+++ b/templates/map.html
@@ -97,6 +97,12 @@
 					<select id="notify-pokemon" multiple="multiple"></select>
 				</label>
 			</div>
+			<div style="margin-top: 25px;">
+				<label for="next-location">
+					<h3>Next Location</h3>
+					<input type="text" id="next-location" style="color: black; background-color: white; border: 1px solid #3b3b3b;"/>
+				</label>
+			</div>
 		</nav>
 
 
@@ -127,7 +133,7 @@
 	</script>
 
 	<script type="text/javascript" src="static/map.js"></script>
-	<script async defer src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&callback=initMap"></script>
+	<script async defer src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&callback=initMap&libraries=places"></script>
 
 	</body>
 </html>


### PR DESCRIPTION
<!-- Please note, we are no longer accepting pull requests for master branch -->
This pull request includes a

- [ x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Fixes the issue where javascript gives errors in method "initSidebar" inside map.js line 126. The missing input for next location is placed inside map.html which teminates the error that element with id "next-location" is missing.

If this is related to an existing ticket, include a link to it as well.

Related to:
https://github.com/AHAAAAAAA/PokemonGo-Map/issues/1310
https://github.com/AHAAAAAAA/PokemonGo-Map/pull/1225

…with id: next-location