### PR TITLE
close db connection after upsert

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -302,6 +302,8 @@ def bulk_upsert(cls, data):
         except OperationalError as e:
             log.warning("%s... Retrying", e)
             continue
+        finally:
+            db.close()
 
         i+=step
 


### PR DESCRIPTION
## Description
See issue #1735 which I opened because I kept getting an error about max_connections being exceeded on my remote mysql database. I added a call to close the db connection in the model class and this seems to take care of it. I suppose Peewee is good about opening connections but not necessarily closing them.

## Motivation and Context
It allows me to use a heroku cleardb mysql database with my heroku deployed version of the app. I plan on using the database to create a bot to alert of rarer, nearby pokemon.

## How Has This Been Tested?
I tested my change by running the runserver.py as normal. I have set my mysql database connection up in the config.ini. I monitored the open connections on the database's web-interface and saw that now only one connection was ever open instead of 10+

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/2680142/17084506/fb2ca1c8-5184-11e6-9245-696e5ea9ee91.png)

## Types of changes
Only the db.close insertion

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

