### PR TITLE
do not require username and password in server only mode

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -101,16 +101,18 @@ def get_args():
     if (args.settings):
         args = parse_config(args) 
     else:
-        if (args.username is None or args.location is None or args.step_limit is None):
+        if args.location is None or ((not args.only_server) and (args.username is None or args.step_limit is None)):
             parser.print_usage()
-            print sys.argv[0] + ': error: arguments -u/--username, -l/--location, -st/--step-limit are required'
+            if args.only_server:
+                print sys.argv[0] + ': error: argument -l/--location required'
+            else:
+                print sys.argv[0] + ': error: arguments -u/--username, -l/--location, -st/--step-limit are required'
             sys.exit(1);
 
-        if config["PASSWORD"] is None and args.password is None:
+        if not args.only_server and config["PASSWORD"] is None and args.password is None:
             config["PASSWORD"] = args.password = getpass.getpass()
         elif args.password is None:
             args.password = config["PASSWORD"]
-
 
     return args
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Don't require username, password, steps in --only-server mode.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is addition to https://github.com/AHAAAAAAA/PokemonGo-Map/pull/1700 as we don't need username, password and steps in --only-server mode. We need only location.
Fixes https://github.com/AHAAAAAAA/PokemonGo-Map/issues/1733
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
with and without -om, -l, -u, -p, -st

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
