### PR TITLE
Ability to display only Lure Pokestops (AHAAAAAAA#1954)

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -782,7 +782,6 @@ function processPokestops(i, item) {
         item2 = map_data.pokestops[item.pokestop_id];
         if (!!item.lure_expiration != !!item2.lure_expiration || item.active_pokemon_id != item2.active_pokemon_id) {
             item2.marker.setMap(null);
-            item.marker.setMap(null);
             item.marker = setupPokestopMarker(item);
             map_data.pokestops[item.pokestop_id] = item;
         }

--- a/static/map.js
+++ b/static/map.js
@@ -134,7 +134,7 @@ var StoreOptions = {
         default: true,
         type: StoreTypes.Boolean
     },
-    showLuredPokestops: {
+    showLuredPokestopsOnly: {
         default: 0,
         type: StoreTypes.Number
     },
@@ -318,7 +318,7 @@ function initSidebar() {
     $('#gyms-switch').prop('checked', Store.get('showGyms'));
     $('#pokemon-switch').prop('checked', Store.get('showPokemon'));
     $('#pokestops-switch').prop('checked', Store.get('showPokestops'));
-    $('#lured-pokestops-switch').val(Store.get('showLuredPokestops'));
+    $('#lured-pokestops-only-switch').val(Store.get('showLuredPokestopsOnly'));
     $('#geoloc-switch').prop('checked', Store.get('geoLocate'));
     $('#scanned-switch').prop('checked', Store.get('showScanned'));
     $('#sound-switch').prop('checked', Store.get('playSound'));
@@ -765,11 +765,16 @@ function processPokestops(i, item) {
     if (!Store.get('showPokestops')) {
         return false;
     }
+    if (Store.get('showLuredPokestopsOnly') && !item.lure_expiration) {
+        if (map_data.pokestops[item.pokestop_id] && map_data.pokestops[item.pokestop_id].marker) {
+            map_data.pokestops[item.pokestop_id].marker.setMap(null);
+            delete map_data.pokestops[item.pokestop_id];
+        }
+        return true;
+    }
     if (map_data.pokestops[item.pokestop_id] == null) { // add marker to map and item to dict
         // add marker to map and item to dict
-        if (item.marker) {
-            item.marker.setMap(null);
-        }
+        if (item.marker) item.marker.setMap(null);
         item.marker = setupPokestopMarker(item);
         map_data.pokestops[item.pokestop_id] = item;
     }
@@ -777,7 +782,7 @@ function processPokestops(i, item) {
         item2 = map_data.pokestops[item.pokestop_id];
         if (!!item.lure_expiration != !!item2.lure_expiration || item.active_pokemon_id != item2.active_pokemon_id) {
             item2.marker.setMap(null);
-            if (item.marker) item.marker.setMap(null);
+            item.marker.setMap(null);
             item.marker = setupPokestopMarker(item);
             map_data.pokestops[item.pokestop_id] = item;
         }
@@ -1148,8 +1153,8 @@ $(function () {
     $('#scanned-switch').change(buildSwitchChangeListener(map_data, "scanned", "showScanned"));
 
 
-    $('#lured-pokestops-switch').change(function() {
-        Store.set("showLuredPokestops", this.value);
+    $('#lured-pokestops-only-switch').change(function() {
+        Store.set("showLuredPokestopsOnly", this.value);
         updateMap();
     });
 

--- a/static/map.js
+++ b/static/map.js
@@ -134,6 +134,10 @@ var StoreOptions = {
         default: true,
         type: StoreTypes.Boolean
     },
+    showLuredPokestops: {
+        default: 0,
+        type: StoreTypes.Number
+    },
     showScanned: {
         default: false,
         type: StoreTypes.Boolean
@@ -314,7 +318,7 @@ function initSidebar() {
     $('#gyms-switch').prop('checked', Store.get('showGyms'));
     $('#pokemon-switch').prop('checked', Store.get('showPokemon'));
     $('#pokestops-switch').prop('checked', Store.get('showPokestops'));
-    $('#lured-pokestops-switch').prop('checked', Store.get('showPokestops'));
+    $('#lured-pokestops-switch').val(Store.get('showLuredPokestops'));
     $('#geoloc-switch').prop('checked', Store.get('geoLocate'));
     $('#scanned-switch').prop('checked', Store.get('showScanned'));
     $('#sound-switch').prop('checked', Store.get('playSound'));
@@ -780,37 +784,6 @@ function processPokestops(i, item) {
     }
 }
 
-function processLuredPokestops(i, item) {
-    if (!(localStorage.showLuredPokestops === 'true')) {
-        return false;
-    }
-    if(!(item.lure_expiration)) {
-				if (map_data.pokestops[item.pokestop_id] && map_data.pokestops[item.pokestop_id].marker) {
-            map_data.pokestops[item.pokestop_id].marker.setMap(null);
-        }
-        return true;
-    }
-    if (map_data.pokestops[item.pokestop_id] == null) { // add marker to map and item to dict
-        // add marker to map and item to dict
-        if (item.marker) {
-            item.marker.setMap(null);
-        }
-        item.marker = setupPokestopMarker(item);
-        map_data.pokestops[item.pokestop_id] = item;
-    }
-    else {
-        item2 = map_data.pokestops[item.pokestop_id];
-        if (!!item.lure_expiration != !!item2.lure_expiration || item.active_pokemon_id != item2.active_pokemon_id) {
-            if (item.marker) {
-                item.marker.setMap(null);
-            }
->>>>>>> Ability to display only Lure Pokestops (AHAAAAAAA#1954)
-            item.marker = setupPokestopMarker(item);
-            map_data.pokestops[item.pokestop_id] = item;
-        }
-    }
-}
-
 function processLuredPokemon(i, item) {
     if (!Store.get('showPokemon')) {
         return false;
@@ -893,7 +866,6 @@ function updateMap() {
     loadRawData().done(function (result) {
         $.each(result.pokemons, processPokemons);
         $.each(result.pokestops, processPokestops);
-        $.each(result.pokestops, processLuredPokestops);
         $.each(result.pokestops, processLuredPokemon);
         $.each(result.gyms, processGyms);
         $.each(result.scanned, processScanned);
@@ -1173,8 +1145,13 @@ $(function () {
     $('#gyms-switch').change(buildSwitchChangeListener(map_data, "gyms", "showGyms"));
     $('#pokemon-switch').change(buildSwitchChangeListener(map_data, "pokemons", "showPokemon"));
     $('#pokestops-switch').change(buildSwitchChangeListener(map_data, "pokestops", "showPokestops"));
-    $('#lured-pokestops-switch').change(buildSwitchChangeListener(map_data, "pokestops", "showLuredPokestops"));
     $('#scanned-switch').change(buildSwitchChangeListener(map_data, "scanned", "showScanned"));
+
+
+    $('#lured-pokestops-switch').change(function() {
+        Store.set("showLuredPokestops", this.value);
+        updateMap();
+    });
 
     $('#sound-switch').change(function() {
         Store.set("playSound", this.checked);

--- a/static/map.js
+++ b/static/map.js
@@ -319,6 +319,7 @@ function initSidebar() {
     $('#pokemon-switch').prop('checked', Store.get('showPokemon'));
     $('#pokestops-switch').prop('checked', Store.get('showPokestops'));
     $('#lured-pokestops-only-switch').val(Store.get('showLuredPokestopsOnly'));
+    $('#lured-pokestops-only-wrapper').toggle(Store.get('showPokestops'));
     $('#geoloc-switch').prop('checked', Store.get('geoLocate'));
     $('#scanned-switch').prop('checked', Store.get('showScanned'));
     $('#sound-switch').prop('checked', Store.get('playSound'));
@@ -1148,9 +1149,17 @@ $(function () {
     // Setup UI element interactions
     $('#gyms-switch').change(buildSwitchChangeListener(map_data, "gyms", "showGyms"));
     $('#pokemon-switch').change(buildSwitchChangeListener(map_data, "pokemons", "showPokemon"));
-    $('#pokestops-switch').change(buildSwitchChangeListener(map_data, "pokestops", "showPokestops"));
     $('#scanned-switch').change(buildSwitchChangeListener(map_data, "scanned", "showScanned"));
 
+    $('#pokestops-switch').change(function () {
+        var options = {'duration': 500}, wrapper = $('#lured-pokestops-only-wrapper');
+        if (this.checked) {
+            wrapper.show(options);
+        } else {
+            wrapper.hide(options);
+        }
+        return buildSwitchChangeListener(map_data, "pokestops", "showPokestops").bind(this)();
+    });
 
     $('#lured-pokestops-only-switch').change(function() {
         Store.set("showLuredPokestopsOnly", this.value);

--- a/static/map.js
+++ b/static/map.js
@@ -314,6 +314,7 @@ function initSidebar() {
     $('#gyms-switch').prop('checked', Store.get('showGyms'));
     $('#pokemon-switch').prop('checked', Store.get('showPokemon'));
     $('#pokestops-switch').prop('checked', Store.get('showPokestops'));
+    $('#lured-pokestops-switch').prop('checked', Store.get('showPokestops'));
     $('#geoloc-switch').prop('checked', Store.get('geoLocate'));
     $('#scanned-switch').prop('checked', Store.get('showScanned'));
     $('#sound-switch').prop('checked', Store.get('playSound'));
@@ -762,7 +763,9 @@ function processPokestops(i, item) {
     }
     if (map_data.pokestops[item.pokestop_id] == null) { // add marker to map and item to dict
         // add marker to map and item to dict
-        if (item.marker) item.marker.setMap(null);
+        if (item.marker) {
+            item.marker.setMap(null);
+        }
         item.marker = setupPokestopMarker(item);
         map_data.pokestops[item.pokestop_id] = item;
     }
@@ -770,6 +773,38 @@ function processPokestops(i, item) {
         item2 = map_data.pokestops[item.pokestop_id];
         if (!!item.lure_expiration != !!item2.lure_expiration || item.active_pokemon_id != item2.active_pokemon_id) {
             item2.marker.setMap(null);
+            if (item.marker) item.marker.setMap(null);
+            item.marker = setupPokestopMarker(item);
+            map_data.pokestops[item.pokestop_id] = item;
+        }
+    }
+}
+
+function processLuredPokestops(i, item) {
+    if (!(localStorage.showLuredPokestops === 'true')) {
+        return false;
+    }
+    if(!(item.lure_expiration)) {
+				if (map_data.pokestops[item.pokestop_id] && map_data.pokestops[item.pokestop_id].marker) {
+            map_data.pokestops[item.pokestop_id].marker.setMap(null);
+        }
+        return true;
+    }
+    if (map_data.pokestops[item.pokestop_id] == null) { // add marker to map and item to dict
+        // add marker to map and item to dict
+        if (item.marker) {
+            item.marker.setMap(null);
+        }
+        item.marker = setupPokestopMarker(item);
+        map_data.pokestops[item.pokestop_id] = item;
+    }
+    else {
+        item2 = map_data.pokestops[item.pokestop_id];
+        if (!!item.lure_expiration != !!item2.lure_expiration || item.active_pokemon_id != item2.active_pokemon_id) {
+            if (item.marker) {
+                item.marker.setMap(null);
+            }
+>>>>>>> Ability to display only Lure Pokestops (AHAAAAAAA#1954)
             item.marker = setupPokestopMarker(item);
             map_data.pokestops[item.pokestop_id] = item;
         }
@@ -858,6 +893,7 @@ function updateMap() {
     loadRawData().done(function (result) {
         $.each(result.pokemons, processPokemons);
         $.each(result.pokestops, processPokestops);
+        $.each(result.pokestops, processLuredPokestops);
         $.each(result.pokestops, processLuredPokemon);
         $.each(result.gyms, processGyms);
         $.each(result.scanned, processScanned);
@@ -1137,6 +1173,7 @@ $(function () {
     $('#gyms-switch').change(buildSwitchChangeListener(map_data, "gyms", "showGyms"));
     $('#pokemon-switch').change(buildSwitchChangeListener(map_data, "pokemons", "showPokemon"));
     $('#pokestops-switch').change(buildSwitchChangeListener(map_data, "pokestops", "showPokestops"));
+    $('#lured-pokestops-switch').change(buildSwitchChangeListener(map_data, "pokestops", "showLuredPokestops"));
     $('#scanned-switch').change(buildSwitchChangeListener(map_data, "scanned", "showScanned"));
 
     $('#sound-switch').change(function() {

--- a/templates/map.html
+++ b/templates/map.html
@@ -87,7 +87,7 @@
 				</div>
 			</div>
       
-      <div class="form-control switch-container">
+			<div class="form-control switch-container">
 				<select name="lured-pokestops-switch" id="lured-pokestops-switch">
 					<option value="0">All</option>
 					<option value="1">Only lured</option>

--- a/templates/map.html
+++ b/templates/map.html
@@ -88,7 +88,7 @@
 			</div>
       
 			<div class="form-control switch-container">
-				<select name="lured-pokestops-switch" id="lured-pokestops-switch">
+				<select name="lured-pokestops-only-switch" id="lured-pokestops-only-switch">
 					<option value="0">All</option>
 					<option value="1">Only lured</option>
 				</select>

--- a/templates/map.html
+++ b/templates/map.html
@@ -88,6 +88,17 @@
 			</div>
 
 			<div class="form-control switch-container">
+				<h3>Lured Pokéstops</h3>
+				<div class="onoffswitch">
+					<input id="lured-pokestops-switch" type="checkbox" name="lured-pokestops-switch" class="onoffswitch-checkbox" checked>
+					<label class="onoffswitch-label" for="lured-pokestops-switch">
+						<span class="switch-label" data-on="On" data-off="Off"></span>
+						<span class="switch-handle"></span>
+					</label>
+				</div>
+			</div>
+
+			<div class="form-control switch-container">
 				<h3>Geolocation</h3>
 				<div class="onoffswitch">
 					<input id="geoloc-switch" type="checkbox" name="geoloc-switch" class="onoffswitch-checkbox" checked/>

--- a/templates/map.html
+++ b/templates/map.html
@@ -86,16 +86,12 @@
 					</label>
 				</div>
 			</div>
-
-			<div class="form-control switch-container">
-				<h3>Lured Pokéstops</h3>
-				<div class="onoffswitch">
-					<input id="lured-pokestops-switch" type="checkbox" name="lured-pokestops-switch" class="onoffswitch-checkbox" checked>
-					<label class="onoffswitch-label" for="lured-pokestops-switch">
-						<span class="switch-label" data-on="On" data-off="Off"></span>
-						<span class="switch-handle"></span>
-					</label>
-				</div>
+      
+      <div class="form-control switch-container">
+				<select name="lured-pokestops-switch" id="lured-pokestops-switch">
+					<option value="0">All</option>
+					<option value="1">Only lured</option>
+				</select>
 			</div>
 
 			<div class="form-control switch-container">

--- a/templates/map.html
+++ b/templates/map.html
@@ -87,10 +87,10 @@
 				</div>
 			</div>
       
-			<div class="form-control switch-container">
+			<div class="form-control switch-container" id="lured-pokestops-only-wrapper" style="display:none">
 				<select name="lured-pokestops-only-switch" id="lured-pokestops-only-switch">
 					<option value="0">All</option>
-					<option value="1">Only lured</option>
+					<option value="1">Only Lured</option>
 				</select>
 			</div>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added switcher to allow display only lured Pokestops

There is one thing I'm not sure about. It's loading of pokestops in raw_data, please verify it.

## How Has This Been Tested?
Tested on Chrome and iOS 9.x (iPhone 6)

## Screenshots (if appropriate):
![screenshot_20160725_122119](https://cloud.githubusercontent.com/assets/80399/17098394/64c1534e-5262-11e6-8581-3de9d67bd5ac.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

