### PR TITLE
Don't hardcode URL root in JS

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -134,7 +134,7 @@ function initSidebar() {
         }
 
         var loc = places[0].geometry.location;
-        $.post("/next_loc?lat=" + loc.lat() + "&lon=" + loc.lng(), {}).done(function (data) {
+        $.post("next_loc?lat=" + loc.lat() + "&lon=" + loc.lng(), {}).done(function (data) {
             $("#next-location").val("");
             map.setCenter(loc);
             marker.setPosition(loc);


### PR DESCRIPTION
The `/next_loc` post request prevents the app from working correctly behind a reverse proxy when the app is not served at the root of the webserver. Making the request relative allows this call to succeed.