### PR TITLE
Added button to use current location

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -125,6 +125,34 @@ function initSidebar() {
     $('#scanned-switch').prop('checked', localStorage.showScanned === 'true');
     $('#sound-switch').prop('checked', localStorage.playSound === 'true');
 
+    var browserLocationButton = $(document.getElementById('browser-location'));
+    var browserLocationButtonDefaultText = browserLocationButton.text();
+    if ("geolocation" in navigator) {
+      browserLocationButton.on('click', function(event) {
+        event.preventDefault();
+        browserLocationButton.attr('disabled', 'disabled');
+        browserLocationButton.text('Fetching your location ...');
+        navigator.geolocation.getCurrentPosition(function(position) {
+          browserLocationButton.text('Found location! Moving map ...');
+          var loc = {
+            "lat": position.coords.latitude,
+            "lng": position.coords.longitude
+          }
+
+          $.post("next_loc?lat=" + loc.lat + "&lon=" + loc.lng, {}).done(function (data) {
+            $("#next-location").val("");
+            map.setCenter(loc);
+            marker.setPosition(loc);
+            browserLocationButton.removeAttr('disabled');
+            browserLocationButton.text(browserLocationButtonDefaultText);
+          });
+        });
+      });
+    } else {
+      browserLocationButton.attr('disabled', 'disabled');
+      browserLocationButton.attr('title', 'You cannot use geolocation, since your browser does not support this.');
+    }
+
     var searchBox = new google.maps.places.SearchBox(document.getElementById('next-location'));
 
     searchBox.addListener('places_changed', function() {

--- a/templates/map.html
+++ b/templates/map.html
@@ -50,7 +50,14 @@
 					<input id="next-location" type="text" name="next-location" placeholder="Change your location" />
 				</label>
 			</div>
-			<div class="form-control switch-container">
+			<div class="form-control">
+				<label for="browser-location">
+					<h3>Detect location</h3>
+					<button id="browser-location" name="browser-location" placeholder="Change your location">Use current location</button>
+				</label>
+			</div>
+
+            <div class="form-control switch-container">
 				<h3>Pokémon</h3>
 				<div class="onoffswitch">
 					<input id="pokemon-switch" type="checkbox" name="pokemon-switch" class="onoffswitch-checkbox" checked/>


### PR DESCRIPTION
It would be great to move the map to the current location of the browser.

## Description
It adds a button to use HTML5 geoapi to retrieve current location and sets the current marker to the position of this map.

## Motivation and Context
It makes it easier to move the map center to the place where you are right now.

## How Has This Been Tested?
Clicked that button with geo activated and the map moved to the right place. If detection is not available a message is shown, as soon as one hovers the button.

## Screenshots (if appropriate):

Before in action:
<img width="288" alt="bildschirmfoto 2016-07-23 um 11 38 02" src="https://cloud.githubusercontent.com/assets/35926/17077269/ff3d505c-50c9-11e6-9a85-af6b34db5e7d.png">

While working:
<img width="287" alt="bildschirmfoto 2016-07-23 um 11 38 06" src="https://cloud.githubusercontent.com/assets/35926/17077270/07fa37fa-50ca-11e6-9413-33f519ce2924.png">


## Types of changes
- [x] New feature: Add "Use current location"-Button

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation: No?!
- [x] I have updated the documentation accordingly: No!

