### PR TITLE
Fixed retrieving and storing values in localStorage

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -58,6 +58,137 @@ var pokemon_sprites = {
     }
 };
 
+
+//
+// LocalStorage helpers
+//
+
+var StoreTypes = {
+    Boolean: {
+        parse: function(str) {
+            switch(str.toLowerCase()) {
+                case '1':
+                case 'true':
+                case 'yes':
+                    return true;
+                default:
+                    return false;
+            }
+        },
+        stringify: function(b) {
+            return b ? 'true' : 'false';
+        }
+    },
+    JSON: {
+        parse: function(str) {
+            return JSON.parse(str);
+        },
+        stringify: function(json) {
+            return JSON.stringify(json);
+        }
+    },
+    String: {
+        parse: function(str) {
+            return str;
+        },
+        stringify: function(str) {
+            return str;
+        }
+    },
+    Number: {
+        parse: function(str) {
+            return parseInt(str, 10);
+        },
+        stringify: function(number) {
+            return number.toString();
+        }
+    }
+};
+
+var StoreOptions = {
+    map_style: {
+        default: 'roadmap',
+        type: StoreTypes.String
+    },
+    remember_select_exclude: {
+        default: [],
+        type: StoreTypes.JSON
+    },
+    remember_select_notify: {
+        default: [],
+        type: StoreTypes.JSON
+    },
+    showGyms: {
+        default: false,
+        type: StoreTypes.Boolean
+    },
+    showPokemon: {
+        default: true,
+        type: StoreTypes.Boolean
+    },
+    showLuredPokemon: {
+        default: true,
+        type: StoreTypes.Boolean
+    },
+    showPokestops: {
+        default: true,
+        type: StoreTypes.Boolean
+    },
+    showScanned: {
+        default: false,
+        type: StoreTypes.Boolean
+    },
+    playSound: {
+        default: false,
+        type: StoreTypes.Boolean
+    },
+    geoLocate: {
+        default: false,
+        type: StoreTypes.Boolean
+    },
+    playSound: {
+        default: false,
+        type: StoreTypes.Boolean
+    },
+    pokemonIcons: {
+        default: 'highres',
+        type: StoreTypes.String
+    },
+    iconSizeModifier: {
+        default: 0,
+        type: StoreTypes.Number
+    }
+};
+
+var Store = {
+    getOption: function(key) {
+        var option = StoreOptions[key];
+        if (!option) {
+            throw "Store key was not defined " + key;
+        }
+        return option;
+    },
+    get: function(key) {
+        var option = this.getOption(key);
+        var optionType = option.type;
+        var rawValue = localStorage[key];
+        if (rawValue === null || rawValue === undefined) {
+            return option.default;
+        }
+        var value = optionType.parse(rawValue);
+        return value;
+    },
+    set: function(key, value) {
+        var option = this.getOption(key);
+        var optionType = option.type || StoreTypes.String;
+        var rawValue = optionType.stringify(value);
+        localStorage[key] = rawValue;
+    },
+    reset: function(key) {
+        localStorage.removeItem(key);
+    }
+};
+
 //
 // Functions
 //
