### PR TITLE
Fix clicking "notified" Pokemon and bounce animation on mobile

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -954,25 +954,38 @@ function getPointDistance(pointA, pointB) {
 }
 
 function sendNotification(title, text, icon, lat, lng) {
-  if (!("Notification" in window)) {
-    return false; // Notifications are not present in browser
+  try
+  {
+    if (!("Notification" in window)) {
+      return false; // Notifications are not present in browser
+    }
+
+    if (Notification.permission !== "granted") {
+      Notification.requestPermission();
+    } else {
+      var notification = new Notification(title, {
+        icon: icon,
+        body: text,
+        sound: 'sounds/ding.mp3'
+      });
+
+      notification.onclick = function() {
+        window.focus();
+        notification.close();
+
+        centerMap(lat, lng, 20);
+      };
+    }        
   }
-
-  if (Notification.permission !== "granted") {
-    Notification.requestPermission();
-  } else {
-    var notification = new Notification(title, {
-      icon: icon,
-      body: text,
-      sound: 'sounds/ding.mp3'
-    });
-
-    notification.onclick = function() {
-      window.focus();
-      notification.close();
-
-      centerMap(lat, lng, 20);
-    };
+  catch(e) // Gotta catch em all!
+  {
+    // Some browsers will throw when creating the Notifcation object, 
+    // with an error pointing us towards ServiceWorkerRegistration.showNotification.
+    // Just eat exceptions until someone can implement that.
+    
+    if ( window.console ) {
+      console.log(e);
+    }
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Chrome on mobile wants us to use ServiceWorkerRegistration.showNotification() for notifications, and will throw an exception if we try to create a Notification object. This exception is isn't caught, which causes our click handler to fail.

Fixed to catch the exception (and log it in case anyone is watching), and also try to avoid sending notifications for browsers that don't support them at all.

Does *not* fix notifications on mobile. That's going to take more work.

Some tab->space fixes snuck in as well by accident, but it looks like that's the style we want, so I left them.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/AHAAAAAAA/PokemonGo-Map/issues/1493 . Also fixes bounce animation on mobile (from comment in https://github.com/AHAAAAAAA/PokemonGo-Map/pull/1831)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Chrome in Windows and Android. Added/remove Pokemon from notification list, verified that (on Windows) notifications worked and all Pokemon were still clickable.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
