### PR TITLE
Doesn't hammer the server when map download fails.

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -132,6 +132,7 @@ def search_thread(args):
                         response_dict = {}
             else:
                 log.info('Map Download failed. Trying again.')
+                time.sleep(config['REQ_SLEEP'])
 
         time.sleep(config['REQ_SLEEP'])
 


### PR DESCRIPTION
## Description
Waits a little when the map download request fails.

## Motivation and Context
Right now this client hammers Pokemon Go servers, which isn't very nice of us.

## How Has This Been Tested?
Run the client when the a PGo server is down.
Without this patch, watch as 'Map Download failed. Trying again.' messages flood your screen sometimes.
Tested on Linux, Ubuntu.

## Screenshots (if appropriate):
After patch: http://i.imgur.com/4XQCWjC.png
Before is the same, only there's a hundreds of messages per second.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

