### PR TITLE
handle OperationalError db lock exception, add pragma busy_timeout 30000

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -3,7 +3,8 @@
 
 import logging
 from peewee import Model, SqliteDatabase, InsertQuery, IntegerField,\
-                   CharField, FloatField, BooleanField, DateTimeField
+                   CharField, FloatField, BooleanField, DateTimeField,\
+                   OperationalError
 from datetime import datetime
 from datetime import timedelta
 from base64 import b64encode
@@ -13,7 +14,9 @@ from .transform import transform_from_wgs_to_gcj
 from .customLog import printPokemon
 
 args = get_args()
-db = SqliteDatabase(args.db)
+db = SqliteDatabase(args.db, pragmas=(
+    ('busy_timeout', '30000'),
+))
 log = logging.getLogger(__name__)
 
 
@@ -183,10 +186,15 @@ def bulk_upsert(cls, data):
     step = 120
 
     while i < num_rows:
-        log.debug("Inserting items {} to {}".format(i, min(i+step, num_rows)))
-        InsertQuery(cls, rows=data.values()[i:min(i+step, num_rows)]).upsert().execute()
+        while True:
+            try:
+                log.debug("Inserting items {} to {}".format(i, min(i+step, num_rows)))
+                InsertQuery(cls, rows=data.values()[i:min(i+step, num_rows)]).upsert().execute()
+                break
+            except OperationalError as e:
+                print('{}... Trying again!'.format(str(e)))
+                time.sleep(1)
         i+=step
-
 
 
 def create_tables():


### PR DESCRIPTION
This deals with the OperationalError exception that is raised when the db locks and then it keeps trying to insert that data so we don't lose it on the way. Also adds pragma busy_timeout 30000 to sqlite. 

I still get some locks eventually but at least it retries. Apparently people on Windows are having a harder time with this.

Try running a version of sqlite3 >= 3.7.15 for pragma busy_timeout.

I'm having trouble understanding the deal of concurrency with sqlite, so if you're good with this please come to save. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] My code does not follow PEP8.