### PR TITLE
Hotfix to clone PGoAPI object when about to make multi-threaded calls.

### DIFF
--- a/pogom/pgoapi/pgoapi.py
+++ b/pogom/pgoapi/pgoapi.py
@@ -54,6 +54,17 @@ class PGoApi:
         self._position_alt = 0
 
         self._req_method_list = []
+
+    def copy(self):
+        other = PGoApi()
+        other.log = self.log
+        other._auth_provider = self._auth_provider
+        other._api_endpoint = self._api_endpoint
+        other._position_lat = self._position_lat
+        other._position_lng = self._position_lng
+        other._position_alt = self._position_alt
+        other._req_method_list = list(self._req_method_list)
+        return other
         
     def call(self):
         if not self._req_method_list:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -36,12 +36,13 @@ def calculate_lng_degrees(lat):
 
 def send_map_request(api, position):
     try:
-        api.set_position(*position)
-        api.get_map_objects(latitude=f2i(position[0]),
+        api_copy = api.copy()
+        api_copy.set_position(*position)
+        api_copy.get_map_objects(latitude=f2i(position[0]),
                             longitude=f2i(position[1]),
                             since_timestamp_ms=TIMESTAMP,
                             cell_id=get_cellid(position[0], position[1]))
-        return api.call()
+        return api_copy.call()
     except Exception as e:
         log.warning("Uncaught exception when downloading map " + str(e))
         return False


### PR DESCRIPTION
This is a temporary hotfix to https://github.com/AHAAAAAAA/PokemonGo-Map/issues/1897 causing missing pokemon from cells. It should be replaced by https://github.com/AHAAAAAAA/PokemonGo-Map/pull/1910 as soon as possible.

## Description
Implemented cloning of entire PGoApi object when about to be used in concurrent environment. Lazy hack but at least the map scans won't be incomplete anymore.

## Motivation and Context
See https://github.com/AHAAAAAAA/PokemonGo-Map/issues/1897

## How Has This Been Tested?
Not very much, please test. I've run out of time today.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

!TEMPORARY!  This should be removed and replaced by appropriate refactor.