### PR TITLE
Add toggle to disable Pokemon filter

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -156,6 +156,7 @@ function initSidebar() {
     $('#lured-pokemon-switch').prop('checked', localStorage.showLuredPokemon === 'true');
     $('#pokestops-switch').prop('checked', localStorage.showPokestops === 'true');
     $('#scanned-switch').prop('checked', localStorage.showScanned === 'true');
+	$('#hide-switch').prop('checked', localStorage.hidePokemon === 'true');
     $('#sound-switch').prop('checked', localStorage.playSound === 'true');
 
     var searchBox = new google.maps.places.SearchBox(document.getElementById('next-location'));
@@ -437,7 +438,8 @@ function clearStaleMarkers() {
     $.each(map_pokemons, function(key, value) {
 
         if (map_pokemons[key]['disappear_time'] < new Date().getTime() ||
-                excludedPokemon.indexOf(map_pokemons[key]['pokemon_id']) >= 0) {
+                (localStorage.hidePokemon === 'true' &&
+                excludedPokemon.indexOf(map_pokemons[key]['pokemon_id']) >= 0)) {
             map_pokemons[key].marker.setMap(null);
             delete map_pokemons[key];
         }
@@ -485,6 +487,7 @@ function updateMap() {
     var loadGyms = localStorage.showGyms || true;
     var loadPokestops =  localStorage.showPokestops || localStorage.showLuredPokemon || false; //lured mons need pokestop data
     var loadScanned = localStorage.showScanned || false;
+	var hidePokemon = localStorage.hidePokemon || true;
 
     var bounds = map.getBounds();
     var swPoint = bounds.getSouthWest();
@@ -514,7 +517,9 @@ function updateMap() {
               return false; // in case the checkbox was unchecked in the meantime.
           }
           if (!(item.encounter_id in map_pokemons) &&
-                    excludedPokemon.indexOf(item.pokemon_id) < 0) {
+                    ((localStorage.hidePokemon === 'true' &&
+                    excludedPokemon.indexOf(item.pokemon_id) < 0) ||
+                    localStorage.hidePokemon === 'false')) {
               // add marker to map and item to dict
               if (item.marker) item.marker.setMap(null);
               item.marker = setupPokemonMarker(item);
@@ -663,6 +668,11 @@ $('#pokestops-switch').change(function() {
 
 $('#sound-switch').change(function() {
     localStorage["playSound"] = this.checked;
+});
+
+$('#hide-switch').change(function () {
+    localStorage["hidePokemon"] = this.checked;
+    updateMap();
 });
 
 $('#scanned-switch').change(function() {

--- a/static/map.js
+++ b/static/map.js
@@ -156,7 +156,7 @@ function initSidebar() {
     $('#lured-pokemon-switch').prop('checked', localStorage.showLuredPokemon === 'true');
     $('#pokestops-switch').prop('checked', localStorage.showPokestops === 'true');
     $('#scanned-switch').prop('checked', localStorage.showScanned === 'true');
-	$('#hide-switch').prop('checked', localStorage.hidePokemon === 'true');
+    $('#hide-switch').prop('checked', localStorage.hidePokemon === 'true');
     $('#sound-switch').prop('checked', localStorage.playSound === 'true');
 
     var searchBox = new google.maps.places.SearchBox(document.getElementById('next-location'));
@@ -487,7 +487,7 @@ function updateMap() {
     var loadGyms = localStorage.showGyms || true;
     var loadPokestops =  localStorage.showPokestops || localStorage.showLuredPokemon || false; //lured mons need pokestop data
     var loadScanned = localStorage.showScanned || false;
-	var hidePokemon = localStorage.hidePokemon || true;
+    var hidePokemon = localStorage.hidePokemon || true;
 
     var bounds = map.getBounds();
     var swPoint = bounds.getSouthWest();
@@ -670,8 +670,8 @@ $('#sound-switch').change(function() {
     localStorage["playSound"] = this.checked;
 });
 
-$('#hide-switch').change(function () {
-    localStorage["hidePokemon"] = this.checked;
+$('#hide-switch').change(function() {
+    localStorage['hidePokemon'] = this.checked;
     updateMap();
 });
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -57,9 +57,9 @@
 				<div class="onoffswitch">
 					<input id="pokemon-switch" type="checkbox" name="pokemon-switch" class="onoffswitch-checkbox" checked>
 					<label class="onoffswitch-label" for="pokemon-switch">
-	        				<span class="switch-label" data-on="On" data-off="Off"></span>
-	        				<span class="switch-handle"></span>
-				        </label>
+							<span class="switch-label" data-on="On" data-off="Off"></span>
+							<span class="switch-handle"></span>
+					</label>
 				</div>
 			</div>
 			<div class="form-control switch-container">
@@ -77,9 +77,9 @@
 				<div class="onoffswitch">
 					<input id="gyms-switch" type="checkbox" name="gyms-switch" class="onoffswitch-checkbox" checked>
 					<label class="onoffswitch-label" for="gyms-switch">
-	        				<span class="switch-label" data-on="On" data-off="Off"></span>
-	        				<span class="switch-handle"></span>
-	        			</label>
+							<span class="switch-label" data-on="On" data-off="Off"></span>
+							<span class="switch-handle"></span>
+					</label>
 				</div>
 			</div>
 			<div class="form-control switch-container">
@@ -102,19 +102,19 @@
 					</label>
 				</div>
 			</div>
-            <hr width="100%">
+			<hr width="100%">
 			<div class="form-control switch-container">
 				<h3>Hide Pokémon</h3>
-                <div class="onoffswitch">
+				<div class="onoffswitch">
 					<input id="hide-switch" type="checkbox" name="hide-switch" class="onoffswitch-checkbox"/>
 					<label class="onoffswitch-label" for="hide-switch">
 						<span class="switch-label" data-on="On" data-off="Off"></span>
 						<span class="switch-handle"></span>
 					</label>
 				</div>
-                <label for="exclude-pokemon">
-                    <select id="exclude-pokemon" multiple="multiple"></select>
-                </label>
+					<label for="exclude-pokemon">
+					<select id="exclude-pokemon" multiple="multiple"></select>
+				</label>
 			</div>
 			<div class="form-control">
 				<label for="notify-pokemon">

--- a/templates/map.html
+++ b/templates/map.html
@@ -102,12 +102,19 @@
 					</label>
 				</div>
 			</div>
-			<hr width="100%">
-			<div class="form-control">
-				<label for="exclude-pokemon">
-					<h3>Hide common Pokémon</h3>
-      					<select id="exclude-pokemon" multiple="multiple"></select>
-    				</label>
+            <hr width="100%">
+			<div class="form-control switch-container">
+				<h3>Hide Pokémon</h3>
+                <div class="onoffswitch">
+					<input id="hide-switch" type="checkbox" name="hide-switch" class="onoffswitch-checkbox"/>
+					<label class="onoffswitch-label" for="hide-switch">
+						<span class="switch-label" data-on="On" data-off="Off"></span>
+						<span class="switch-handle"></span>
+					</label>
+				</div>
+                <label for="exclude-pokemon">
+                    <select id="exclude-pokemon" multiple="multiple"></select>
+                </label>
 			</div>
 			<div class="form-control">
 				<label for="notify-pokemon">

--- a/templates/map.html
+++ b/templates/map.html
@@ -57,8 +57,8 @@
 				<div class="onoffswitch">
 					<input id="pokemon-switch" type="checkbox" name="pokemon-switch" class="onoffswitch-checkbox" checked>
 					<label class="onoffswitch-label" for="pokemon-switch">
-							<span class="switch-label" data-on="On" data-off="Off"></span>
-							<span class="switch-handle"></span>
+						<span class="switch-label" data-on="On" data-off="Off"></span>
+						<span class="switch-handle"></span>
 					</label>
 				</div>
 			</div>
@@ -77,8 +77,8 @@
 				<div class="onoffswitch">
 					<input id="gyms-switch" type="checkbox" name="gyms-switch" class="onoffswitch-checkbox" checked>
 					<label class="onoffswitch-label" for="gyms-switch">
-							<span class="switch-label" data-on="On" data-off="Off"></span>
-							<span class="switch-handle"></span>
+						<span class="switch-label" data-on="On" data-off="Off"></span>
+						<span class="switch-handle"></span>
 					</label>
 				</div>
 			</div>


### PR DESCRIPTION
## Description
Added a toggle to disable Pokemon filter

## Motivation and Context
Suggested in #1539 #1598 
Convenient because there's no need to delete all the filters if you want to quickly check out what pokemon are around you.

## How Has This Been Tested?
Tested on Chrome, IE and ios

## Screenshots (if appropriate):
![2016-07-24_010950](https://cloud.githubusercontent.com/assets/20599458/17080521/dcee17d0-513b-11e6-8a9e-3979e6836bae.png)
![2016-07-24_010956](https://cloud.githubusercontent.com/assets/20599458/17080522/e3eba26e-513b-11e6-9cd0-b4a8f9ac5bab.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## PS:
Sorry if I screwed up somewhere, I promise I'll learn (already did screw up once).