### PR TITLE
Added option to hide search bar

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -6,6 +6,7 @@ from flask import Flask, jsonify, render_template, request
 from flask.json import JSONEncoder
 from datetime import datetime
 from s2sphere import *
+from pogom.utils import get_args
 
 from . import config
 from .models import Pokemon, Gym, Pokestop, ScannedLocation
@@ -22,11 +23,18 @@ class Pogom(Flask):
         self.route("/mobile", methods=['GET'])(self.list_pokemon)
 
     def fullmap(self):
+        args = get_args()
+        dis = "inline"
+        if args.fixed_location:
+            dis = "none"
+        
         return render_template('map.html',
                                lat=config['ORIGINAL_LATITUDE'],
                                lng=config['ORIGINAL_LONGITUDE'],
                                gmaps_key=config['GMAPS_KEY'],
-                               lang=config['LOCALE'])
+                               lang=config['LOCALE'],
+                               is_fixed=dis
+                               )
 
     def raw_data(self):
         d = {}

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -52,6 +52,7 @@ def get_args():
     parser.add_argument('-d', '--debug', help='Debug Mode', action='store_true')
     parser.add_argument('-m', '--mock', help='Mock mode. Starts the web server but not the background thread.', action='store_true', default=False)
     parser.add_argument('-ns', '--no-server', help='No-Server Mode. Starts the searcher but not the Webserver.', action='store_true', default=False, dest='no_server')
+    parser.add_argument('-fl', '--fixed-location', help='Hides the search bar for use in shared maps.', action='store_true', default=False, dest='fixed_location')
     parser.add_argument('-k', '--google-maps-key', help='Google Maps Javascript API Key', default=None, dest='gmaps_key')
     parser.add_argument('-C', '--cors', help='Enable CORS on web server', action='store_true', default=False)
     parser.add_argument('-D', '--db', help='Database filename', default='pogom.db')

--- a/templates/map.html
+++ b/templates/map.html
@@ -44,7 +44,7 @@
 		<!-- Nav -->
 		<nav id="nav">
 			<p>Filter through Pokémon, Gyms &amp; Pokéstops.</p>
-			<div class="form-control">
+			<div class="form-control" style="display:{{is_fixed}}" >
 				<label for="next-location">
 					<h3>Change your location</h3>
 					<input id="next-location" type="text" name="next-location" placeholder="Change your location" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This allows users to hide the search bar by using the -fl (fixed location) parameter. It is designated for use in shared maps where relocation of the marker is not desired.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I have a map of my city I shared with my team members and ever since the search bar was introduced people keep changing it.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running the app with the parameter hides the search bar (display:none so it doesn't affect the UI) while running it without the parameter keeps the search bar intact.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

Toggled by adding -fl (fixed location) when calling the function.