### PR TITLE
Fix multiple password request from console

### DIFF
--- a/pogom/__init__.py
+++ b/pogom/__init__.py
@@ -10,5 +10,6 @@ config = {
     'GMAPS_KEY': None,
     'REQ_SLEEP': 1,
     'REQ_HEAVY_SLEEP': 30,
-    'REQ_MAX_FAILED': 5
+    'REQ_MAX_FAILED': 5,
+    'PASSWORD': None
 }

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -104,8 +104,10 @@ def get_args():
             print sys.argv[0] + ': error: arguments -u/--username, -l/--location, -st/--step-limit are required'
             sys.exit(1);
 
-        if args.password is None:
-            args.password = getpass.getpass()
+        if config["PASSWORD"] is None and args.password is None:
+            config["PASSWORD"] = args.password = getpass.getpass()
+        elif args.password is None:
+            args.password = config["PASSWORD"]
 
 
     return args


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix request for multiple passwords when -p argument is left out

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently a password is requested three times in a row due to get_args being called three times and the password not being stored anywhere

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally for google login

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
