### PR TITLE
Added double-click to change location.

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -64,8 +64,8 @@ function initMap() {
         disableDoubleClickZoom: true,
         fullscreenControl: true,
         streetViewControl: false,
-		mapTypeControl: true,
-		mapTypeControlOptions: {
+        mapTypeControl: true,
+        mapTypeControlOptions: {
           style: google.maps.MapTypeControlStyle.DROPDOWN_MENU,
           position: google.maps.ControlPosition.RIGHT_TOP,
           mapTypeIds: [

--- a/static/map.js
+++ b/static/map.js
@@ -398,6 +398,7 @@ function setupScannedMarker(item) {
     var marker = new google.maps.Circle({
         map: map,
         center: circleCenter,
+        clickable: false,
         radius: 100,    // 10 miles in metres
         fillColor: getColorByDate(item.last_modified),
         strokeWeight: 1

--- a/static/map.js
+++ b/static/map.js
@@ -61,6 +61,7 @@ function initMap() {
             lng: center_lng
         },
         zoom: 16,
+        disableDoubleClickZoom: true,
         fullscreenControl: true,
         streetViewControl: false,
 		mapTypeControl: true,
@@ -78,7 +79,6 @@ function initMap() {
               'style_pgo_nl']
         },
     });
-    map.setOptions({disableDoubleClickZoom: true });
     
     var style_dark = new google.maps.StyledMapType(darkStyle, {name: "Dark"});
     map.mapTypes.set('dark_style', style_dark);

--- a/static/map.js
+++ b/static/map.js
@@ -78,7 +78,8 @@ function initMap() {
               'style_pgo_nl']
         },
     });
-
+    map.setOptions({disableDoubleClickZoom: true });
+    
 	var style_dark = new google.maps.StyledMapType(darkStyle, {name: "Dark"});
 	map.mapTypes.set('dark_style', style_dark);
 
@@ -112,10 +113,22 @@ function initMap() {
 
     addMyLocationButton();
     initSidebar();
+
+    google.maps.event.addListener(map, 'dblclick', function(e) {
+        var oldLocation = marker.getPosition();
+        changeSearchLocation(e.latLng.lat(), e.latLng.lng())
+            .done(function() {
+                oldLocation = null;
+                marker.setPosition(e.latLng);
+            })
+            .fail(function() {
+                marker.setPosition(oldLocation);
+            });
+    });
+
     google.maps.event.addListenerOnce(map, 'idle', function(){
         updateMap();
     });
-    
 };
 
 function createSearchMarker() {

--- a/static/map.js
+++ b/static/map.js
@@ -80,14 +80,14 @@ function initMap() {
     });
     map.setOptions({disableDoubleClickZoom: true });
     
-	var style_dark = new google.maps.StyledMapType(darkStyle, {name: "Dark"});
-	map.mapTypes.set('dark_style', style_dark);
+    var style_dark = new google.maps.StyledMapType(darkStyle, {name: "Dark"});
+    map.mapTypes.set('dark_style', style_dark);
 
-	var style_light2 = new google.maps.StyledMapType(light2Style, {name: "Light2"});
-	map.mapTypes.set('style_light2', style_light2);
+    var style_light2 = new google.maps.StyledMapType(light2Style, {name: "Light2"});
+    map.mapTypes.set('style_light2', style_light2);
 
-	var style_pgo = new google.maps.StyledMapType(pGoStyle, {name: "PokemonGo"});
-	map.mapTypes.set('style_pgo', style_pgo);
+    var style_pgo = new google.maps.StyledMapType(pGoStyle, {name: "PokemonGo"});
+    map.mapTypes.set('style_pgo', style_pgo);
 
     var style_dark_nl = new google.maps.StyledMapType(darkStyleNoLabels, {name: "Dark (No Labels)"});
     map.mapTypes.set('dark_style_nl', style_dark_nl);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Added a double click to change search location, faster than dragging and dropping, but also works along side it.

## Motivation and Context
- When making a big change in location, zooming in and out and dragging the marker can be annoying. This is a simple solution.

## How Has This Been Tested?
 - Lots of double clicking. Lots. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
