### PR TITLE
Implemented logic to change position of the marker and trigger search by double click (map won't zoom)

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -15,7 +15,7 @@ var notifiedPokemon = [];
 
 var map;
 var locationMarker;
-var marker;
+var searchMarker;
 
 var light2Style=[{"elementType":"geometry","stylers":[{"hue":"#ff4400"},{"saturation":-68},{"lightness":-4},{"gamma":0.72}]},{"featureType":"road","elementType":"labels.icon"},{"featureType":"landscape.man_made","elementType":"geometry","stylers":[{"hue":"#0077ff"},{"gamma":3.1}]},{"featureType":"water","stylers":[{"hue":"#00ccff"},{"gamma":0.44},{"saturation":-33}]},{"featureType":"poi.park","stylers":[{"hue":"#44ff00"},{"saturation":-23}]},{"featureType":"water","elementType":"labels.text.fill","stylers":[{"hue":"#007fff"},{"gamma":0.77},{"saturation":65},{"lightness":99}]},{"featureType":"water","elementType":"labels.text.stroke","stylers":[{"gamma":0.11},{"weight":5.6},{"saturation":99},{"hue":"#0091ff"},{"lightness":-86}]},{"featureType":"transit.line","elementType":"geometry","stylers":[{"lightness":-48},{"hue":"#ff5e00"},{"gamma":1.2},{"saturation":-23}]},{"featureType":"transit","elementType":"labels.text.stroke","stylers":[{"saturation":-64},{"hue":"#ff9100"},{"lightness":16},{"gamma":0.47},{"weight":2.7}]}];
 var darkStyle=[{"featureType":"all","elementType":"labels.text.fill","stylers":[{"saturation":36},{"color":"#b39964"},{"lightness":40}]},{"featureType":"all","elementType":"labels.text.stroke","stylers":[{"visibility":"on"},{"color":"#000000"},{"lightness":16}]},{"featureType":"all","elementType":"labels.icon","stylers":[{"visibility":"off"}]},{"featureType":"administrative","elementType":"geometry.fill","stylers":[{"color":"#000000"},{"lightness":20}]},{"featureType":"administrative","elementType":"geometry.stroke","stylers":[{"color":"#000000"},{"lightness":17},{"weight":1.2}]},{"featureType":"landscape","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":20}]},{"featureType":"poi","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":21}]},{"featureType":"road.highway","elementType":"geometry.fill","stylers":[{"color":"#000000"},{"lightness":17}]},{"featureType":"road.highway","elementType":"geometry.stroke","stylers":[{"color":"#000000"},{"lightness":29},{"weight":0.2}]},{"featureType":"road.arterial","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":18}]},{"featureType":"road.local","elementType":"geometry","stylers":[{"color":"#181818"},{"lightness":16}]},{"featureType":"transit","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":19}]},{"featureType":"water","elementType":"geometry","stylers":[{"lightness":17},{"color":"#525252"}]}];
@@ -110,8 +110,7 @@ function initMap() {
     map.setMapTypeId(localStorage['map_style']);
     google.maps.event.addListener(map, 'idle', updateMap);
 
-    marker = createSearchMarker();
-
+    createSearchMarker();
     addMyLocationButton();
     initSidebar();
     google.maps.event.addListenerOnce(map, 'idle', function(){
@@ -121,7 +120,7 @@ function initMap() {
 };
 
 function createSearchMarker() {
-    var marker = new google.maps.Marker({
+    searchMarker = new google.maps.Marker({
         position: {
             lat: center_lat,
             lng: center_lng
@@ -132,19 +131,19 @@ function createSearchMarker() {
     });
 
     var oldLocation = null;
-    google.maps.event.addListener(marker, 'dragstart', function() {
-        oldLocation = marker.getPosition();
+    google.maps.event.addListener(searchMarker, 'dragstart', function() {
+        oldLocation = searchMarker.getPosition();
     });
 
-    google.maps.event.addListener(marker, 'dragend', function() {
-        var newLocation = marker.getPosition();
+    google.maps.event.addListener(searchMarker, 'dragend', function() {
+        var newLocation = searchMarker.getPosition();
         changeLocation(newLocation, 
             function() {
                 oldLocation = null;
             },
             function() {
                 if (oldLocation) {
-                    marker.setPosition(oldLocation);
+                    searchMarker.setPosition(oldLocation);
                 }
             }
         );
@@ -153,18 +152,16 @@ function createSearchMarker() {
     // double click event
     google.maps.event.addListener(map, 'dblclick', function(e) {
         var positionDoubleclick = e.latLng;
-        var oldLocation = marker.getPosition();
+        var oldLocation = searchMarker.getPosition();
         changeLocation(positionDoubleclick, 
             function() {
-                marker.setPosition(positionDoubleclick);
+                searchMarker.setPosition(positionDoubleclick);
             },
             function() {
-                marker.setPosition(oldLocation);
+                searchMarker.setPosition(oldLocation);
             }
         );
     });
-
-    return marker;
 }
 
 function initSidebar() {
@@ -187,7 +184,7 @@ function initSidebar() {
         changeLocation(loc, 
             function() {
                 map.setCenter(loc);
-                marker.setPosition(loc);
+                searchMarker.setPosition(loc);
             }
         );
     });
@@ -772,13 +769,13 @@ function myLocationButton() {
                 currentLocation.style.backgroundPosition = '-144px 0px';
 
                 //Change seach position to marker position:
-                var oldLocation = marker.getPosition();
+                var oldLocation = searchMarker.getPosition();
                 changeLocation(latlng,
                     function() {
-                        marker.setPosition(latlng);
+                        searchMarker.setPosition(latlng);
                     },
                     function() {
-                        marker.setPosition(oldLocation);
+                        searchMarker.setPosition(oldLocation);
                     }
                 );
             });

--- a/static/map.js
+++ b/static/map.js
@@ -137,6 +137,7 @@ function createSearchMarker() {
     });
 
     google.maps.event.addListener(marker, 'dragend', function() {
+        var newLocation = marker.getPosition();
         changeLocation(newLocation, 
             function() {
                 oldLocation = null;

--- a/static/map.js
+++ b/static/map.js
@@ -822,7 +822,7 @@ function changeLocation(location, successCallback, failCallback) {
         promise.done(successCallback);
     }
     if (failCallback) {
-        promise.fai(failCallback);
+        promise.fail(failCallback);
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Implemented logic to change position of the marker and trigger search by double click (map won't zoom)

## Description
<!--- Describe your changes in detail -->
- Implemented logic to change position of the marker (also re-search) by double click (map won't zoom)
- Implemented the ability to re-center the marker (also re-search) by clicking the myLocationButton
- Refactored code for readability

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When there's many un-filtered pokemons on the map, it is hard to drag the marker (especially when accessing using a phone). Double click to change the marker position and triggers a search is more user-friendly. The zoom capability is still available from pinch gesture (or mouse scroll).

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested on localhost desktop. Also deployed to heroku and tested using phone.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Now that clicking on the myLocationButton will bring marker to the center of the map as well so the myLocationButton itself seems redundant. This is a change of behaviour and I think it's fair to let all other contributors to decide whether this is a more friendly behaviour. :)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
