### PR TITLE
Easy Setup: Python installed in folder with space failed

### DIFF
--- a/Easy Setup/setup.bat
+++ b/Easy Setup/setup.bat
@@ -34,10 +34,10 @@ setx PATH "%PATH%;%PATH2%;%PATH2%\Scripts;"
 
 popd
 
-%PATH2%\python get-pip.py
+"%PATH2%\python" get-pip.py
 cd ..
-%PATH2%\Scripts\pip install -r requirements.txt
-%PATH2%\Scripts\pip install -r requirements.txt --upgrade
+"%PATH2%\Scripts\pip" install -r requirements.txt
+"%PATH2%\Scripts\pip" install -r requirements.txt --upgrade
 cd config
 set /p API= Enter your Google API key here:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If Python is installed in a folder with space such as "C:\Program Files\Python27" the Easy Setup will fail.
By adding some quote around command the script work better.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug correction

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran it on my system

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.