### PR TITLE
Consecutive failures in map download should increase wait time 

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -124,6 +124,10 @@ def search_thread(args):
                 sem.release()
         else:
             log.info('Map Download failed. Trying again.')
+            failed_consecutive += 1
+            if (failed_consecutive > 5):
+                raise Exception('Too many empty responses')
+            time.sleep(config['REQ_SLEEP'] * (failed_consecutive))
 
     time.sleep(config['REQ_SLEEP'])
 


### PR DESCRIPTION
Consecutive failures in map download should increase wait time to prevent getting locked out by server's overload/spam filter.

When left long-running with multiple accounts, we might end up with empty/no responses from server possibly because it is being overloaded or maybe some spam filter is taking effect. If we wait endlessly only time.sleep(config['REQ_SLEEP'], we may always hit the window of the overload/spam and successive requests will fail endlessly.

## Description
Implemented gradual increase in the wait to defeat possible spam/overload threshold. If failing even after large wait, throw and force a new login.

## Motivation and Context
Reproduced multiple times that running with multiple accounts can end up with all requests failing after some time (30 mins+), always ending up in 'Map Download failed'.

## How Has This Been Tested?
Left running for 10 hours straight and now still getting valid responses

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Note: Feel free to adjust the number of retries, possibly make a setting out of tit.