### PR TITLE
make sure mock creates valid lured pokestops

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -110,7 +110,8 @@ def insert_mock_data():
                         longitude=locations[i+num_pokemon][1],
                         last_modified=datetime.now(),
                         #Every other pokestop be lured
-                        lure_expiration=disappear_time if (i % 2 == 0) else None
+                        lure_expiration=disappear_time if (i % 2 == 0) else None,
+                        active_pokemon_id=i
                         )
 
     for i in range(num_gym):


### PR DESCRIPTION
## Description
Mock mode didn't set an active pokemon on lured pokestops. Now it does.

## Motivation and Context
I didn't like mock giving me invalid data and therefore `undefined` in the interface.

## How Has This Been Tested?
Run the server with `-m` and see whether lured pokestops have a pokemon.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

