### PR TITLE
Center map on Pokemon on notification click

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -575,7 +575,7 @@ function sendNotification(title, text, icon, lat, lng) {
 function changeLocation(lat, lng) {
     var loc = new google.maps.LatLng(lat, lng);
 
-    $.post("/next_loc?lat=" + loc.lat() + "&lon=" + loc.lng(), {}).done(function (data) {
+    $.post("next_loc?lat=" + loc.lat() + "&lon=" + loc.lng(), {}).done(function (data) {
         map.setCenter(loc);
         marker.setPosition(loc);
     });

--- a/static/map.js
+++ b/static/map.js
@@ -134,11 +134,7 @@ function initSidebar() {
         }
 
         var loc = places[0].geometry.location;
-        $.post("/next_loc?lat=" + loc.lat() + "&lon=" + loc.lng(), {}).done(function (data) {
-            $("#next-location").val("");
-            map.setCenter(loc);
-            marker.setPosition(loc);
-        });
+        changeLocation(loc.lat(), loc.lng());
     });
 }
 
@@ -557,7 +553,7 @@ var updateLabelDiffTime = function() {
 
 window.setInterval(updateLabelDiffTime, 1000);
 
-function sendNotification(title, text, icon) {
+function sendNotification(title, text, icon, lat, lng) {
     if (Notification.permission !== "granted") {
         Notification.requestPermission();
     } else {
@@ -568,7 +564,29 @@ function sendNotification(title, text, icon) {
         });
 
         notification.onclick = function () {
-            window.open(window.location.href);
+            window.focus();
+            notification.close();
+
+            centerMap(lat, lng, 20);
         };
+    }
+}
+
+function changeLocation(lat, lng) {
+    var loc = new google.maps.LatLng(lat, lng);
+
+    $.post("/next_loc?lat=" + loc.lat() + "&lon=" + loc.lng(), {}).done(function (data) {
+        map.setCenter(loc);
+        marker.setPosition(loc);
+    });
+}
+
+function centerMap(lat, lng, zoom) {
+    var loc = new google.maps.LatLng(lat, lng);
+
+    map.setCenter(loc);
+
+    if (zoom) {
+        map.setZoom(zoom)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When a notification of a new Pokémon spawn is pressed, you will not be brought to the Pokémon's location instead of being brought back to your previous location on the map. This will make it much easier to locate rare Pokémon when a notification is sent of its spawn.

## Motivation and Context
This will make finding rare Pokémon after being alerted of their spawn much easier. Simply click on the notification and you will immediately be brought to the Pokémon's spawn location.

## How Has This Been Tested?
Tested on Chrome, Firefox, and Safari using OSX Yosemite. The `map.setCenter()` and `map.setZoom()` functions should work in all modern web browsers, so this should not have any compatibility issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

