### PR TITLE
Added bounce animation end on click

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -339,6 +339,10 @@ function setupPokemonMarker(item) {
         map: map,
         icon: icon,
     });
+    
+    marker.addListener('click', function() {
+        this.setAnimation(null);
+    });
 
     marker.infoWindow = new google.maps.InfoWindow({
         content: pokemonLabel(item.pokemon_name, item.disappear_time, item.pokemon_id, item.latitude, item.longitude, item.encounter_id),
@@ -352,7 +356,6 @@ function setupPokemonMarker(item) {
 
         sendNotification('A wild ' + item.pokemon_name + ' appeared!', 'Click to load map', 'static/icons/' + item.pokemon_id + '.png', item.latitude, item.longitude);
         marker.setAnimation(google.maps.Animation.BOUNCE);
-        setTimeout(function(){ marker.setAnimation(null); }, 3000);
     }
 
     addListeners(marker);

--- a/static/map.js
+++ b/static/map.js
@@ -352,6 +352,7 @@ function setupPokemonMarker(item) {
 
         sendNotification('A wild ' + item.pokemon_name + ' appeared!', 'Click to load map', 'static/icons/' + item.pokemon_id + '.png', item.latitude, item.longitude);
         marker.setAnimation(google.maps.Animation.BOUNCE);
+        setTimeout(function(){ marker.setAnimation(null); }, 3000);
     }
 
     addListeners(marker);


### PR DESCRIPTION
## Description
3 lines added that makes sure the animation ends when the marker is clicked

## Motivation and Context
Prevents continuous loop of bouncing pokémon ( #1955 )

## How Has This Been Tested?
By running the setup several times on Linux and Windows.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

