### PR TITLE
Fixed dropdown of Icon size after page load

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -210,7 +210,7 @@ function initSidebar() {
         icons.append($('<option></option>').attr("value", key).text(value.name));
     });
     icons.val((pokemon_sprites[localStorage.pokemonIcons]) ? localStorage.pokemonIcons : 'highres');
-    $('#pokemon-icon-size').val(localStorage.iconModifierSize || 0);
+    $('#pokemon-icon-size').val(localStorage.iconSizeModifier || 0);
 }
 
 function pad(number) { return number <= 99 ? ("0" + number).slice(-2) : number; }


### PR DESCRIPTION

## Description
New switcher for icons (quality and size) contains bug, where icon size is not properly loaded from localStorage. This pull request fixes it.


## How Has This Been Tested?
Tested on lastest Chrome beta and iPhone (Safari, iOS 9.x)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

