### PR TITLE
Add ability to run server through https

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -93,10 +93,24 @@ def get_args():
     parser.add_argument('-np', '--no-pokemon', help='Disables Pokemon from the map (including parsing them into local db)', action='store_true', default=False)
     parser.add_argument('-ng', '--no-gyms', help='Disables Gyms from the map (including parsing them into local db)', action='store_true', default=False)
     parser.add_argument('-nk', '--no-pokestops', help='Disables PokeStops from the map (including parsing them into local db)', action='store_true', default=False)
+    parser.add_argument('-hc', '--https-cert', help='Specify https certificate', default=None, dest='https_cert')
+    parser.add_argument('-hpk', '--https-private-key', help='Specify https private key', default=None, dest='https_key')
     parser.set_defaults(DEBUG=False)
     args = parser.parse_args()
 
     args = parse_db_config(args)
+
+    if args.https_cert is not None or args.https_key is not None:
+        if args.https_cert is None:
+            print sys.argv[0] + ': error: you should also specify -hc/--https-cert'
+            sys.exit(1)
+        if args.https_key is None:
+            print sys.argv[0] + ': error: you should also specify -hpk/--https-private-key'
+            sys.exit(1)
+
+        args.ssl_context = (args.https_cert, args.https_key)
+    else:
+        args.ssl_context = None
 
     if (args.settings):
         args = parse_config(args)

--- a/runserver.py
+++ b/runserver.py
@@ -92,4 +92,4 @@ if __name__ == '__main__':
             time.sleep(1)
         search_thread.join()
     else:
-        app.run(threaded=True, debug=args.debug, host=args.host, port=args.port)
+        app.run(threaded=True, debug=args.debug, host=args.host, port=args.port, ssl_context=args.ssl_context)


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [X] New feature
- [ ] Translation

The following changes were made

- Added configuration to allow to run server through https.

As Google Chrome (desktop and mobile) disallow using location data from non-secure websites I added ability to run server as https.
