### PR TITLE
Remove pokemon_name from json payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # PokemonGo Map![Python 2.7](https://img.shields.io/badge/python-2.7-blue.svg)[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.me/PoGoMapDev)
 
-
 Live visualization of all the pokemon (with option to show gyms and pokestops) in your area. This is a proof of concept that we can load all the pokemon visible nearby given a location. Currently runs on a Flask server displaying a Google Maps with markers on it.
 
 [![Deploy](https://raw.githubusercontent.com/sych74/PokemonGo-Map-in-Cloud/master/images/deploy-to-jelastic.png)](https://jelastic.com/install-application/?manifest=https://raw.githubusercontent.com/sych74/PokemonGo-Map-in-Cloud/master/manifest.jps) [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://github.com/AHAAAAAAA/PokemonGo-Map/wiki/Heroku-Deployment) 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -11,7 +11,7 @@ from datetime import timedelta
 from base64 import b64encode
 
 from . import config
-from .utils import get_pokemon_name, load_credentials, get_args
+from .utils import load_credentials, get_args
 from .transform import transform_from_wgs_to_gcj
 from .customLog import printPokemon
 
@@ -84,7 +84,6 @@ class Pokemon(BaseModel):
 
         pokemons = []
         for p in query:
-            p['pokemon_name'] = get_pokemon_name(p['pokemon_id'])
             if args.china:
                 p['latitude'], p['longitude'] = \
                     transform_from_wgs_to_gcj(p['latitude'], p['longitude'])
@@ -113,7 +112,6 @@ class Pokemon(BaseModel):
 
         pokemons = []
         for p in query:
-            p['pokemon_name'] = get_pokemon_name(p['pokemon_id'])
             if args.china:
                 p['latitude'], p['longitude'] = \
                     transform_from_wgs_to_gcj(p['latitude'], p['longitude'])

--- a/static/map.js
+++ b/static/map.js
@@ -296,6 +296,10 @@ function calculateSpritePoints(num) {
     return new google.maps.Point(30 * x, 30 * y);
 }
 
+function getPokemonName(item) {
+  return idToPokemon[item.pokemon_id];
+}
+
 function setupPokemonMarker(item) {
     var icon = new google.maps.MarkerImage("static/icons-sprite.png", new google.maps.Size(30, 30), calculateSpritePoints(parseInt(item.pokemon_id)));
     var marker = new google.maps.Marker({
@@ -310,7 +314,7 @@ function setupPokemonMarker(item) {
     });
 
     marker.infoWindow = new google.maps.InfoWindow({
-        content: pokemonLabel(item.pokemon_name, item.disappear_time, item.pokemon_id, item.latitude, item.longitude, item.encounter_id)
+        content: pokemonLabel(getPokemonName(item), item.disappear_time, item.pokemon_id, item.latitude, item.longitude, item.encounter_id)
     });
 
     if (notifiedPokemon.indexOf(item.pokemon_id) > -1) {
@@ -318,7 +322,7 @@ function setupPokemonMarker(item) {
           audio.play();
         }
 
-        sendNotification('A wild ' + item.pokemon_name + ' appeared!', 'Click to load map', 'static/icons/' + item.pokemon_id + '.png', item.latitude, item.longitude);
+        sendNotification('A wild ' + getPokemonName(item) + ' appeared!', 'Click to load map', 'static/icons/' + item.pokemon_id + '.png', item.latitude, item.longitude);
         marker.setAnimation(google.maps.Animation.BOUNCE);
     }
 


### PR DESCRIPTION
This is part 1 of an attempt to reduce the json payload size.

## Description
Removes the `pokemon_name` key from the json object that is sent from the server to the client. The `pokemon_name` can be obtained in the client by mapping to the `idToPokemon` object that already exists in the client.

## Motivation and Context
This is  an attempt to further reduce the json payload size.

## How Has This Been Tested?
- Manual verification that the mapping data exists in the browser.
- Manual verification that the rendered map marker contains the mapped pokemon name.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

