### PR TITLE
allow fixing map settings

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -30,17 +30,20 @@ class Pogom(Flask):
 
     def fullmap(self):
         args = get_args()
-        display = "inline"
+        display_location = "inline"
+        display_settings = "inline"
         if args.fixed_location:
-            display = "none"
-        
+            display_location = "none"
+        if args.fixed_settings:
+            display_settings = "none"
+
         return render_template('map.html',
                                lat=config['ORIGINAL_LATITUDE'],
                                lng=config['ORIGINAL_LONGITUDE'],
                                gmaps_key=config['GMAPS_KEY'],
                                lang=config['LOCALE'],
-                               is_fixed=display
-                               )
+                               is_fixed_location=display_location,
+                               is_fixed_settings=display_settings)
 
     def raw_data(self):
         d = {}

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -86,6 +86,7 @@ def get_args():
     parser.add_argument('-ns', '--no-server', help='No-Server Mode. Starts the searcher but not the Webserver.', action='store_true', default=False, dest='no_server')
     parser.add_argument('-os', '--only-server', help='Server-Only Mode. Starts only the Webserver without the searcher.', action='store_true', default=False, dest='only_server')
     parser.add_argument('-fl', '--fixed-location', help='Hides the search bar for use in shared maps.', action='store_true', default=False, dest='fixed_location')
+    parser.add_argument('-fs', '--fixed-settings', help='Hides the settings for use in shared maps.', action='store_true', default=False, dest='fixed_settings')
     parser.add_argument('-k', '--google-maps-key', help='Google Maps Javascript API Key', default=None, dest='gmaps_key')
     parser.add_argument('-C', '--cors', help='Enable CORS on web server', action='store_true', default=False)
     parser.add_argument('-D', '--db', help='Database filename', default='pogom.db')

--- a/templates/map.html
+++ b/templates/map.html
@@ -38,93 +38,97 @@
 	<div class="wrapper">
 		<!-- Header -->
 		<header id="header">
-			<a href="#nav">Options</a>
+      {% if  is_fixed_location == 'inline' or  is_fixed_settings == 'inline'%}
+			  <a href="#nav">Options</a>
+      {% endif %}
 			<h1><a href="#">Pokémon Go Map</a></h1>
 		</header>
 
 		<!-- Nav -->
 		<nav id="nav">
-			<div class="form-control" style="display:{{is_fixed}}" >
+			<div class="form-control" style="display:{{is_fixed_location}}" >
 				<label for="next-location">
 					<h3>Change your location</h3>
 					<input id="next-location" type="text" name="next-location" placeholder="Change your location">
 				</label>
 				<hr width="100%">
 			</div>
