### PR TITLE
Add switch to hide pokemon

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -138,6 +138,7 @@ function initSidebar() {
     $('#pokemon-switch').prop('checked', localStorage.showPokemon === 'true');
     $('#pokestops-switch').prop('checked', localStorage.showPokestops === 'true');
     $('#scanned-switch').prop('checked', localStorage.showScanned === 'true');
+    $('#hide-switch').prop('checked', localStorage.hidePokemon === 'true');
     $('#sound-switch').prop('checked', localStorage.playSound === 'true');
 
     var searchBox = new google.maps.places.SearchBox(document.getElementById('next-location'));
@@ -407,7 +408,8 @@ function clearStaleMarkers() {
     $.each(map_pokemons, function(key, value) {
 
         if (map_pokemons[key]['disappear_time'] < new Date().getTime() ||
-                excludedPokemon.indexOf(map_pokemons[key]['pokemon_id']) >= 0) {
+                (localStorage.hidePokemon === 'true' &&
+                excludedPokemon.indexOf(map_pokemons[key]['pokemon_id']) >= 0)) {
             map_pokemons[key].marker.setMap(null);
             delete map_pokemons[key];
         }
@@ -428,6 +430,7 @@ function updateMap() {
     localStorage.showGyms = localStorage.showGyms || true;
     localStorage.showPokestops = localStorage.showPokestops || false;
     localStorage.showScanned = localStorage.showScanned || false;
+    localStorage.hidePokemon = localStorage.hidePokemon || true;
 
     $.ajax({
         url: "raw_data",
@@ -445,7 +448,9 @@ function updateMap() {
               return false; // in case the checkbox was unchecked in the meantime.
           }
           if (!(item.encounter_id in map_pokemons) &&
-                    excludedPokemon.indexOf(item.pokemon_id) < 0) {
+                    ((localStorage.hidePokemon === 'true' &&
+                    excludedPokemon.indexOf(item.pokemon_id) < 0) ||
+                    localStorage.hidePokemon === 'false')) {
               // add marker to map and item to dict
               if (item.marker) item.marker.setMap(null);
               item.marker = setupPokemonMarker(item);
@@ -550,6 +555,11 @@ $('#pokestops-switch').change(function() {
 
 $('#sound-switch').change(function() {
     localStorage["playSound"] = this.checked;
+});
+
+$('#hide-switch').change(function () {
+    localStorage["hidePokemon"] = this.checked;
+    updateMap();
 });
 
 $('#scanned-switch').change(function() {

--- a/templates/map.html
+++ b/templates/map.html
@@ -91,11 +91,18 @@
 					</label>
 				</div>
 			</div>
-			<div class="form-control">
-				<label for="exclude-pokemon">
-					<h3>Hide common Pokémon</h3>
-      		<select id="exclude-pokemon" multiple="multiple"></select>
-    		</label>
+			<div class="form-control switch-container">
+				<h3>Hide Pokémon</h3>
+                <div class="onoffswitch">
+					<input id="hide-switch" type="checkbox" name="hide-switch" class="onoffswitch-checkbox"/>
+					<label class="onoffswitch-label" for="hide-switch">
+						<span class="switch-label" data-on="On" data-off="Off"></span>
+						<span class="switch-handle"></span>
+					</label>
+				</div>
+                <label for="exclude-pokemon">
+      		        <select id="exclude-pokemon" multiple="multiple"></select>
+    		    </label>
 			</div>
 			<div class="form-control">
 				<label for="notify-pokemon">


### PR DESCRIPTION
## Description
Added a toggle to disable Pokemon filter.

## Motivation and Context
Suggested in #1539 
Convenient because there's no need to delete all the filters if you want to quickly check out what pokemon are around you.

## How Has This Been Tested?
Tested on Chrome, IE and ios

## Screenshots (if appropriate):
![2016-07-23_203615](https://cloud.githubusercontent.com/assets/20599458/17079351/0c214dea-5116-11e6-90e1-af7526057530.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## PS:
Sorry if I screwed up somewhere, I promie I'll learn.