### PR TITLE
Remove pokemon_name from json payload

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 from base64 import b64encode
 
 from . import config
-from .utils import get_pokemon_name, get_pokemon_rarity, get_pokemon_types, get_args, send_to_webhook
+from .utils import get_args, send_to_webhook
 from .transform import transform_from_wgs_to_gcj
 from .customLog import printPokemon
 
@@ -93,9 +93,6 @@ class Pokemon(BaseModel):
 
         pokemons = []
         for p in query:
-            p['pokemon_name'] = get_pokemon_name(p['pokemon_id'])
-            p['pokemon_rarity'] = get_pokemon_rarity(p['pokemon_id'])
-            p['pokemon_types'] = get_pokemon_types(p['pokemon_id'])
             if args.china:
                 p['latitude'], p['longitude'] = \
                     transform_from_wgs_to_gcj(p['latitude'], p['longitude'])
@@ -124,9 +121,6 @@ class Pokemon(BaseModel):
 
         pokemons = []
         for p in query:
-            p['pokemon_name'] = get_pokemon_name(p['pokemon_id'])
-            p['pokemon_rarity'] = get_pokemon_rarity(p['pokemon_id'])
-            p['pokemon_types'] = get_pokemon_types(p['pokemon_id'])
             if args.china:
                 p['latitude'], p['longitude'] = \
                     transform_from_wgs_to_gcj(p['latitude'], p['longitude'])

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -250,10 +250,6 @@ def get_pokemon_name(pokemon_id):
 def get_pokemon_rarity(pokemon_id):
     return i8ln(get_pokemon_data(pokemon_id)['rarity'])
 
-def get_pokemon_types(pokemon_id):
-    pokemon_types = get_pokemon_data(pokemon_id)['types']
-    return map(lambda x: {"type": i8ln(x['type']), "color": x['color']}, pokemon_types)
-
 def send_to_webhook(message_type, message):
     args = get_args()
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -388,20 +388,21 @@ function getTypeSpan(type) {
   return `<span style='padding: 2px 5px; text-transform: uppercase; color: white; margin-right: 2px; border-radius: 4px; font-size: 0.8em; vertical-align: text-bottom; background-color: ${type['color']}'>${type['type']}</span>`;
 }
 
-function pokemonLabel(name, rarity, types, disappear_time, id, latitude, longitude, encounter_id) {
-  var disappear_date = new Date(disappear_time);
-  var rarity_display = rarity ? '(' + rarity + ')' : "";
+function pokemonLabel(pokemon) {
+  var pokemon_info = idToPokemon[pokemon.pokemon_id]
+  var disappear_date = new Date(pokemon.disappear_time);
+  var rarity_display = pokemon_info.rarity ? '(' + pokemon_info.rarity + ')' : "";
   var types_display = "";
-  $.each(types, function(index, type) {
+  $.each(pokemon_info.types, function(index, type) {
     types_display += getTypeSpan(type);
   });
 
   var contentstring = `
     <div>
-      <b>${name}</b>
+      <b>${pokemon_info.name}</b>
       <span> - </span>
       <small>
-        <a href='http://www.pokemon.com/us/pokedex/${id}' target='_blank' title='View in Pokedex'>#${id}</a>
+        <a href='http://www.pokemon.com/us/pokedex/${pokemon.pokemon_id}' target='_blank' title='View in Pokedex'>#${pokemon.pokemon_id}</a>
       </small>
       <span> ${rarity_display}</span>
       <span> - </span>
@@ -409,16 +410,16 @@ function pokemonLabel(name, rarity, types, disappear_time, id, latitude, longitu
     </div>
     <div>
       Disappears at ${pad(disappear_date.getHours())}:${pad(disappear_date.getMinutes())}:${pad(disappear_date.getSeconds())}
-      <span class='label-countdown' disappears-at='${disappear_time}'>(00m00s)</span>
+      <span class='label-countdown' disappears-at='${pokemon_info.disappear_time}'>(00m00s)</span>
     </div>
     <div>
-      Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
+      Location: ${pokemon.latitude.toFixed(6)}, ${pokemon.longitude.toFixed(7)}
     </div>
     <div>
-      <a href='javascript:excludePokemon(${id})'>Exclude</a>&nbsp;&nbsp;
-      <a href='javascript:notifyAboutPokemon(${id})'>Notify</a>&nbsp;&nbsp;
-      <a href='javascript:removePokemonMarker("${encounter_id}")'>Remove</a>&nbsp;&nbsp;
-      <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}' target='_blank' title='View in Maps'>Get directions</a>
+      <a href='javascript:excludePokemon(${pokemon.pokemon_id})'>Exclude</a>&nbsp;&nbsp;
+      <a href='javascript:notifyAboutPokemon(${pokemon.pokemon_id})'>Notify</a>&nbsp;&nbsp;
+      <a href='javascript:removePokemonMarker("${pokemon.encounter_id}")'>Remove</a>&nbsp;&nbsp;
+      <a href='https://www.google.com/maps/dir/Current+Location/${pokemon.latitude},${pokemon.longitude}' target='_blank' title='View in Maps'>Get directions</a>
     </div>`;
   return contentstring;
 }
@@ -595,7 +596,7 @@ function setupPokemonMarker(item, skipNotification, isBounceDisabled) {
   });
 
   marker.infoWindow = new google.maps.InfoWindow({
-    content: pokemonLabel(item.pokemon_name, item.pokemon_rarity, item.pokemon_types, item.disappear_time, item.pokemon_id, item.latitude, item.longitude, item.encounter_id),
+    content: pokemonLabel(item),
     disableAutoPan: true
   });
 
@@ -604,7 +605,7 @@ function setupPokemonMarker(item, skipNotification, isBounceDisabled) {
       if (Store.get('playSound')) {
         audio.play();
       }
-      sendNotification('A wild ' + item.pokemon_name + ' appeared!', 'Click to load map', 'static/icons/' + item.pokemon_id + '.png', item.latitude, item.longitude);
+      sendNotification('A wild ' + idToPokemon[item.pokemon_id].name + ' appeared!', 'Click to load map', 'static/icons/' + item.pokemon_id + '.png', item.latitude, item.longitude);
     }
     if (marker.animationDisabled != true) {
       marker.setAnimation(google.maps.Animation.BOUNCE);


### PR DESCRIPTION
This is part 1 of an attempt to reduce the json payload size.

## Description
Removes the `pokemon_name` key from the json object that is sent from the server to the client. The `pokemon_name` can be obtained in the client by mapping to the `idToPokemon` object that already exists in the client.

## Motivation and Context
This is  an attempt to further reduce the json payload size.

## How Has This Been Tested?
- Manual verification that the mapping data exists in the browser.
- Manual verification that the rendered map marker contains the mapped pokemon name.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