-			<p>Select markers to be visible on map.</p>
-			<div class="form-control switch-container">
-				<h3>Wild Pokémon</h3>
-				<div class="onoffswitch">
-					<input id="pokemon-switch" type="checkbox" name="pokemon-switch" class="onoffswitch-checkbox" checked>
-					<label class="onoffswitch-label" for="pokemon-switch">
-	        				<span class="switch-label" data-on="On" data-off="Off"></span>
-	        				<span class="switch-handle"></span>
-				        </label>
-				</div>
-			</div>
-			<div class="form-control switch-container">
-				<h3>Lured Pokemon</h3>
-				<div class="onoffswitch">
-					<input id="lured-pokemon-switch" type="checkbox" name="lured-pokemon-switch" class="onoffswitch-checkbox" checked/>
-					<label class="onoffswitch-label" for="lured-pokemon-switch">
-						<span class="switch-label" data-on="On" data-off="Off"></span>
-						<span class="switch-handle"></span>
-					</label>
-				</div>
-			</div>
-			<div class="form-control switch-container">
-				<h3>Gyms</h3>
-				<div class="onoffswitch">
-					<input id="gyms-switch" type="checkbox" name="gyms-switch" class="onoffswitch-checkbox" checked>
-					<label class="onoffswitch-label" for="gyms-switch">
-	        				<span class="switch-label" data-on="On" data-off="Off"></span>
-	        				<span class="switch-handle"></span>
-	        			</label>
-				</div>
-			</div>
-			<div class="form-control switch-container">
-				<h3>Pokéstops</h3>
-				<div class="onoffswitch">
-					<input id="pokestops-switch" type="checkbox" name="pokestops-switch" class="onoffswitch-checkbox" checked>
-					<label class="onoffswitch-label" for="pokestops-switch">
-						<span class="switch-label" data-on="On" data-off="Off"></span>
-						<span class="switch-handle"></span>
-					</label>
-				</div>
-			</div>
-			<div class="form-control switch-container">
-				<h3>Scanned Locations</h3>
-				<div class="onoffswitch">
-					<input id="scanned-switch" type="checkbox" name="scanned-switch" class="onoffswitch-checkbox">
-					<label class="onoffswitch-label" for="scanned-switch">
-						<span class="switch-label" data-on="On" data-off="Off"></span>
-						<span class="switch-handle"></span>
-					</label>
-				</div>
-			</div>
-			<hr width="100%">
-			<div class="form-control">
-				<label for="exclude-pokemon">
-					<h3>Hide common Pokémon</h3>
-      					<select id="exclude-pokemon" multiple="multiple"></select>
-    				</label>
-			</div>
-			<div class="form-control">
-				<label for="notify-pokemon">
-					<h3>Notify of Pokémon</h3>
-					<select id="notify-pokemon" multiple="multiple"></select>
-				</label>
-			</div>
-			<div class="form-control switch-container">
-				<h3>Notify with sound</h3>
-				<div class="onoffswitch">
-					<input id="sound-switch" type="checkbox" name="sound-switch" class="onoffswitch-checkbox" checked>
-					<label class="onoffswitch-label" for="sound-switch">
-						<span class="switch-label" data-on="On" data-off="Off"></span>
-						<span class="switch-handle"></span>
-					</label>
-				</div>
-			</div>
+      <div style="display:{{is_fixed_settings}}">
+			  <p>Select markers to be visible on map.</p>
+        <div class="form-control switch-container">
+          <h3>Wild Pokémon</h3>
+          <div class="onoffswitch">
+            <input id="pokemon-switch" type="checkbox" name="pokemon-switch" class="onoffswitch-checkbox" checked>
+            <label class="onoffswitch-label" for="pokemon-switch">
+                    <span class="switch-label" data-on="On" data-off="Off"></span>
+                    <span class="switch-handle"></span>
+                  </label>
+          </div>
+        </div>
+        <div class="form-control switch-container">
+          <h3>Lured Pokemon</h3>
+          <div class="onoffswitch">
+            <input id="lured-pokemon-switch" type="checkbox" name="lured-pokemon-switch" class="onoffswitch-checkbox" checked/>
+            <label class="onoffswitch-label" for="lured-pokemon-switch">
+              <span class="switch-label" data-on="On" data-off="Off"></span>
+              <span class="switch-handle"></span>
+            </label>
+          </div>
+        </div>
+        <div class="form-control switch-container">
+          <h3>Gyms</h3>
+          <div class="onoffswitch">
+            <input id="gyms-switch" type="checkbox" name="gyms-switch" class="onoffswitch-checkbox" checked>
+            <label class="onoffswitch-label" for="gyms-switch">
+                    <span class="switch-label" data-on="On" data-off="Off"></span>
+                    <span class="switch-handle"></span>
+                  </label>
+          </div>
+        </div>
+        <div class="form-control switch-container">
+          <h3>Pokéstops</h3>
+          <div class="onoffswitch">
+            <input id="pokestops-switch" type="checkbox" name="pokestops-switch" class="onoffswitch-checkbox" checked>
+            <label class="onoffswitch-label" for="pokestops-switch">
+              <span class="switch-label" data-on="On" data-off="Off"></span>
+              <span class="switch-handle"></span>
+            </label>
+          </div>
+        </div>
+        <div class="form-control switch-container">
+          <h3>Scanned Locations</h3>
+          <div class="onoffswitch">
+            <input id="scanned-switch" type="checkbox" name="scanned-switch" class="onoffswitch-checkbox">
+            <label class="onoffswitch-label" for="scanned-switch">
+              <span class="switch-label" data-on="On" data-off="Off"></span>
+              <span class="switch-handle"></span>
+            </label>
+          </div>
+        </div>
+        <hr width="100%">
+        <div class="form-control">
+          <label for="exclude-pokemon">
+            <h3>Hide common Pokémon</h3>
+                  <select id="exclude-pokemon" multiple="multiple"></select>
+              </label>
+        </div>
+        <div class="form-control">
+          <label for="notify-pokemon">
+            <h3>Notify of Pokémon</h3>
+            <select id="notify-pokemon" multiple="multiple"></select>
+          </label>
+        </div>
+        <div class="form-control switch-container">
+          <h3>Notify with sound</h3>
+          <div class="onoffswitch">
+            <input id="sound-switch" type="checkbox" name="sound-switch" class="onoffswitch-checkbox" checked>
+            <label class="onoffswitch-label" for="sound-switch">
+              <span class="switch-label" data-on="On" data-off="Off"></span>
+              <span class="switch-handle"></span>
+            </label>
+          </div>
+        </div>
+      </div>
 		</nav>
 
 		<div id="map"></div>

--- a/templates/map.html
+++ b/templates/map.html
@@ -40,6 +40,8 @@
 		<header id="header">
       {% if  is_fixed_location == 'inline' or  is_fixed_settings == 'inline'%}
 			  <a href="#nav">Options</a>
+      {% else %}
+        <a></a>
       {% endif %}
 			<h1><a href="#">Pokémon Go Map</a></h1>
 		</header>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Similar to #1616 , this allows for disabling the settings and filters on shared servers

## Description

- Adds an optional additional flag `-fs` that disables the settings in the options menu
- Removes the options button completely if both setting and location are fixed

## Motivation and Context

Same reasoning than merged PR #1616, only for settings:

> This allows users to hide the search bar by using the -fl (fixed location) parameter. It is
> designated for use in shared maps where relocation of the marker is not desired.

and

> I have a map of my city I shared with my team members and ever since the search bar was 
> introduced people keep changing it.

## How Has This Been Tested?

Local server with all combinations

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.