### PR TITLE
Database deadlocks fixed

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -308,7 +308,7 @@ def parse_map(map_dict, iteration_num, step, step_location):
 def bulk_upsert(cls, data):
     num_rows = len(data.values())
     i = 0
-    step = 120
+    step = 1
 
     while i < num_rows:
         log.debug("Inserting items {} to {}".format(i, min(i+step, num_rows)))


### PR DESCRIPTION
This is the fix I suggested for issue #1889 which seems to work.

## Description
Changed numbers of simultaneous upserts from 120 to 1.

## How Has This Been Tested?
I have run this for many hours without any problem. Before, when running with several threads, I would get deadlocks after just some minutes, which would stop the program from working correctly.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

