### PR TITLE
Add scan-here button

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -297,6 +297,11 @@ function initMap() {
     redrawPokemon(map_data.pokemons);
     redrawPokemon(map_data.lure_pokemons);
   });
+
+  $('#scan-here').on('click', function() {
+    var loc = map.getCenter();
+    changeLocation(loc.lat(), loc.lng());
+  });
 }
 
 function createSearchMarker() {

--- a/static/sass/layout/_main.scss
+++ b/static/sass/layout/_main.scss
@@ -31,3 +31,26 @@ html, body {
 	bottom: 0px;
   width: 100%;
 }
+
+.fab {
+  background: darken(_palette(accent2, bg), 12);
+  color: _palette(accent2, fg);
+  width:30px;
+  height:30px;
+  border-radius:100%;
+  border:none;
+  outline:none;
+  font-size:19px;
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  transition:.3s;
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  text-align: center;
+  @include icon('\f05b');
+}
+
+#scan-here {
+  position: fixed;
+  left: 50%;
+  margin-left: -15px;
+  bottom: 1.5em;
+}

--- a/templates/map.html
+++ b/templates/map.html
@@ -172,6 +172,7 @@
 		</div>
 	  </nav>
       <div id="map"></div>
+      <div class="fab" id="scan-here" style="display:{{is_fixed}}"></div>
     </div>
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.9.1/polyfill.min.js"></script>


### PR DESCRIPTION
## Description
Adds a "scan here" link to the header. When clicked/touched, will set the current map center as new search location.

## Motivation and Context
When outside hunting Pokemon you often want to check a few nearby places before deciding which way to go. This is way more convenient when you can just move the map one or two kilometers/miles and tap "scan here" instead of having to type in the name of some location.

## How Has This Been Tested?
Tested using docker.

## Types of changes
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the code style of this project. (I think?)

