### PR TITLE
Add option to fade Pokémons with time

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -105,6 +105,7 @@ function initSidebar() {
     $('#pokestops-switch').prop('checked', localStorage.showPokestops === 'true');
     $('#scanned-switch').prop('checked', localStorage.showScanned === 'true');
     $('#sound-switch').prop('checked', localStorage.playSound === 'true');
+    $('#opacity-switch').prop('checked', localStorage.fadePokemons === 'true');
 
     var searchBox = new google.maps.places.SearchBox(document.getElementById('next-location'));
 
@@ -252,6 +253,7 @@ function setupPokemonMarker(item) {
         sendNotification('A wild ' + item.pokemon_name + ' appeared!', 'Click to load map', 'static/icons/' + item.pokemon_id + '.png')
     }
 
+    setMarkerOpacity(marker, item.disappear_time);
     addListeners(marker);
     return marker;
 };
@@ -304,6 +306,16 @@ function getColorByDate(value){
     //value from 0 to 1 - Green to Red
     var hue=((1-diff)*120).toString(10);
     return ["hsl(",hue,",100%,50%)"].join("");
+}
+
+function setMarkerOpacity(marker, disappear_time) {
+    if (localStorage.fadePokemons === 'true') {
+        //range opacity: 0.3 to 1.0
+        var percentage = Math.min(Math.abs(new Date(disappear_time) - new Date()), 15 * 60 * 1000) / (15 * 60 * 1000);
+        marker.setOpacity(0.3 + (percentage * 0.7));
+    } else {
+        marker.setOpacity(1);
+    }
 }
 
 function setupScannedMarker(item) {
@@ -696,6 +708,13 @@ $(function () {
 
     $('#sound-switch').change(function() {
         localStorage["playSound"] = this.checked;
+    });
+
+    $('#opacity-switch').change(function() {
+        localStorage["fadePokemons"] = this.checked;
+        $.each(map_pokemons, function(key, value) {
+            setMarkerOpacity(map_pokemons[key].marker, map_pokemons[key]["disappear_time"]);
+        });
     });
 
     $('#scanned-switch').change(function() {

--- a/static/map.js
+++ b/static/map.js
@@ -479,6 +479,10 @@ function updateMap() {
 };
 
 function updateLabelDiffTime() {
+    $.each(map_pokemons, function(key, value) {
+        setMarkerOpacity(map_pokemons[key].marker, map_pokemons[key]["disappear_time"]);
+    });
+    
     $('.label-countdown').each(function(index, element) {
         var disappearsAt = new Date(parseInt(element.getAttribute("disappears-at")));
         var now = new Date();

--- a/templates/map.html
+++ b/templates/map.html
@@ -113,6 +113,16 @@
 					</label>
 				</div>
 			</div>
+			<div class="form-control switch-container">
+				<h3>Fade out Pokémons</h3>
+				<div class="onoffswitch">
+					<input id="opacity-switch" type="checkbox" name="opacity-switch" class="onoffswitch-checkbox" checked/>
+					<label class="onoffswitch-label" for="opacity-switch">
+						<span class="switch-label" data-on="On" data-off="Off"></span>
+						<span class="switch-handle"></span>
+					</label>
+				</div>
+			</div>
 		</nav>
 
 		<div id="map"></div>


### PR DESCRIPTION
Adds the option to fade out Pokémons, which are going to expire soon, without clicking on each Pokémon. By default disabled, togglable in the sidebar.

## Motivation and Context
You probably don't want to click on each Pokémon to check their expire time. This provides a simple visual clue, highlighting newest Pokémons and hiding the old ones.

## How Has This Been Tested?
Tested on Chrome, Edge, Firefox and Chrome/Android. 

## Screenshots:
![map](https://cloud.githubusercontent.com/assets/1443449/17082532/3cf40d7e-5182-11e6-8f2a-e70c8340ae60.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.