### PR TITLE
Add Remove option to Pokemon label to allow hiding captured pokemon

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -46,6 +46,10 @@ function notifyAboutPokemon(id) {
     ).trigger('change')
 }
 
+function removePokemonMarker(encounter_id) {
+    map_pokemons[encounter_id].marker.setMap(null);
+}
+
 function initMap() {
 
     map = new google.maps.Map(document.getElementById('map'), {
@@ -124,7 +128,7 @@ function initSidebar() {
 
 function pad(number) { return number <= 99 ? ("0" + number).slice(-2) : number; }
 
-function pokemonLabel(name, disappear_time, id, latitude, longitude) {
+function pokemonLabel(name, disappear_time, id, latitude, longitude, encounter_id) {
     disappear_date = new Date(disappear_time)
 
     var contentstring = `
@@ -141,6 +145,7 @@ function pokemonLabel(name, disappear_time, id, latitude, longitude) {
         <div>
             <a href='javascript:excludePokemon(${id})'>Exclude</a>&nbsp;&nbsp;
             <a href='javascript:notifyAboutPokemon(${id})'>Notify</a>&nbsp;&nbsp;
+            <a href='javascript:removePokemonMarker("${encounter_id}")'>Remove</a>&nbsp;&nbsp;
             <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}'
                     target='_blank' title='View in Maps'>Get directions</a>
         </div>`;
@@ -251,7 +256,7 @@ function setupPokemonMarker(item) {
     });
 
     marker.infoWindow = new google.maps.InfoWindow({
-        content: pokemonLabel(item.pokemon_name, item.disappear_time, item.pokemon_id, item.latitude, item.longitude)
+        content: pokemonLabel(item.pokemon_name, item.disappear_time, item.pokemon_id, item.latitude, item.longitude, item.encounter_id)
     });
 
     if (notifiedPokemon.indexOf(item.pokemon_id) > -1) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added option to hide individual Pokemon from map using the Pokemon label.
When 'Remove' is clicked, that particular Pokemon marker is set to null to hide it from the map.  All other mechanisms still know the Pokemon exists and will be internally expired when disappear time is hit.

## Description
<!--- Describe your changes in detail -->
- Added `encounter_id` to `pokemonLabel` signature.
- Added `removePokemonMarker` function
- Added `Remove` button on Label pop up.

## Motivation and Context
fixes #1607 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Started up server and hid 1 Pokemon.  Waited full 15 min to make sure it didnt reappear or crash.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.