### PR TITLE
Swapped loading of javascript tags map.js and googlemaps

### DIFF
--- a/templates/map.html
+++ b/templates/map.html
@@ -143,7 +143,8 @@
 		var center_lng = {{lng}};
 	</script>
 
-	<script async defer src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&amp;callback=initMap&amp;libraries=places"></script>
+
 	<script src="static/map.js"></script>
+	<script src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&amp;callback=initMap&amp;libraries=places"></script>
 	</body>
 </html>

--- a/templates/map.html
+++ b/templates/map.html
@@ -144,7 +144,7 @@
 	</script>
 
 
-	<script src="static/map.js"></script>
-	<script src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&amp;callback=initMap&amp;libraries=places"></script>
+    <script defer src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&amp;callback=initMap&amp;libraries=places"></script>
+    <script src="static/map.js"></script>
 	</body>
 </html>

--- a/templates/map.html
+++ b/templates/map.html
@@ -144,7 +144,7 @@
 	</script>
 
 
-    <script defer src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&amp;callback=initMap&amp;libraries=places"></script>
-    <script src="static/map.js"></script>
+	<script defer src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&amp;callback=initMap&amp;libraries=places"></script>
+	<script src="static/map.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
Changed loading of app and gmaps javascript

## Description
I reversed the loading of javascript on the bottom of the page.

## Motivation and Context
I often got errors while reloading the page saying that function "initMap" not found in gmaps api callback in script tag.
`<script src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&amp;callback=initMap&amp;libraries=places"></script>`
There were probably race conditions in loading the script tags.
I also removed async and defer loading because it is not really needed in my opinion.

## How Has This Been Tested?
Tested locally and on Heroku.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

