### PR TITLE
Center map on Pokemon on notification click

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -116,11 +116,7 @@ function initSidebar() {
         }
 
         var loc = places[0].geometry.location;
-        $.post("next_loc?lat=" + loc.lat() + "&lon=" + loc.lng(), {}).done(function (data) {
-            $("#next-location").val("");
-            map.setCenter(loc);
-            marker.setPosition(loc);
-        });
+        changeLocation(loc.lat(), loc.lng());
     });
 }
 
@@ -246,10 +242,11 @@ function setupPokemonMarker(item) {
     });
 
     if (notifiedPokemon.indexOf(item.pokemon_id) > -1) {
-        if(localStorage.playSound === 'true'){
+        if (localStorage.playSound === 'true') {
           audio.play();
         }
-        sendNotification('A wild ' + item.pokemon_name + ' appeared!', 'Click to load map', 'static/icons/' + item.pokemon_id + '.png')
+        
+        sendNotification('A wild ' + item.pokemon_name + ' appeared!', 'Click to load map', 'static/icons/' + item.pokemon_id + '.png', item.latitude, item.longitude);
     }
 
     addListeners(marker);
@@ -492,7 +489,7 @@ function updateLabelDiffTime() {
     });
 };
 
-function sendNotification(title, text, icon) {
+function sendNotification(title, text, icon, lat, lng) {
     if (Notification.permission !== "granted") {
         Notification.requestPermission();
     } else {
@@ -503,7 +500,10 @@ function sendNotification(title, text, icon) {
         });
 
         notification.onclick = function () {
-            window.open(window.location.href);
+            window.focus();
+            notification.close();
+
+            centerMap(lat, lng, 20);
         };
     }
 }
@@ -589,6 +589,25 @@ function addMyLocationButton() {
         currentLocation.style.backgroundPosition = '0px 0px';
         locationMarker.setOptions({'opacity': 0.5});
     });
+}
+
+function changeLocation(lat, lng) {
+    var loc = new google.maps.LatLng(lat, lng);
+
+    $.post("next_loc?lat=" + loc.lat() + "&lon=" + loc.lng(), {}).done(function (data) {
+        map.setCenter(loc);
+        marker.setPosition(loc);
+    });
+}
+
+function centerMap(lat, lng, zoom) {
+    var loc = new google.maps.LatLng(lat, lng);
+
+    map.setCenter(loc);
+
+    if (zoom) {
+        map.setZoom(zoom)
+    }
 }
 
 //


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When a notification of a new Pokémon spawn is pressed, you will not be brought to the Pokémon's location instead of being brought back to your previous location on the map. This will make it much easier to locate rare Pokémon when a notification is sent of its spawn.

## Motivation and Context
This will make finding rare Pokémon after being alerted of their spawn much easier. Simply click on the notification and you will immediately be brought to the Pokémon's spawn location.

## How Has This Been Tested?
Tested on Chrome, Firefox, and Safari using OSX Yosemite, as well as Linux. The `map.setCenter()` and `map.setZoom()` functions should work in all modern web browsers, so this should not have any compatibility issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

This is a copy of #1459 to work on the newest develop branch.