### PR TITLE
Producer/consumer pattern for search threads instead of task batching (speedup)

### DIFF
--- a/pogom/__init__.py
+++ b/pogom/__init__.py
@@ -11,5 +11,6 @@ config = {
     'REQ_SLEEP': 1,
     'REQ_HEAVY_SLEEP': 30,
     'REQ_MAX_FAILED': 5,
-    'PASSWORD': None
+    'PASSWORD': None,
+    'SEARCH_QUEUE_DEPTH': 100
 }

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -6,6 +6,7 @@ import time
 import math
 
 from threading import Thread, Lock
+from queue import Queue
 
 from pgoapi import PGoApi
 from pgoapi.utilities import f2i, get_cellid
@@ -26,6 +27,8 @@ lng_gap_meters = 86.6
 #111111m is approx 1 degree Lat, which is close enough for this
 meters_per_degree = 111111
 lat_gap_degrees = float(lat_gap_meters) / meters_per_degree
+
+search_queue = Queue(config['SEARCH_QUEUE_DEPTH'])
 
 def calculate_lng_degrees(lat):
     return float(lng_gap_meters) / (meters_per_degree * math.cos(math.radians(lat)))
@@ -98,32 +101,37 @@ def login(args, position):
 
     log.info('Login to Pokemon Go successful.')
 
+def create_search_threads(num) :
+    search_threads = []
+    for i in range(num):
+        t = Thread(target=search_thread, name='search_thread {}'.format(i), args=( search_queue,))
+        t.start()
+        search_threads.append(t)
 
 def search_thread(args):
-    i, total_steps, step_location, step, lock = args
+    queue = args
+    while True:
+        i, total_steps, step_location, step, lock = queue.get()
+        log.info("Search queue depth is: " + str(queue.qsize()))
+        response_dict = {}
+        failed_consecutive = 0
+        while not response_dict:
+            response_dict = send_map_request(api, step_location)
+            if response_dict:
+                with lock:
+                    try:
+                        parse_map(response_dict, i, step, step_location)
+                    except KeyError:
+                        log.error('Scan step {:d} failed. Response dictionary key error.'.format(step))
+                        failed_consecutive += 1
+                        if(failed_consecutive >= config['REQ_MAX_FAILED']):
+                            log.error('Niantic servers under heavy load. Waiting before trying again')
+                            time.sleep(config['REQ_HEAVY_SLEEP'])
+                            failed_consecutive = 0
+            else:
+                log.info('Map Download failed. Trying again.')
 
-    log.info('Scanning step {:d} of {:d} started.'.format(step, total_steps))
-    log.debug('Scan location is {:f}, {:f}'.format(step_location[0], step_location[1]))
-
-    response_dict = {}
-    failed_consecutive = 0
-    while not response_dict:
-        response_dict = send_map_request(api, step_location)
-        if response_dict:
-            with lock:
-                try:
-                    parse_map(response_dict, i, step, step_location)
-                except KeyError:
-                    log.error('Scan step {:d} failed. Response dictionary key error.'.format(step))
-                    failed_consecutive += 1
-                    if(failed_consecutive >= config['REQ_MAX_FAILED']):
-                        log.error('Niantic servers under heavy load. Waiting before trying again')
-                        time.sleep(config['REQ_HEAVY_SLEEP'])
-                        failed_consecutive = 0
-        else:
-            log.info('Map Download failed. Trying again.')
-
-    time.sleep(config['REQ_SLEEP'])
+        time.sleep(config['REQ_SLEEP'])
 
 def process_search_threads(search_threads, curr_steps, total_steps):
     for thread in search_threads:
@@ -164,16 +172,8 @@ def search(args, i):
             search(args, i)
             return
 
-        search_args = (i, total_steps, step_location, step, lock)
-        search_threads.append(Thread(target=search_thread, name='search_step_thread {}'.format(step), args=(search_args, )))
-
-        if step % max_threads == 0:
-            curr_steps = process_search_threads(search_threads, curr_steps, total_steps)
-            search_threads = []
-
-    if search_threads:
-        process_search_threads(search_threads, curr_steps, total_steps)
-
+        search_args = ( i, total_steps, step_location, step, lock)
+        search_queue.put(search_args)
 
 def search_loop(args):
     i = 0

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -128,6 +128,7 @@ def search_thread(args):
                             log.error('Niantic servers under heavy load. Waiting before trying again')
                             time.sleep(config['REQ_HEAVY_SLEEP'])
                             failed_consecutive = 0
