### PR TITLE
--only-server mode added to complement --no-server

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -84,6 +84,7 @@ def get_args():
     parser.add_argument('-d', '--debug', help='Debug Mode', action='store_true')
     parser.add_argument('-m', '--mock', help='Mock mode. Starts the web server but not the background thread.', action='store_true', default=False)
     parser.add_argument('-ns', '--no-server', help='No-Server Mode. Starts the searcher but not the Webserver.', action='store_true', default=False, dest='no_server')
+    parser.add_argument('-os', '--only-server', help='Server-Only Mode. Starts only the Webserver without the searcher.', action='store_true', default=False, dest='only_server')
     parser.add_argument('-fl', '--fixed-location', help='Hides the search bar for use in shared maps.', action='store_true', default=False, dest='fixed_location')
     parser.add_argument('-k', '--google-maps-key', help='Google Maps Javascript API Key', default=None, dest='gmaps_key')
     parser.add_argument('-C', '--cors', help='Enable CORS on web server', action='store_true', default=False)

--- a/runserver.py
+++ b/runserver.py
@@ -70,10 +70,11 @@ if __name__ == '__main__':
     config['LOCALE'] = args.locale
     config['CHINA'] = args.china
 
-    if not args.mock:
-        start_locator_thread(args)
-    else:
-        insert_mock_data()
+    if not args.only_server:
+        if not args.mock:
+            start_locator_thread(args)
+        else:
+            insert_mock_data()
 
     app = Pogom(__name__)
 


### PR DESCRIPTION
Since we already have isolated shared data into database and we have --no-server option just for the searcher, let's complement it with --only-server as well so anyone can easily start a server in one process and N searchers as other processes.

## Description
Very simple addition of new command-line argument and forfeiting instantiation of searcher threads

## Motivation and Context
1) To enable scaling the solution by allowing having multiple workers share the server easily
2) Server in separate process can be more easily set to higher priority than workers 

## How Has This Been Tested?
Ran --no-server and --only-server in separate processes, no issues encountered, database is shared 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
