### PR TITLE
Add/remove bounce animation when notification list changes

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1110,6 +1110,24 @@ function centerMap(lat, lng, zoom) {
   }
 }
 
+function updateNotifiedPokemom() {
+  notifiedPokemon = $selectNotify.val().map(Number);
+  Store.set('remember_select_notify', notifiedPokemon);
+
+  $.each(map_data.pokemons, function(encounterId, item) {
+    if ( item.marker ) {
+      if (notifiedPokemon.indexOf(item.pokemon_id) > -1) {
+        if (!item.marker.animationDisabled && !item.marker.getAnimation() ) {
+          item.marker.setAnimation(google.maps.Animation.BOUNCE);
+        }
+      }
+      else {
+        item.marker.setAnimation(null);   
+      }
+    }
+  });
+}
+
 function i8ln(word) {
   if ($.isEmptyObject(i8ln_dictionary) && language != "en" && language_lookups < language_lookup_threshold) {
     $.ajax({
@@ -1241,8 +1259,7 @@ $(function() {
       Store.set('remember_select_exclude', excludedPokemon);
     });
     $selectNotify.on("change", function(e) {
-      notifiedPokemon = $selectNotify.val().map(Number);
-      Store.set('remember_select_notify', notifiedPokemon);
+    updateNotifiedPokemom()
     });
 
     // recall saved lists


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If Pokemon are added to the notification list, any matches on the map don't animate without a refresh. Vice versa when removing Pokemon from the notification list. This fixes that by updating marker animation when necessary

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes an issue from a comment in PR 1831: https://github.com/AHAAAAAAA/PokemonGo-Map/pull/1831#issuecomment-234792365

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Chrome in Windows and Android. Tested for animation changes when adding/removing Pokemon from notification list

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

