### PR TITLE
Add google analytics support

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -26,7 +26,8 @@ class Pogom(Flask):
                                lat=config['ORIGINAL_LATITUDE'],
                                lng=config['ORIGINAL_LONGITUDE'],
                                gmaps_key=config['GMAPS_KEY'],
-                               lang=config['LOCALE'])
+                               lang=config['LOCALE'],
+                               ga_code=config['GA_CODE'])
 
     def raw_data(self):
         d = {}

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -57,6 +57,7 @@ def get_args():
     parser.add_argument('-C', '--cors', help='Enable CORS on web server', action='store_true', default=False)
     parser.add_argument('-D', '--db', help='Database filename', default='pogom.db')
     parser.add_argument('-t', '--threads', help='Number of search threads', required=False, type=int, default=5, dest='num_threads')
+    parser.add_argument('-ga', '--googleanalytics', help='The google analytics code', required=False, default='', type=str)
     parser.set_defaults(DEBUG=False)
     args = parser.parse_args()
 

--- a/runserver.py
+++ b/runserver.py
@@ -58,6 +58,7 @@ if __name__ == '__main__':
     config['ORIGINAL_LONGITUDE'] = position[1]
     config['LOCALE'] = args.locale
     config['CHINA'] = args.china
+    config['GA_CODE'] = args.googleanalytics
 
     if not args.mock:
         start_locator_thread(args)

--- a/templates/map.html
+++ b/templates/map.html
@@ -32,6 +32,17 @@
 
 		<link rel="stylesheet" href="static/dist/css/app.min.css" />
 		<script src="static/js/vendor/modernizr.custom.js"></script>
+    {% if  ga_code|length > 0 %}
+      <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+        ga('create', '{{ ga_code }}', 'auto');
+        ga('send', 'pageview');
+      </script>
+    {% endif %}
 	</head>
 	<body id="top">
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adds Support for Google Analytics. Turns GA on if a GA code is provided by use of `-ga the-key`

## Description
<!--- Describe your changes in detail -->

- Adds another command line parameter `-ga`  to backend
- Adds the GA snippet to the map.html template but only renders it into the page if a code is provided

## Motivation and Context
As a admin of a public platform using PokemonGO-Map, I want to be able to track user behavior of my page

## How Has This Been Tested?
- Running it with and without code provided
- Running it in production for my own fork

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
