### PR TITLE
Remove username and password requirement for -os

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -47,10 +47,10 @@ def parse_config(args):
     args.no_pokestops = Config.getboolean('Search_Settings', 'Disable_Pokestops')
     args.no_gyms = Config.getboolean('Search_Settings', 'Disable_Gyms')
     if Config.get('Misc', 'Google_Maps_API_Key') :
-        args.gmaps_key = Config.get('Misc', 'Google_Maps_API_Key') 
-    args.host = Config.get('Misc', 'Host') 
-    args.port = Config.get('Misc', 'Port') 
-    
+        args.gmaps_key = Config.get('Misc', 'Google_Maps_API_Key')
+    args.host = Config.get('Misc', 'Host')
+    args.port = Config.get('Misc', 'Port')
+
     return args
 
 def parse_db_config(args):
@@ -99,17 +99,23 @@ def get_args():
     args = parse_db_config(args)
 
     if (args.settings):
-        args = parse_config(args) 
+        args = parse_config(args)
     else:
-        if (args.username is None or args.location is None or args.step_limit is None):
-            parser.print_usage()
-            print sys.argv[0] + ': error: arguments -u/--username, -l/--location, -st/--step-limit are required'
-            sys.exit(1);
+        if args.only_server:
+            if args.location is None:
+                parser.print_usage()
+                print sys.argv[0] + ': error: arguments -l/--location is required'
+                sys.exit(1);
+        else:
+            if (args.username is None or args.location is None or args.step_limit is None):
+                parser.print_usage()
+                print sys.argv[0] + ': error: arguments -u/--username, -l/--location, -st/--step-limit are required'
+                sys.exit(1);
 
-        if config["PASSWORD"] is None and args.password is None:
-            config["PASSWORD"] = args.password = getpass.getpass()
-        elif args.password is None:
-            args.password = config["PASSWORD"]
+            if config["PASSWORD"] is None and args.password is None:
+                config["PASSWORD"] = args.password = getpass.getpass()
+            elif args.password is None:
+                args.password = config["PASSWORD"]
 
 
     return args


### PR DESCRIPTION
## Description
Only check username and  password if -os is off.

## Motivation and Context
https://github.com/AHAAAAAAA/PokemonGo-Map/issues/1733

## How Has This Been Tested?
Run -os thread and -ns thread.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
