### PR TITLE
Fixed lured pokemon issue

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -659,7 +659,9 @@ function processLuredPokemon(i, item) {
         disappear_time: expire_time
     };
 
-    if (map_data.lure_pokemons[lured_pokemon.pokestop_id] == null) {
+    if (lured_pokemon.pokemon_id == null){
+        return;
+    } else if (map_data.lure_pokemons[lured_pokemon.pokestop_id] == null) {
         lured_pokemon.marker = setupPokemonMarker(lured_pokemon);
         map_data.lure_pokemons[lured_pokemon.pokestop_id] = lured_pokemon;
     } else if (lured_pokemon.active_pokemon_id !== map_data.lure_pokemons[lured_pokemon.pokestop_id].active_pokemon_id) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
processLuredPokemon in map.js did not account for if a given pokestop did not have any active lured pokemon, modified the if statement to add an initial test for if the pokestop had any active lured pokemon.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes #1984. When enabling the Lured Pokemon switch all pokestops would be overwritten with a pokemon marker. If that pokestop did not currently have any lured pokemon then it would be a null pokemon object overlayed on the pokestop. The marker was invisible but still active whenever the Lured Pokemon switch was on

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested and working with active lured and non-lured pokestops.

## Screenshots (if appropriate):
There is an applicable screenshot in #1984 of the issue, here is a screenshot showing the fix with an active luring pokestop and its pokemon but other pokestops without lured pokemon remain intact:
![fixluredpokestops](https://cloud.githubusercontent.com/assets/1903878/17101216/4c47454c-5241-11e6-911d-de833e003987.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

…ble pokemon object when the lured pokemon option was enabled