### PR TITLE
Cleanup map.js

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -1,4 +1,4 @@
-document.addEventListener("DOMContentLoaded", function () {
+$(function () {
     if (!Notification) {
         console.log('could not load notifications');
         return;

--- a/static/map.js
+++ b/static/map.js
@@ -512,7 +512,7 @@ function updateMap() {
 window.setInterval(updateMap, 5000);
 updateMap();
 
-document.getElementById('gyms-switch').onclick = function() {
+$('#gyms-switch').change(function() {
     localStorage["showGyms"] = this.checked;
     if (this.checked) {
         updateMap();
@@ -522,7 +522,7 @@ document.getElementById('gyms-switch').onclick = function() {
         });
         map_gyms = {}
     }
-};
+});
 
 $('#pokemon-switch').change(function() {
     localStorage["showPokemon"] = this.checked;


### PR DESCRIPTION
 - Use jquery instead of direct JS in a few places
 - Move vars/functions/onload code into distinct sections
 - Standardized on `function name(params)` style*
 - Ensure that all functions which bind, manipulate, etc are inside a proper domcontentloaded so they can't race condition and throw errors

\* I have no prefernce on this format vs others, it was just the most common, so I went with it
