### PR TITLE
Make "disable" config.ini options less confusing

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -21,9 +21,9 @@ Location:
 #Time delay before beginning new scan
 Scan_delay: 1
 # Disable Map elements
-disable_pokemon:
-disable_pokestops:
-disable_gyms: 
+disable_pokemon: false
+disable_pokestops: false
+disable_gyms: false
 
 [Misc]
 #you need a google maps api key to run this!

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -43,9 +43,9 @@ def parse_config(args):
     args.location = Config.get('Search_Settings', 'Location')
     args.step_limit = int(Config.get('Search_Settings', 'Steps'))
     args.scan_delay = int(Config.get('Search_Settings', 'Scan_delay'))
-    args.no_pokemon = Config.get('Search_Settings', 'Disable_Pokemon')
-    args.no_pokestops = Config.get('Search_Settings', 'Disable_Pokestops')
-    args.no_gyms = Config.get('Search_Settings', 'Disable_Gyms')
+    args.no_pokemon = Config.getboolean('Search_Settings', 'Disable_Pokemon')
+    args.no_pokestops = Config.getboolean('Search_Settings', 'Disable_Pokestops')
+    args.no_gyms = Config.getboolean('Search_Settings', 'Disable_Gyms')
     if Config.get('Misc', 'Google_Maps_API_Key') :
         args.gmaps_key = Config.get('Misc', 'Google_Maps_API_Key') 
     args.host = Config.get('Misc', 'Host') 


### PR DESCRIPTION
## Description
Make the config a little bit more clear to ease user confusion

the three disable_ flags in the config.ini now take true/false, yes/no, on/off (thanks to ConfigParser's getboolean method)

Before, it was using get() which takes everything as a string. No string? Off. Any string? On

The example config has also been updated

## Motivation and Context
This can cause some user confusion, e.g. https://github.com/AHAAAAAAA/PokemonGo-Map/issues/1666

It's not obvious that if you write anything in there instead of nothing then the feature will be disabled.

## How Has This Been Tested?
Briefly tested with and without the flags. Watch the console log. Setting the appropriate option reports e.g. "parsing of Pokestops disabled"

## Types of changes
- [x ] New feature (non-breaking change which adds functionality)