### PR TITLE
Fix exception on /mobile

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -98,7 +98,7 @@ class Pogom(Flask):
         # todo: check if client is android/iOS/Desktop for geolink, currently only supports android
         pokemon_list = []
         origin_point = LatLng.from_degrees(config['ORIGINAL_LATITUDE'], config['ORIGINAL_LONGITUDE'])
-        for pokemon in Pokemon.get_active():
+        for pokemon in Pokemon.get_active(None, None, None, None):
             pokemon_point = LatLng.from_degrees(pokemon['latitude'], pokemon['longitude'])
             diff = pokemon_point - origin_point
             diff_lat = diff.lat().degrees


### PR DESCRIPTION
`Pokemon.get_active` now requires args; This fixes a fatal on `/mobile` caused by 5deb540dcac4f5c9600f7797caa30c3c1def3296.