### PR TITLE
Use local ding, instead of one from github

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -255,7 +255,7 @@ map_gyms = {} // Gyms
 map_pokestops = {} // Pokestops
 map_scanned = {} // Pokestops
 var gym_types = ["Uncontested", "Mystic", "Valor", "Instinct"];
-var audio = new Audio('https://github.com/AHAAAAAAA/PokemonGo-Map/raw/develop/static/sounds/ding.mp3');
+var audio = new Audio('static/sounds/ding.mp3');
 
 function setupPokemonMarker(item) {
     var marker = new google.maps.Marker({


### PR DESCRIPTION
map.js is hard-coded to use ding.mp3 from GitHub, making it impossible to replace ding.mp3 with something less likely to wake the baby up.

## Description
Just use the local one, so you can replace ding.mp3 if you want.

## Motivation and Context
This was probably not meant to be hard-coded as it was.

## How Has This Been Tested?
Works great on my personal instance!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

