### PR TITLE
change FloatField to DoubleField

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -4,7 +4,7 @@
 import logging
 import os
 from peewee import Model, MySQLDatabase, SqliteDatabase, InsertQuery, IntegerField,\
-                   CharField, FloatField, BooleanField, DateTimeField,\
+                   CharField, DoubleField, BooleanField, DateTimeField,\
                    OperationalError
 from datetime import datetime
 from datetime import timedelta
@@ -61,8 +61,8 @@ class Pokemon(BaseModel):
     encounter_id = CharField(primary_key=True)
     spawnpoint_id = CharField()
     pokemon_id = IntegerField()
-    latitude = FloatField()
-    longitude = FloatField()
+    latitude = DoubleField()
+    longitude = DoubleField()
     disappear_time = DateTimeField()
 
     @classmethod
@@ -125,8 +125,8 @@ class Pokemon(BaseModel):
 class Pokestop(BaseModel):
     pokestop_id = CharField(primary_key=True)
     enabled = BooleanField()
-    latitude = FloatField()
-    longitude = FloatField()
+    latitude = DoubleField()
+    longitude = DoubleField()
     last_modified = DateTimeField()
     lure_expiration = DateTimeField(null=True)
     active_pokemon_id = IntegerField(null=True)
@@ -164,8 +164,8 @@ class Gym(BaseModel):
     guard_pokemon_id = IntegerField()
     gym_points = IntegerField()
     enabled = BooleanField()
-    latitude = FloatField()
-    longitude = FloatField()
+    latitude = DoubleField()
+    longitude = DoubleField()
     last_modified = DateTimeField()
 
     @classmethod
@@ -191,8 +191,8 @@ class Gym(BaseModel):
 
 class ScannedLocation(BaseModel):
     scanned_id = CharField(primary_key=True)
-    latitude = FloatField()
-    longitude = FloatField()
+    latitude = DoubleField()
+    longitude = DoubleField()
     last_modified = DateTimeField()
 
     @classmethod


### PR DESCRIPTION
Change FloatField to DoubleField

## Description
Change FloatField to DoubleField

## Motivation and Context
The field type that peewee is setting for mysql is insufficient for the precision demanded by latitude and longitude leading to markers on the map being considerably out of position.
This PR changes the field type to a more appropriate one.
As detailed in #1791 

## How Has This Been Tested?
Works on my machine ;)
Also according to the table at https://peewee.readthedocs.io/en/2.0.2/peewee/fields.html#field-types-table
this change will have no effect on sqlite. Postgress is not yet implemented so I don't have to worry about compatibility with that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.

FloatField does not retain the required precision for coordinates when
used with mysql