### PR TITLE
Option to notify with sound via Browser

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -123,6 +123,7 @@ function initSidebar() {
     $('#pokemon-switch').prop('checked', localStorage.showPokemon === 'true');
     $('#pokestops-switch').prop('checked', localStorage.showPokestops === 'true');
     $('#scanned-switch').prop('checked', localStorage.showScanned === 'true');
+    $('#sound-switch').prop('checked', localStorage.playSound === 'true');
 
     var searchBox = new google.maps.places.SearchBox(document.getElementById('next-location'));
 
@@ -254,6 +255,7 @@ map_gyms = {} // Gyms
 map_pokestops = {} // Pokestops
 map_scanned = {} // Pokestops
 var gym_types = ["Uncontested", "Mystic", "Valor", "Instinct"];
+var audio = new Audio('https://github.com/AHAAAAAAA/PokemonGo-Map/raw/develop/static/sounds/ding.mp3');
 
 function setupPokemonMarker(item) {
     var marker = new google.maps.Marker({
@@ -270,6 +272,9 @@ function setupPokemonMarker(item) {
     });
 
     if (notifiedPokemon.indexOf(item.pokemon_id) > -1) {
+        if(localStorage.playSound === 'true'){
+          audio.play();
+        }
         sendNotification('A wild ' + item.pokemon_name + ' appeared!', 'Click to load map', 'static/icons/' + item.pokemon_id + '.png')
     }
 
@@ -516,6 +521,9 @@ $('#pokestops-switch').change(function() {
     }
 });
 
+$('#sound-switch').change(function() {
+    localStorage["playSound"] = this.checked;
+});
 
 $('#scanned-switch').change(function() {
     localStorage["showScanned"] = this.checked;

--- a/templates/map.html
+++ b/templates/map.html
@@ -102,6 +102,16 @@
 					<select id="notify-pokemon" multiple="multiple"></select>
 				</label>
 			</div>
+			<div class="form-control switch-container">
+				<h3>Notify with sound</h3>
+				<div class="onoffswitch">
+					<input id="sound-switch" type="checkbox" name="sound-switch" class="onoffswitch-checkbox" checked/>
+					<label class="onoffswitch-label" for="sound-switch">
+						<span class="switch-label" data-on="On" data-off="Off"></span>
+						<span class="switch-handle"></span>
+					</label>
+				</div>
+			</div>
 			<!-- <button id="trigger-overlay">Test overlay</button> -->
 		</nav>
 


### PR DESCRIPTION
## Description
Adding a switch to play a tone when a "notify Pokemon" appears on the map.
You can see this in the Filter option under original: "Notify of Pokemon"

## Motivation and Context
Notify users via sound for users who are multitasking, or AFK.
https://github.com/AHAAAAAAA/PokemonGo-Map/issues/1417
https://github.com/AHAAAAAAA/PokemonGo-Map/pull/631#event-731855022

## How Has This Been Tested?
Intelligently watch and observe.

## Screenshots (if appropriate):
https://puu.sh/qbpUQ/583939ce53.png

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.