### PR TITLE
Loading pokemons hangs, when Notification is not supported in browser

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -772,6 +772,9 @@ function getPointDistance(pointA, pointB) {
 }
 
 function sendNotification(title, text, icon, lat, lng) {
+    if (!("Notification" in window)) {
+        return false; // Notifications are not present in browser
+    }
     if (Notification.permission !== "granted") {
         Notification.requestPermission();
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, when I enable notification for some type of pokemon, loading of pokemons freezes in my phone (iPhone 6, Safari browser), because Notification is not supported.

## How Has This Been Tested?
Tested in Safari on iOS and in desktop Chrome.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

