### PR TITLE
Minimize update-size in raw_data

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -8,7 +8,7 @@ from flask import Flask, jsonify, render_template, request
 from flask.json import JSONEncoder
 from flask_compress import Compress
 from datetime import datetime
-from dateutil import parser
+import time
 from s2sphere import *
 from pogom.utils import get_args, get_pokemon_name
 
@@ -18,13 +18,6 @@ from .models import Pokemon, Gym, Pokestop, ScannedLocation
 args = get_args()
 log = logging.getLogger(__name__)
 compress = Compress()
-
-from datetime import datetime, tzinfo, timedelta
-class simple_utc(tzinfo):
-    def tzname(self):
-        return "UTC"
-    def utcoffset(self, dt):
-        return timedelta(0)
 
 class Pogom(Flask):
     def __init__(self, import_name, **kwargs):
@@ -61,9 +54,10 @@ class Pogom(Flask):
         lastUpdate = request.args.get('lastUpdate')
 
         if lastUpdate:
-            lastUpdate = parser.parse(lastUpdate)
+            lastUpdate = datetime.fromtimestamp(float(lastUpdate))
 
-        d['updateTime'] = now.replace(tzinfo=simple_utc()).isoformat()
+        # Use unix time in JSON
+        d['updateTime'] = time.mktime(now.timetuple())
 
         if request.args.get('pokemon', 'true') == 'true':
             pokemons = (Pokemon.select()

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -104,7 +104,8 @@ def insert_mock_data():
                        latitude=locations[i][0],
                        longitude=locations[i][1],
                        disappear_time=disappear_time,
-                       detect_time=detect_time)
+                       detect_time=detect_time,
+                       last_modified=detect_time)
 
     for i in range(num_pokestop):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ protobuf-to-dict==0.1.0
 PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0
+python-dateutil==2.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,3 @@ protobuf-to-dict==0.1.0
 PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0
-python-dateutil==2.5.3

--- a/static/map.js
+++ b/static/map.js
@@ -746,7 +746,7 @@ function loadRawData() {
             'swLng': swLng,
             'neLat': neLat,
             'neLng': neLng,
-            'lastUpdate': lastUpdateTime ? lastUpdateTime.toISOString() : null
+            'lastUpdate': lastUpdateTime ? lastUpdateTime.getTime() : null
         },
         dataType: "json",
         beforeSend: function() {
@@ -875,7 +875,8 @@ function processScanned(i, item) {
 function updateMap() {
 
     loadRawData().done(function (result) {
-        lastUpdateTime = new Date(Date.parse(result.updateTime));
+        console.log(result.pokemons.length);
+        lastUpdateTime = new Date(result.updateTime);
         $.each(result.pokemons, processPokemons);
         $.each(result.pokestops, processPokestops);
         $.each(result.pokestops, processLuredPokemon);


### PR DESCRIPTION
## Description
This optimizes the updates send using `raw_data` to only contain items that were changed in-between updates.

### Database

This adds `last_modified` to Pokemon, so that the server knows when a Pokemon was found.
This also restructures the queries, so that lastModified can be used optionally.

### Server

This restructures the `raw_data` function a bit so that queries are done in a more flexible manner. This was not required, but it made the resulting code smaller and (imo) more readable. Another side-effect is that the viewmodels are created in `app.py` instead of `model.py`. It seemed to me `model.py` should only contain the database models.

### Client

The client now tracks when it was last updated and with what parameters (bounds, showPokemon, showGym, etc). If the parameters stay the same, a minimal update can be done. If the parameters do change (by moving the map) a full update is required.

## Motivation and Context

I have a limited data subscription on my phone and sending over the whole set of pokemon, pokestops and gyms every 5 seconds took quite a bit of data.

## How Has This Been Tested?

Ran on my PC. Checked network activity in browser and checked console.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
