### PR TITLE
Add ability to get raw Pokémon filtered by id

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -31,7 +31,11 @@ class Pogom(Flask):
     def raw_data(self):
         d = {}
         if request.args.get('pokemon', 'true') == 'true':
-            d['pokemons'] = Pokemon.get_active()
+            if request.args.get('ids'):
+                ids = [int(x) for x in request.args.get('ids').split(',')]
+                d['pokemons'] = Pokemon.get_active_by_id(ids)
+            else:
+                d['pokemons'] = Pokemon.get_active()
 
         if request.args.get('pokestops', 'false') == 'true':
             d['pokestops'] = Pokestop.get_all()

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -55,6 +55,21 @@ class Pokemon(BaseModel):
 
         return pokemons
 
+    @classmethod
+    def get_active_by_id(cls, ids):
+        query = (Pokemon
+                 .select()
+                 .where((Pokemon.pokemon_id << ids) &
+                        (Pokemon.disappear_time > datetime.utcnow()))
+                 .dicts())
+
+        pokemons = []
+        for p in query:
+            p['pokemon_name'] = get_pokemon_name(p['pokemon_id'])
+            pokemons.append(p)
+
+        return pokemons
+
 
 class Pokestop(BaseModel):
     pokestop_id = CharField(primary_key=True)


### PR DESCRIPTION
Added a parameter for filtering specific Pokémon.

## Description
Added a paramter to the `/raw_data` endpoint for requesting only selected and active Pokémon by their id. Just add a parameter with comma separated values to the request like this: `http://localhost:5000/raw_data?gyms=false&scanned=false&ids=13,16` and the server will only respond with active pidgeys and weedles.

## Motivation and Context
Using the raw data as an endpoint for further development for example as input to a mobile application, we need some way to filter on the server side. Especially regarding mobile data usage.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)