### PR TITLE
Added auto-open PokeInfo toggle and PokeInfo close button

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -270,7 +270,8 @@ function setupPokemonMarker(item) {
     });
 
     marker.infoWindow = new google.maps.InfoWindow({
-        content: pokemonLabel(item.pokemon_name, item.disappear_time, item.pokemon_id, item.latitude, item.longitude)
+        content: pokemonLabel(item.pokemon_name, item.disappear_time, item.pokemon_id, item.latitude, item.longitude),
+        disableAutoPan: true
     });
 
     if (notifiedPokemon.indexOf(item.pokemon_id) > -1) {
@@ -314,8 +315,7 @@ function setupPokestopMarker(item) {
     });
 
     marker.infoWindow = new google.maps.InfoWindow({
-        content: pokestopLabel(!!item.lure_expiration, item.last_modified, item.active_pokemon_id, item.latitude, item.longitude),
-        disableAutoPan: true
+        content: pokestopLabel(!!item.lure_expiration, item.last_modified, item.active_pokemon_id, item.latitude, item.longitude)
     });
 
     addListeners(marker);

--- a/static/map.js
+++ b/static/map.js
@@ -314,7 +314,8 @@ function setupPokestopMarker(item) {
     });
 
     marker.infoWindow = new google.maps.InfoWindow({
-        content: pokestopLabel(!!item.lure_expiration, item.last_modified, item.active_pokemon_id, item.latitude, item.longitude)
+        content: pokestopLabel(!!item.lure_expiration, item.last_modified, item.active_pokemon_id, item.latitude, item.longitude),
+        disableAutoPan: true
     });
 
     addListeners(marker);

--- a/static/map.js
+++ b/static/map.js
@@ -124,6 +124,8 @@ function initSidebar() {
     $('#pokestops-switch').prop('checked', localStorage.showPokestops === 'true');
     $('#scanned-switch').prop('checked', localStorage.showScanned === 'true');
     $('#sound-switch').prop('checked', localStorage.playSound === 'true');
+    $('#aepi-switch').prop('checked', localStorage.autoExpandPI === 'true');
+    
 
     var searchBox = new google.maps.places.SearchBox(document.getElementById('next-location'));
 
@@ -411,6 +413,7 @@ function updateMap() {
     localStorage.showGyms = localStorage.showGyms || true;
     localStorage.showPokestops = localStorage.showPokestops || false;
     localStorage.showScanned = localStorage.showScanned || false;
+    localStorage.autoExpandPI = localStorage.autoExpandPI || false;
 
     $.ajax({
         url: "raw_data",
@@ -433,7 +436,10 @@ function updateMap() {
               if (item.marker) item.marker.setMap(null);
               item.marker = setupPokemonMarker(item);
               map_pokemons[item.encounter_id] = item;
-          }
+              if(localStorage["autoExpandPI"]==='true') {
+                  item.marker.infoWindow.open(map, item.marker);
+              }
+          } 
         });
 
         $.each(result.pokestops, function(i, item) {
@@ -500,8 +506,8 @@ document.getElementById('gyms-switch').onclick = function() {
     if (this.checked) {
         updateMap();
     } else {
-        $.each(map_gyms, function(key, value) {
-            map_gyms[key].marker.setMap(null);
+        $.each(map_gyms, function(key, item) {
+            item.marker.setMap(null);
         });
         map_gyms = {}
     }
@@ -512,8 +518,8 @@ $('#pokemon-switch').change(function() {
     if (this.checked) {
         updateMap();
     } else {
-        $.each(map_pokemons, function(key, value) {
-            map_pokemons[key].marker.setMap(null);
+        $.each(map_pokemons, function(key, item) {
+            item.marker.setMap(null);
         });
         map_pokemons = {}
     }
@@ -524,8 +530,8 @@ $('#pokestops-switch').change(function() {
     if (this.checked) {
         updateMap();
     } else {
-        $.each(map_pokestops, function(key, value) {
-            map_pokestops[key].marker.setMap(null);
+        $.each(map_pokestops, function(key, item) {
+            item.marker.setMap(null);
         });
         map_pokestops = {}
     }
@@ -534,18 +540,26 @@ $('#pokestops-switch').change(function() {
 $('#sound-switch').change(function() {
     localStorage["playSound"] = this.checked;
 });
+$('#aepi-switch').change(function() {
+    localStorage["autoExpandPI"] = this.checked;
+});
 
 $('#scanned-switch').change(function() {
     localStorage["showScanned"] = this.checked;
     if (this.checked) {
         updateMap();
     } else {
-        $.each(map_scanned, function(key, value) {
-            map_scanned[key].marker.setMap(null);
+        $.each(map_scanned, function(key, item) {
+            item.marker.setMap(null);
         });
         map_scanned = {}
     }
 });
+$("#close-pi").click(function () {
+    $.each(map_pokemons, function(key, item) {
+        item.marker.infoWindow.close();
+    });
+})
 
 var updateLabelDiffTime = function() {
     $('.label-countdown').each(function(index, element) {

--- a/templates/map.html
+++ b/templates/map.html
@@ -113,6 +113,17 @@
 					</label>
 				</div>
 			</div>
+			<div class="form-control switch-container">
+				<h3>Auto expand PokeInfo</h3>
+				<div class="onoffswitch">
+					<input id="aepi-switch" type="checkbox" name="aepi-switch" class="onoffswitch-checkbox"/>
+					<label class="onoffswitch-label" for="aepi-switch">
+						<span class="switch-label" data-on="On" data-off="Off"></span>
+						<span class="switch-handle"></span>
+					</label>
+				</div>
+			</div>
+			<button id="close-pi">Close all PokeInfo</button>
 			<!-- <button id="trigger-overlay">Test overlay</button> -->
 		</nav>
 


### PR DESCRIPTION
## Description
Added switch-toggle to enable/disable Pokemon's InfoWindow auto-opening whenever new Pokemon is inserted onto map.
Also I've added button to close all Pokemon InfoWindows - it might be helpful.
Lastly, I've disabled auto-panning to newly open InfoWindows.

## Motivation and Context
Toggle is helpful if you're too lazy to open/hover PokeInfo. Button is helpful whenever you've too much of them open. AutoPanning has been disabled so map doesn't jump around whenever marker is hovered by accident, or new PokeInfo windows is opened automatically.

## How Has This Been Tested?
Windows7 - Firefox 49.0a2, Firefox 47, Chrome 54, Chrome 51
Windows7 64bit - Firefox 49.0a2
Android 4.4 - Stock, Chrome, Firefox
Android 4.2 - Stock, Chrome, Firefox
Ubuntu - Firefox 47, Chrome 54
Windows10 - Firefox 49.0a2, Chrome 54
Windows Phone  - Stock

## Screenshots (if appropriate):
http://i.imgur.com/DD4ACkh.png

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