@@ -127,14 +258,10 @@ function initMap() {
     map.mapTypes.set('style_pgo_nl', style_pgo_nl);
 
     map.addListener('maptypeid_changed', function(s) {
-        localStorage['map_style'] = this.mapTypeId;
+        Store.set('map_style', this.mapTypeId);
     });
 
-    if (!localStorage['map_style'] || localStorage['map_style'] === 'undefined') {
-        localStorage['map_style'] = 'roadmap';
-    }
-
-    map.setMapTypeId(localStorage['map_style']);
+    map.setMapTypeId(Store.get('map_style'));
     google.maps.event.addListener(map, 'idle', updateMap);
 
     marker = createSearchMarker();
@@ -184,13 +311,13 @@ function createSearchMarker() {
 }
 
 function initSidebar() {
-    $('#gyms-switch').prop('checked', localStorage.showGyms === 'true');
-    $('#pokemon-switch').prop('checked', localStorage.showPokemon === 'true');
-    $('#lured-pokemon-switch').prop('checked', localStorage.showLuredPokemon === 'true');
-    $('#pokestops-switch').prop('checked', localStorage.showPokestops === 'true');
-    $('#geoloc-switch').prop('checked', localStorage.geoLocate === 'true');
-    $('#scanned-switch').prop('checked', localStorage.showScanned === 'true');
-    $('#sound-switch').prop('checked', localStorage.playSound === 'true');
+    $('#gyms-switch').prop('checked', Store.get('showGyms'));
+    $('#pokemon-switch').prop('checked', Store.get('showPokemon'));
+    $('#lured-pokemon-switch').prop('checked', Store.get('showLuredPokemon'));
+    $('#pokestops-switch').prop('checked', Store.get('showPokestops'));
+    $('#geoloc-switch').prop('checked', Store.get('geoLocate'));
+    $('#scanned-switch').prop('checked', Store.get('showScanned'));
+    $('#sound-switch').prop('checked', Store.get('playSound'));
 
     var searchBox = new google.maps.places.SearchBox(document.getElementById('next-location'));
 
@@ -209,8 +336,8 @@ function initSidebar() {
     $.each(pokemon_sprites, function(key, value) {
         icons.append($('<option></option>').attr("value", key).text(value.name));
     });
-    icons.val((pokemon_sprites[localStorage.pokemonIcons]) ? localStorage.pokemonIcons : 'highres');
-    $('#pokemon-icon-size').val(localStorage.iconModifierSize || 0);
+    icons.val((pokemon_sprites[Store.get('pokemonIcons')]) ? Store.get('pokemonIcons') : 'highres');
+    $('#pokemon-icon-size').val(Store.get('iconSizeModifier'));
 }
 
 function pad(number) { return number <= 99 ? ("0" + number).slice(-2) : number; }
@@ -373,9 +500,9 @@ function getGoogleSprite(index, sprite, display_height) {
 function setupPokemonMarker(item) {
 
     // Scale icon size up with the map exponentially
-    var icon_size = 2 + (map.getZoom()-3) * (map.getZoom()-3) * .2 + parseInt(localStorage.iconSizeModifier || 0);
+    var icon_size = 2 + (map.getZoom()-3) * (map.getZoom()-3) * .2 + Store.get('iconSizeModifier');
     var pokemon_index = item.pokemon_id - 1;
-    var sprite = pokemon_sprites[localStorage.pokemonIcons] || pokemon_sprites['highres']
+    var sprite = pokemon_sprites[Store.get('pokemonIcons')] || pokemon_sprites['highres']
     var icon = getGoogleSprite(pokemon_index, sprite, icon_size);
 
     var marker = new google.maps.Marker({
@@ -395,7 +522,7 @@ function setupPokemonMarker(item) {
     });
 
     if (notifiedPokemon.indexOf(item.pokemon_id) > -1) {
-        if (localStorage.playSound === 'true') {
+        if (Store.get('playSound')) {
           audio.play();
         }
 
@@ -563,10 +690,10 @@ function clearOutOfBoundsMarkers(markers) {
 }
 
 function loadRawData() {
-    var loadPokemon = localStorage.showPokemon || true;
-    var loadGyms = localStorage.showGyms || true;
-    var loadPokestops =  localStorage.showPokestops || localStorage.showLuredPokemon || false; //lured mons need pokestop data
-    var loadScanned = localStorage.showScanned || false;
+    var loadPokemon = Store.get('showPokemon');
+    var loadGyms = Store.get('showGyms');
+    var loadPokestops = Store.get('showPokestops') || Store.get('showLuredPokemon');
+    var loadScanned = Store.get('showScanned');
 
     var bounds = map.getBounds();
     var swPoint = bounds.getSouthWest();
@@ -604,7 +731,7 @@ function loadRawData() {
 }
 
 function processPokemons(i, item) {
-    if (!(localStorage.showPokemon === 'true')) {
+    if (!Store.get('showPokemon')) {
         return false; // in case the checkbox was unchecked in the meantime.
     }
     if (!(item.encounter_id in map_data.pokemons) &&
@@ -617,7 +744,7 @@ function processPokemons(i, item) {
 }
 
 function processPokestops(i, item) {
-    if (!(localStorage.showPokestops === 'true')) {
+    if (!Store.get('showPokestops')) {
         return false;
     }
     if (map_data.pokestops[item.pokestop_id] == null) { // add marker to map and item to dict
@@ -637,7 +764,7 @@ function processPokestops(i, item) {
 }
 
 function processLuredPokemon(i, item) {
-    if (!(localStorage.showLuredPokemon === 'true')) {
+    if (!Store.get('showLuredPokemon')) {
         return false;
     }
     var item2 = {
@@ -667,7 +794,7 @@ function processLuredPokemon(i, item) {
 }
 
 function processGyms(i, item) {
-    if (!(localStorage.showGyms === 'true')) {
+    if (!Store.get('showGyms')) {
         return false; // in case the checkbox was unchecked in the meantime.
     }
 
@@ -693,7 +820,7 @@ function processGyms(i, item) {
 
 
 function processScanned(i, item) {
-    if (!localStorage.showScanned) {
+    if (!Store.get('showScanned')) {
         return false;
     }
 
@@ -934,27 +1061,23 @@ $(function () {
         $selectExclude.on("change", function (e) {
             excludedPokemon = $selectExclude.val().map(Number);
             clearStaleMarkers();
-            localStorage.remember_select_exclude = JSON.stringify(excludedPokemon);
+            Store.set('remember_select_exclude', excludedPokemon);
         });
         $selectNotify.on("change", function (e) {
             notifiedPokemon = $selectNotify.val().map(Number);
-            localStorage.remember_select_notify = JSON.stringify(notifiedPokemon);
+            Store.set('remember_select_notify', notifiedPokemon);
         });
 
         // recall saved lists
-        if (localStorage['remember_select_exclude']) {
-            $selectExclude.val(JSON.parse(localStorage.remember_select_exclude)).trigger("change");
-        }
-        if (localStorage['remember_select_notify']) {
-            $selectNotify.val(JSON.parse(localStorage.remember_select_notify)).trigger("change");
-        }
+        $selectExclude.val(Store.get('remember_select_exclude')).trigger("change");
+        $selectNotify.val(Store.get('remember_select_notify')).trigger("change");
     });
 
     // run interval timers to regularly update map and timediffs
     window.setInterval(updateLabelDiffTime, 1000);
     window.setInterval(updateMap, 5000);
     window.setInterval(function() {
-      if(navigator.geolocation && localStorage.geoLocate === 'true') {
+      if(navigator.geolocation && Store.get('geoLocate')) {
         navigator.geolocation.getCurrentPosition(function (position){
           var baseURL = location.protocol + "//" + location.hostname + (location.port ? ":"+location.port: "");
           lat = position.coords.latitude;
@@ -977,7 +1100,7 @@ $(function () {
 
     function buildSwitchChangeListener(data, data_type, storageKey) {
         return function () {
-            localStorage[storageKey] = this.checked;
+            Store.set(storageKey, this.checked);
             if (this.checked) {
                 updateMap();
             } else {
@@ -997,17 +1120,17 @@ $(function () {
     $('#scanned-switch').change(buildSwitchChangeListener(map_data, "scanned", "showScanned"));
 
     $('#sound-switch').change(function() {
-        localStorage["playSound"] = this.checked;
+        Store.set("playSound", this.checked);
     });
 
     $('#pokemon-icons').change(function() {
-        localStorage["pokemonIcons"] = this.value;
+        Store.set('pokemonIcons', this.value);
         redrawPokemon(map_data.pokemons);
         redrawPokemon(map_data.lure_pokemons);
     });
 
     $('#pokemon-icon-size').change(function() {
-        localStorage["iconSizeModifier"] = this.value;
+        Store.set('iconSizeModifier', this.value);
         redrawPokemon(map_data.pokemons);
         redrawPokemon(map_data.lure_pokemons);
     });
@@ -1016,7 +1139,7 @@ $(function () {
         if(!navigator.geolocation)  
             this.checked = false;  
         else   
-            localStorage["geoLocate"] = this.checked;  
+            Store.set('geoLocate', this.checked);
     });
 
 });


### PR DESCRIPTION
## Description
There were a number of errors with retrieving values from localStorage where it was presumed the value from localStorage was a boolean, whereas localStorage only stores strings (booleans are automatically converted to strings).
For example (https://github.com/AHAAAAAAA/PokemonGo-Map/blob/develop/static/map.js#L462)
```
if (!(localStorage.showPokemon === 'true')) {
```
Here `localStorage.showPokemon` is retrieved. If it was not set earlier, then null is returned. The default value of `showPokemon` is not used in this case (which should be `'true'`). So for some people, pokemon weren't loaded.

To circumvent this in the future I added `Store` which predefines which options are stored in localStorage, what their default values are and how to parse/stringify those values. I replaced raw usage of localStorage with usage of Store.

The options are predefined here: https://github.com/Chlodochar/PokemonGo-Map/commit/2b5a44872484c275b71b9e061d49c509d862c2d2#diff-a350469a6764edb653c7280bd0cf5adbR72

## Motivation and Context
To circumvent invalid usage of `localStorage` by making sure the type and the default values are predefined.

## How Has This Been Tested?
Run by all controls in webinterface.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
