### PR TITLE
Speed up JSON encoding

### DIFF
--- a/Easy Setup/requirements.txt
+++ b/Easy Setup/requirements.txt
@@ -16,3 +16,4 @@ protobuf-to-dict==0.1.0
 PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0
+simplejson==3.8.2

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -3,8 +3,9 @@
 
 import calendar
 import logging
+import simplejson as json
 
-from flask import Flask, jsonify, render_template, request
+from flask import Flask, render_template, request
 from flask.json import JSONEncoder
 from flask_compress import Compress
 from datetime import datetime
@@ -64,14 +65,14 @@ class Pogom(Flask):
         if request.args.get('scanned', 'true') == 'true':
             d['scanned'] = ScannedLocation.get_recent(swLat, swLng, neLat, neLng)
 
-        return jsonify(d)
+        return json.dumps(d, cls=self.json_encoder)
 
     def loc(self):
         d = {}
         d['lat']=config['ORIGINAL_LATITUDE']
         d['lng']=config['ORIGINAL_LONGITUDE']
 
-        return jsonify(d)
+        return json.dumps(d, cls=self.json_encoder)
 
     def next_loc(self):
         args = get_args()

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -65,14 +65,14 @@ class Pogom(Flask):
         if request.args.get('scanned', 'true') == 'true':
             d['scanned'] = ScannedLocation.get_recent(swLat, swLng, neLat, neLng)
 
-        return json.dumps(d, cls=self.json_encoder)
+        return json.dumps(d, cls=self.json_encoder), 200, {'Content-Type': 'application/json'}
 
     def loc(self):
         d = {}
         d['lat']=config['ORIGINAL_LATITUDE']
         d['lng']=config['ORIGINAL_LONGITUDE']
 
-        return json.dumps(d, cls=self.json_encoder)
+        return json.dumps(d, cls=self.json_encoder), 200, {'Content-Type': 'application/json'}
 
     def next_loc(self):
         args = get_args()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ protobuf-to-dict==0.1.0
 PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0
+simplejson==3.8.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Switch from the Flask's jsonify to remove a bottleneck.

## Motivation and Context
While processing a large amount of data server was really slow. I've narrowed down the issue.

## How Has This Been Tested?
Windows/Chrome/MySQL
With jsonify I ran ~20 threads and soon after 1500 rows serialization took about 20 seconds to process.
Simplejson managed to do it within 3 seconds.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the documentation.

