### PR TITLE
Fix database lock hang

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -188,7 +188,7 @@ def bulk_upsert(cls, data):
           InsertQuery(cls, rows=data.values()[i:min(i+step, num_rows)]).upsert().execute()
           i+=step
         except:
-            log.debug("Inserting items {} to {}".format(i, min(i+step, num_rows)))
+            log.debug("Failed to insert items {} to {}".format(i, min(i+step, num_rows)))
 
 
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -183,9 +183,12 @@ def bulk_upsert(cls, data):
     step = 120
 
     while i < num_rows:
-        log.debug("Inserting items {} to {}".format(i, min(i+step, num_rows)))
-        InsertQuery(cls, rows=data.values()[i:min(i+step, num_rows)]).upsert().execute()
-        i+=step
+        try:
+          log.debug("Inserting items {} to {}".format(i, min(i+step, num_rows)))
+          InsertQuery(cls, rows=data.values()[i:min(i+step, num_rows)]).upsert().execute()
+          i+=step
+        except:
+            log.debug("Inserting items {} to {}".format(i, min(i+step, num_rows)))
 
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Just added a try/except in the while loop of bulk_upsert.  Tested for a few hours and instances no longer hang/display database lock message. This should now continue to try to insert the row until successful.

## Motivation and Context
Scripts were hanging when running multiple instances at once due to database locks.

## How Has This Been Tested?
Tested for a few hours via 7 simultaneous instances, no lock errors/no script hangups.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- x Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Fixes Issues
#1384  #1319  #1028  #998  #744 