### PR TITLE
moving Mapstyle selector to Option menu

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -220,7 +220,7 @@ function initMap() {
         zoom: 16,
         fullscreenControl: true,
         streetViewControl: false,
-		mapTypeControl: true,
+		mapTypeControl: false,
 		mapTypeControlOptions: {
           style: google.maps.MapTypeControlStyle.DROPDOWN_MENU,
           position: google.maps.ControlPosition.RIGHT_TOP,

--- a/static/map.js
+++ b/static/map.js
@@ -339,6 +339,11 @@ function initSidebar() {
     });
     icons.val((pokemon_sprites[Store.get('pokemonIcons')]) ? Store.get('pokemonIcons') : 'highres');
     $('#pokemon-icon-size').val(Store.get('iconSizeModifier'));
+	
+	var changeStyle = document.getElementById('map-style')
+	changeStyle.addEventListener("change", function(key, value) {
+		map.setMapTypeId(changeStyle.value)
+	}
 }
 
 function pad(number) { return number <= 99 ? ("0" + number).slice(-2) : number; }

--- a/static/map.js
+++ b/static/map.js
@@ -343,7 +343,7 @@ function initSidebar() {
 	var changeStyle = document.getElementById('map-style')
 	changeStyle.addEventListener("change", function(key, value) {
 		map.setMapTypeId(changeStyle.value)
-	}
+	})
 }
 
 function pad(number) { return number <= 99 ? ("0" + number).slice(-2) : number; }

--- a/templates/map.html
+++ b/templates/map.html
@@ -155,6 +155,22 @@
 					</label>
 				</div>
 			</div>
+			<div class="form-control">
+				<hr width="100%">
+					<h3>Style</h3>
+					<div>
+					<select id="map-style" style="min-width:100%;">
+						<option value="roadmap">Roadmap</option>
+						<option value="satellite">Satellite</option>
+						<option value="nolabels_style">No Labels</option>
+						<option value="dark_style">Dark</option>
+						<option value="style_light2">Light2</option>
+						<option value="style_pgo">PokemonGo</option>
+						<option value="dark_style_nl">Dark (No Labels)</option>
+						<option value="style_light2_nl">Light2 (No Labels)</option>
+						<option value="style_pgo_nl">PokemonGo (No Labels)</option>
+					</select>
+			</div>
 		</nav>
 
 		<div id="map"></div>
@@ -171,6 +187,14 @@
 	<script>
 		var center_lat = {{lat}};
 		var center_lng = {{lng}};
+	</script>
+	
+	<script>
+		$(function() {
+			if(localStorage.getItem('map_style')){
+				$('#map-style').val(localStorage.getItem('map_style'));
+			}
+		});
 	</script>
 
 	<script async defer src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&amp;callback=initMap&amp;libraries=places,geometry"></script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Move the map style selector to Option menu

<!--- Describe your changes in detail -->
*added dropdown menu to Option menu with map styles
*made the dropdown read localstorage so it reads the last used style
*removed mapstyle selector from map itself


<!--- Why is this change required? What problem does it solve? -->
More screen real estate especially on mobile
also responds to  #1674


## How Has This Been Tested?
after editing loaded page on:
Microsoft Edge 
Chrome ( Win10)
IPhone Safari
IPhone Chrome


## Screenshots (if appropriate):

![image](https://cloud.githubusercontent.com/assets/14372954/17107793/0aa2baa4-5291-11e6-8197-815d0b26c17e.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x?] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

