### PR TITLE
Add `*.db-*` to gitignore.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ node_modules
 Easy\ Setup
 pogom.db
 core
+pogom.db-*

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.pyc
 *.idea
 *.db
-*.db-journal
+*.db-*
 *.sass-cache
 *.orig
 config/config.ini


### PR DESCRIPTION
The usecase for this is for people who set `PRAGMA journal_mode=WAL` on
their database.

Specifically, I was wanting to do some scripting (local pokemon rarity
lists, etc.) around the database, but I kept hitting lock issues, even
though I was just reading. Setting `WAL` fixes this, but causes sqlite
to create two extra files, `pogom.db-shm` and `pogom.db-wal`. Ignoring
them here ensures that there is less to worry about when pulling in
changes from the upstream or preparing diffs to send.

I realize that setting `WAL` is a fairly custom change and not supported
by the upstream, but I think the change here (in .gitignore) is minor
enough that it's worth future-proofing for myself and anyone else who
hits a similar scenario.