### PR TITLE
Added longpress to change location

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -306,6 +306,25 @@ function createSearchMarker() {
                 }
             });
     });
+    
+    var longpress = false;
+    google.maps.event.addListener(map, 'mousedown', function(e) { 
+        longpress = true;
+        setTimeout(function() {
+            if(longpress === true) {
+                changeSearchLocation(e.latLng.lat(), e.latLng.lng())
+                    .done(function() {
+                        marker.setPosition(e.latLng);
+                    });
+            }
+        }, 3000);
+    });
+    google.maps.event.addListener(map, 'mouseup', function(e) { 
+        longpress = false;
+    });
+    google.maps.event.addListener(map, 'dragstart', function(e) { 
+        longpress = false;
+    });
 
     return marker;
 }

--- a/static/map.js
+++ b/static/map.js
@@ -322,7 +322,7 @@ function createSearchMarker() {
     google.maps.event.addListener(map, 'mouseup', function(e) { 
         longpress = false;
     });
-    google.maps.event.addListener(map, 'dragstart', function(e) { 
+    google.maps.event.addListener(map, 'drag', function(e) { 
         longpress = false;
     });
 

--- a/static/map.js
+++ b/static/map.js
@@ -317,7 +317,7 @@ function createSearchMarker() {
                         marker.setPosition(e.latLng);
                     });
             }
-        }, 3000);
+        }, 1000);
     });
     google.maps.event.addListener(map, 'mouseup', function(e) { 
         longpress = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Click and hold the map 3-seconds to change the next location and map pin.

## Motivation and Context
Easily change the location without needing the search box and doesn't require access to the original pin to drag so you can change the location farther distances.  Doesn't break zooming with double click and is mobile friendly.

## How Has This Been Tested?
Tested on PC and Android in Chrome.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