+                        response_dict = {}
             else:
                 log.info('Map Download failed. Trying again.')
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -105,6 +105,7 @@ def create_search_threads(num) :
     search_threads = []
     for i in range(num):
         t = Thread(target=search_thread, name='search_thread {}'.format(i), args=( search_queue,))
+        t.daemon = True
         t.start()
         search_threads.append(t)
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -84,6 +84,7 @@ def get_args():
     parser.add_argument('-d', '--debug', help='Debug Mode', action='store_true')
     parser.add_argument('-m', '--mock', help='Mock mode. Starts the web server but not the background thread.', action='store_true', default=False)
     parser.add_argument('-ns', '--no-server', help='No-Server Mode. Starts the searcher but not the Webserver.', action='store_true', default=False, dest='no_server')
+    parser.add_argument('-os', '--only-server', help='Server-Only Mode. Starts only the Webserver without the searcher.', action='store_true', default=False, dest='only_server')
     parser.add_argument('-fl', '--fixed-location', help='Hides the search bar for use in shared maps.', action='store_true', default=False, dest='fixed_location')
     parser.add_argument('-k', '--google-maps-key', help='Google Maps Javascript API Key', default=None, dest='gmaps_key')
     parser.add_argument('-C', '--cors', help='Enable CORS on web server', action='store_true', default=False)

--- a/runserver.py
+++ b/runserver.py
@@ -12,7 +12,7 @@ from flask_cors import CORS, cross_origin
 from pogom import config
 from pogom.app import Pogom
 from pogom.utils import get_args, insert_mock_data, load_credentials
-from pogom.search import search_loop
+from pogom.search import search_loop, create_search_threads
 from pogom.models import init_database, create_tables, Pokemon, Pokestop, Gym
 
 from pogom.pgoapi.utilities import get_pos_by_name
@@ -71,6 +71,7 @@ if __name__ == '__main__':
     config['CHINA'] = args.china
 
     if not args.only_server:
+        create_search_threads(args.num_threads)
         if not args.mock:
             start_locator_thread(args)
         else:

--- a/runserver.py
+++ b/runserver.py
@@ -70,10 +70,11 @@ if __name__ == '__main__':
     config['LOCALE'] = args.locale
     config['CHINA'] = args.china
 
-    if not args.mock:
-        start_locator_thread(args)
-    else:
-        insert_mock_data()
+    if not args.only_server:
+        if not args.mock:
+            start_locator_thread(args)
+        else:
+            insert_mock_data()
 
     app = Pogom(__name__)
 


### PR DESCRIPTION
Current implementation uses optional batching of up to --threads requests yet it always waits for the entire batch to finish which equals to waiting for the slowest thread of the batch before launching new batch.  This seriously impacts scalability since the entire node does nothing when waiting for prohibitively slow responses.

## Description
Rewritten the pattern to async producer/consumer queue of configurable SEARCH_QUEUE_DEPTH so all threads can be kept busy even if requests of uneven response speed are encountered. This should speed search times considerably when using a lot of threads (tested with 25 and up to 100).

Also **added retrying** in case server responds with invalid response which can start happening in very high throughput scenarios (previously thread gave up upon encountering log.error('Scan step {:d} failed. Response dictionary key error.'.format(step), creating gaps)

This should bring multiple workers + one server scenario a step closer to reality.

## Motivation and Context
Scalability of current solution is poor as adding more search threads can start slowing the entire process due to current wait_for_join(slowest_thread_of_the_batch)

## How Has This Been Tested?
Tested thoroughly with --threads 25 and seen a dramatic rise in search performance - test for yourself and see.
Note: --threads 100 often causes niantic servers to stop responding properly if on a fast connection - we need to implement adaptive delays for such low-latency scenarios.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
