### PR TITLE
move client config to client

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -15,18 +15,22 @@ class Pogom(Flask):
     def __init__(self, import_name, **kwargs):
         super(Pogom, self).__init__(import_name, **kwargs)
         self.json_encoder = CustomJSONEncoder
-        self.route("/", methods=['GET'])(self.fullmap)
         self.route("/raw_data", methods=['GET'])(self.raw_data)
         self.route("/loc", methods=['GET'])(self.loc)
         self.route("/next_loc", methods=['POST'])(self.next_loc)
         self.route("/mobile", methods=['GET'])(self.list_pokemon)
+        self.route("/config.js", methods=['GET'])(self.configjs)
+        self.route("/", methods=['GET'])(self.fullmap)
 
-    def fullmap(self):
-        return render_template('map.html',
+    def configjs(self):
+        return render_template('config.js',
                                lat=config['ORIGINAL_LATITUDE'],
                                lng=config['ORIGINAL_LONGITUDE'],
                                gmaps_key=config['GMAPS_KEY'],
                                lang=config['LOCALE'])
+
+    def fullmap(self):
+        return self.send_static_file('index.html')
 
     def raw_data(self):
         d = {}

--- a/static/index.html
+++ b/static/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html lang="{{lang}}">
+<html>
 	<head>
 		<title>Pokémon Go Map</title>
 		<meta charset="utf-8" />
@@ -136,13 +136,15 @@
 	<script type="text/javascript" src="static/js/vendor/classie.js"></script>
 	<!-- <script type="text/javascript" src="static/js/vendor/svg-overlay.js"></script> -->
 
-	<script type="text/javascript">
-		var center_lat = {{lat}};
-		var center_lng = {{lng}};
+	<script type="text/javascript" src="config.js"></script>
+
+	<script>
+		var script = document.createElement('script');
+		script.src = 'https://maps.googleapis.com/maps/api/js?key=' + CONFIG.gmaps_key + '&callback=initMap&libraries=places';
+		script.async = true;
+		script.defer = true;
+		document.getElementsByTagName('body')[0].appendChild(script);
 	</script>
-
-
-	<script async defer src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&callback=initMap&libraries=places"></script>
 	<script type="text/javascript" src="static/map.js"></script>
 	</body>
 </html>

--- a/static/map.js
+++ b/static/map.js
@@ -63,7 +63,7 @@ var pGoStyle=[{"featureType":"landscape.man_made","elementType":"geometry.fill",
 
 var selectedStyle = 'light';
 
-function initMap() {
+function initMapHelper(center_lat, center_lng) {
 
 
     map = new google.maps.Map(document.getElementById('map'), {
@@ -116,7 +116,12 @@ function initMap() {
     });
 
     initSidebar();
+    updateMap();
 };
+
+function initMap() {
+  initMapHelper(CONFIG.latitude, CONFIG.longitude);
+}
 
 function initSidebar() {
     $('#gyms-switch').prop('checked', localStorage.showGyms === 'true');
@@ -483,7 +488,6 @@ function updateMap() {
 };
 
 window.setInterval(updateMap, 5000);
-updateMap();
 
 document.getElementById('gyms-switch').onclick = function() {
     localStorage["showGyms"] = this.checked;

--- a/templates/config.js
+++ b/templates/config.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// CHANGE ME
+window.CONFIG = {
+  latitude: {{lat}}
+, longitude: {{lat}}
+, gmaps_key: '{{ gmaps_key }}'
+};
+
+// Auto-detect language to use
+window.document.documentElement.lang = '{{lang}}';
+[ 'de', 'en', 'fr', 'pt_br', 'ru', 'zh_cn', 'zh_hk' ].some(function (lang) {
+  if (window.navigator.language.match(lang)) {
+    window.document.documentElement.lang = 'en';
+    return true;
+  }
+});


### PR DESCRIPTION
In relation to https://github.com/AHAAAAAAA/PokemonGo-Map/pull/1532 and https://github.com/AHAAAAAAA/PokemonGo-Map/pull/1561

Here's a small set of changes, without removing code, that allows the client to be developed independently of the server.

The client config variables are moved to config.js, which can are still be templated by the python server, but can just as easily be used with any other server as a static file with no code changes.

I'd like to be able to continue to develop this web client and track its changes (as would others) and this is a good first step.