### PR TITLE
Add current location indicator to the map, Fixes removal of PR #570

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -55,7 +55,8 @@ $selectNotify.on("change", function (e) {
     localStorage.remember_select_notify = JSON.stringify(notifiedPokemon);
 });
 
-var map;
+var map,
+    locationMarker;
 
 var light2Style=[{"elementType":"geometry","stylers":[{"hue":"#ff4400"},{"saturation":-68},{"lightness":-4},{"gamma":0.72}]},{"featureType":"road","elementType":"labels.icon"},{"featureType":"landscape.man_made","elementType":"geometry","stylers":[{"hue":"#0077ff"},{"gamma":3.1}]},{"featureType":"water","stylers":[{"hue":"#00ccff"},{"gamma":0.44},{"saturation":-33}]},{"featureType":"poi.park","stylers":[{"hue":"#44ff00"},{"saturation":-23}]},{"featureType":"water","elementType":"labels.text.fill","stylers":[{"hue":"#007fff"},{"gamma":0.77},{"saturation":65},{"lightness":99}]},{"featureType":"water","elementType":"labels.text.stroke","stylers":[{"gamma":0.11},{"weight":5.6},{"saturation":99},{"hue":"#0091ff"},{"lightness":-86}]},{"featureType":"transit.line","elementType":"geometry","stylers":[{"lightness":-48},{"hue":"#ff5e00"},{"gamma":1.2},{"saturation":-23}]},{"featureType":"transit","elementType":"labels.text.stroke","stylers":[{"saturation":-64},{"hue":"#ff9100"},{"lightness":16},{"gamma":0.47},{"weight":2.7}]}];
 var darkStyle=[{"featureType":"all","elementType":"labels.text.fill","stylers":[{"saturation":36},{"color":"#b39964"},{"lightness":40}]},{"featureType":"all","elementType":"labels.text.stroke","stylers":[{"visibility":"on"},{"color":"#000000"},{"lightness":16}]},{"featureType":"all","elementType":"labels.icon","stylers":[{"visibility":"off"}]},{"featureType":"administrative","elementType":"geometry.fill","stylers":[{"color":"#000000"},{"lightness":20}]},{"featureType":"administrative","elementType":"geometry.stroke","stylers":[{"color":"#000000"},{"lightness":17},{"weight":1.2}]},{"featureType":"landscape","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":20}]},{"featureType":"poi","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":21}]},{"featureType":"road.highway","elementType":"geometry.fill","stylers":[{"color":"#000000"},{"lightness":17}]},{"featureType":"road.highway","elementType":"geometry.stroke","stylers":[{"color":"#000000"},{"lightness":29},{"weight":0.2}]},{"featureType":"road.arterial","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":18}]},{"featureType":"road.local","elementType":"geometry","stylers":[{"color":"#181818"},{"lightness":16}]},{"featureType":"transit","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":19}]},{"featureType":"water","elementType":"geometry","stylers":[{"lightness":17},{"color":"#525252"}]}];
@@ -115,6 +116,7 @@ function initMap() {
         animation: google.maps.Animation.DROP
     });
 
+    addMyLocationButton();
     initSidebar();
 };
 
@@ -589,4 +591,87 @@ function sendNotification(title, text, icon) {
             window.open(window.location.href);
         };
     }
+}
+
+myLocationButton = function (map, marker) {
+    var locationContainer = document.createElement('div');
+
+    var locationButton = document.createElement('button');
+    locationButton.style.backgroundColor = '#fff';
+    locationButton.style.border = 'none';
+    locationButton.style.outline = 'none';
+    locationButton.style.width = '28px';
+    locationButton.style.height = '28px';
+    locationButton.style.borderRadius = '2px';
+    locationButton.style.boxShadow = '0 1px 4px rgba(0,0,0,0.3)';
+    locationButton.style.cursor = 'pointer';
+    locationButton.style.marginRight = '10px';
+    locationButton.style.padding = '0px';
+    locationButton.title = 'Your Location';
+    locationContainer.appendChild(locationButton);
+
+    var locationIcon = document.createElement('div');
+    locationIcon.style.margin = '5px';
+    locationIcon.style.width = '18px';
+    locationIcon.style.height = '18px';
+    locationIcon.style.backgroundImage = 'url(static/mylocation-sprite-1x.png)';
+    locationIcon.style.backgroundSize = '180px 18px';
+    locationIcon.style.backgroundPosition = '0px 0px';
+    locationIcon.style.backgroundRepeat = 'no-repeat';
+    locationIcon.id = 'current-location';
+    locationButton.appendChild(locationIcon);
+
+    locationButton.addEventListener('click', function() {
+        var currentLocation = document.getElementById('current-location');
+        var imgX = '0';
+        var animationInterval = setInterval(function(){
+            if(imgX == '-18') imgX = '0';
+            else imgX = '-18';
+            currentLocation.style.backgroundPosition = imgX+'px 0';
+        }, 500);
+        if(navigator.geolocation) {
+            navigator.geolocation.getCurrentPosition(function(position) {
+                var latlng = new google.maps.LatLng(position.coords.latitude, position.coords.longitude);
+                locationMarker.setVisible(true);
+                locationMarker.setOptions({'opacity': 1});
+                locationMarker.setPosition(latlng);
+                map.setCenter(latlng);
+                clearInterval(animationInterval);
+                currentLocation.style.backgroundPosition = '-144px 0px';
+            });
+        }
+        else{
+            clearInterval(animationInterval);
+            currentLocation.style.backgroundPosition = '0px 0px';
+        }
+    });
+
+    locationContainer.index = 1;
+    map.controls[google.maps.ControlPosition.RIGHT_BOTTOM].push(locationContainer);
+}
+
+addMyLocationButton = function () {
+    locationMarker = new google.maps.Marker({
+        map: map,
+        animation: google.maps.Animation.DROP,
+        position: {lat: center_lat, lng: center_lng},
+        icon: {
+            path: google.maps.SymbolPath.CIRCLE,
+            fillOpacity: 1,
+            fillColor: '#1c8af6',
+            scale: 6,
+            strokeColor: '#1c8af6',
+            strokeWeight: 8,
+            strokeOpacity: 0.3
+        }
+    });
+    locationMarker.setVisible(false);
+
+    myLocationButton(map, locationMarker);
+
+    google.maps.event.addListener(map, 'dragend', function() {
+        var currentLocation = document.getElementById('current-location');
+        currentLocation.style.backgroundPosition = '0px 0px';
+        locationMarker.setOptions({'opacity': 0.5});
+    });
 }


### PR DESCRIPTION
## Description
Add current location indicator via google map custom controls.

This was already merged in #570 but got removed afterwards by mistake.

## Motivation and Context
Sometimes it's quite hard to figure out the own current position on the map. This PR adds a new button to the map controls in the bottom right. 

Clicking the button will get the users current location and add the location indicator to the map. If the map is dragged the marker gets slightly transparent (because the current location might have changed in the meantime). Clicking the button again will get the new location and update the location indicator accordingly.

## How Has This Been Tested?
Keep in mind that geolocation needs HTTPS to work in Chrome 50+. Tested in Safari and Mobile Safari.

## Screenshots (if appropriate):

![juli-23-2016 12-14-59](https://cloud.githubusercontent.com/assets/1174951/17077375/31ed8cb0-50cf-11e6-9211-735af490ea58.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.

