### PR TITLE
Use explicit styling for Javascript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,18 @@
     "Store": true,
     "centerLat": true,
     "centerLng": true,
-    "pageLoaded": true
+    "pageLoaded": true,
+    "countMarkers": true,
+    "skel": true,
+    "setupPokemonMarker": true,
+
+    "noLabelsStyle": true,
+    "darkStyle": true,
+    "light2Style": true,
+    "pGoStyle": true,
+    "darkStyleNoLabels": true,
+    "light2StyleNoLabels": true,
+    "pGoStyleNoLabels": true
   },
   "rules": {
     "semi": 0

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,8 +13,11 @@
   },
   "globals": {
     "google": true,
+    "mapData": true,
+    "Store": true,
     "centerLat": true,
-    "centerLng": true
+    "centerLng": true,
+    "pageLoaded": true
   },
   "rules": {
     "semi": 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ install:
   - npm install
 script:
   - npm run build
+  - npm run lint
   - nosetests

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,62 +1,67 @@
-(function() {
-
-  "use strict";
+;(function () {
+  'use strict'
 
   // Methods/polyfills.
 
   // addEventsListener
-  var addEventsListener = function(o, t, e) {
-    var n, i = t.split(" ");
-    for (n in i) o.addEventListener(i[n], e)
+  var addEventsListener = function (o, t, e) {
+    var n
+    var i = t.split(' ')
+    for (n in i) {
+      o.addEventListener(i[n], e)
+    }
   }
 
   // classList | (c) @remy | github.com/remy/polyfills | rem.mit-license.org
-  ! function() {
-    function t(t) {
-      this.el = t;
-      for (var n = t.className.replace(/^\s+|\s+$/g, "").split(/\s+/), i = 0; i < n.length; i++) e.call(this, n[i])
+  !function () {
+    function t (t) {
+      this.el = t
+      for (var n = t.className.replace(/^\s+|\s+$/g, '').split(/\s+/), i = 0; i < n.length; i++) {
+        e.call(this, n[i])
+      }
     }
 
-    function n(t, n, i) {
+    function n (t, n, i) {
       Object.defineProperty ? Object.defineProperty(t, n, {
         get: i
       }) : t.__defineGetter__(n, i)
     }
-    if (!("undefined" == typeof window.Element || "classList" in document.documentElement)) {
-      var i = Array.prototype,
-        e = i.push,
-        s = i.splice,
-        o = i.join;
+    if (!('undefined' === typeof window.Element || 'classList' in document.documentElement)) {
+      var i = Array.prototype
+      var e = i.push
+      var s = i.splice
+      var o = i.join
       t.prototype = {
-        add: function(t) {
+        add: function (t) {
           this.contains(t) || (e.call(this, t), this.el.className = this.toString())
         },
-        contains: function(t) {
-          return -1 != this.el.className.indexOf(t)
+        contains: function (t) {
+          return -1 !== this.el.className.indexOf(t)
         },
-        item: function(t) {
+        item: function (t) {
           return this[t] || null
         },
-        remove: function(t) {
+        remove: function (t) {
           if (this.contains(t)) {
-            for (var n = 0; n < this.length && this[n] != t; n++);
-            s.call(this, n, 1), this.el.className = this.toString()
+            for (var n = 0; n < this.length && this[n] !== t; n++) {
+              s.call(this, n, 1), this.el.className = this.toString()
+            }
           }
         },
-        toString: function() {
-          return o.call(this, " ")
+        toString: function () {
+          return o.call(this, ' ')
         },
-        toggle: function(t) {
+        toggle: function (t) {
           return this.contains(t) ? this.remove(t) : this.add(t), this.contains(t)
         }
-      }, window.DOMTokenList = t, n(Element.prototype, "classList", function() {
+      }, window.DOMTokenList = t, n(Element.prototype, 'classList', function () {
         return new t(this)
       })
     }
-  }();
+  }()
 
   // Vars.
-  var $body = document.querySelector('body');
+  var $body = document.querySelector('body')
 
   // Breakpoints.
   skel.breakpoints({
@@ -65,110 +70,112 @@
     medium: '(max-width: 980px)',
     small: '(max-width: 736px)',
     xsmall: '(max-width: 480px)'
-  });
+  })
 
   // Disable animations/transitions until everything's loaded.
-  $body.classList.add('is-loading');
+  $body.classList.add('is-loading')
 
-  window.addEventListener('load', function() {
-    $body.classList.remove('is-loading');
-  });
+  window.addEventListener('load', function () {
+    $body.classList.remove('is-loading')
+  })
 
   // Nav.
-  var $nav = document.querySelector('#nav'),
-    $navToggle = document.querySelector('a[href="#nav"]'),
-    $navClose;
+  var $nav = document.querySelector('#nav')
+  var $navToggle = document.querySelector('a[href="#nav"]')
+  var $navClose
 
   // Stats.
-  var $stats = document.querySelector('#stats'),
-    $statsToggle = document.querySelector('a[href="#stats"]'),
-    $statsClose;
+  var $stats = document.querySelector('#stats')
+  var $statsToggle = document.querySelector('a[href="#stats"]')
+  var $statsClose
 
   // Event: Prevent clicks/taps inside the nav from bubbling.
-  addEventsListener($nav, 'click touchend', function(event) {
-    event.stopPropagation();
-  });
+  addEventsListener($nav, 'click touchend', function (event) {
+    event.stopPropagation()
+  })
 
-  if($stats){
+  if ($stats) {
     // Event: Prevent clicks/taps inside the stats from bubbling.
-    addEventsListener($stats, 'click touchend', function(event) {
-      event.stopPropagation();
-    });
+    addEventsListener($stats, 'click touchend', function (event) {
+      event.stopPropagation()
+    })
   }
 
   // Event: Hide nav on body click/tap.
-  addEventsListener($body, 'click touchend', function(event) {
+  addEventsListener($body, 'click touchend', function (event) {
     // on ios safari, when navToggle is clicked,
     // this function executes too, so if the target
     // is the toggle button, exit this function
     if (event.target.matches('a[href="#nav"]')) {
-      return;
+      return
     }
     if ($stats && event.target.matches('a[href="#stats]')) {
-      return;
+      return
     }
-    $nav.classList.remove('visible');
-    if($stats)
-      $stats.classList.remove('visible');
-  });
+    $nav.classList.remove('visible')
+    if ($stats) {
+      $stats.classList.remove('visible')
+    }
+  })
 
   // Toggle.
 
   // Event: Toggle nav on click.
-  $navToggle.addEventListener('click', function(event) {
-    event.preventDefault();
-    event.stopPropagation();
-    $nav.classList.toggle('visible');
-  });
+  $navToggle.addEventListener('click', function (event) {
+    event.preventDefault()
+    event.stopPropagation()
+    $nav.classList.toggle('visible')
+  })
 
   // Event: Toggle stats on click.
-  if($statsToggle){
-    $statsToggle.addEventListener('click', function(event) {
-      event.preventDefault();
-      event.stopPropagation();
-      $stats.classList.toggle('visible');
-    });
+  if ($statsToggle) {
+    $statsToggle.addEventListener('click', function (event) {
+      event.preventDefault()
+      event.stopPropagation()
+      $stats.classList.toggle('visible')
+    })
   }
 
   // Close.
 
   // Create elements.
-  $navClose = document.createElement('a');
-  $navClose.href = '#';
-  $navClose.className = 'close';
-  $navClose.tabIndex = 0;
-  $nav.appendChild($navClose);
+  $navClose = document.createElement('a')
+  $navClose.href = '#'
+  $navClose.className = 'close'
+  $navClose.tabIndex = 0
+  $nav.appendChild($navClose)
 
-  if($stats){
-    $statsClose = document.createElement('a');
-    $statsClose.href = '#';
-    $statsClose.className = 'close';
-    $statsClose.tabIndex = 0;
-    $stats.appendChild($statsClose);
+  if ($stats) {
+    $statsClose = document.createElement('a')
+    $statsClose.href = '#'
+    $statsClose.className = 'close'
+    $statsClose.tabIndex = 0
+    $stats.appendChild($statsClose)
   }
 
   // Event: Hide on ESC.
-  window.addEventListener('keydown', function(event) {
-    if (event.keyCode == 27) {
-      $nav.classList.remove('visible');
-      if($stats)
-        $stats.classList.remove('visible');
+  window.addEventListener('keydown', function (event) {
+    if (event.keyCode === 27) {
+      $nav.classList.remove('visible')
+      if ($stats) {
+        $stats.classList.remove('visible')
+      }
     }
-  });
+  })
 
   // Event: Hide nav on click.
-  $navClose.addEventListener('click', function(event) {
-    event.preventDefault();
-    event.stopPropagation();
-    $nav.classList.remove('visible');
-  });
+  $navClose.addEventListener('click', function (event) {
+    event.preventDefault()
+    event.stopPropagation()
+    $nav.classList.remove('visible')
+  })
 
-  if($statsClose){
+  if ($statsClose) {
     // Event: Hide stats on click.
-    $statsClose.addEventListener('click', function(event) {
-      event.preventDefault();
-      event.stopPropagation();
-      $stats.classList.remove('visible');
-    });
+    $statsClose.addEventListener('click', function (event) {
+      event.preventDefault()
+      event.stopPropagation()
+      $stats.classList.remove('visible')
+    })
   }
-})();
+})()

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -13,7 +13,7 @@
   }
 
   // classList | (c) @remy | github.com/remy/polyfills | rem.mit-license.org
-  !function () {
+  ;(function () {
     function t (t) {
       this.el = t
       for (var n = t.className.replace(/^\s+|\s+$/g, '').split(/\s+/), i = 0; i < n.length; i++) {
@@ -26,7 +26,7 @@
         get: i
       }) : t.__defineGetter__(n, i)
     }
-    if (!('undefined' === typeof window.Element || 'classList' in document.documentElement)) {
+    if (!(typeof window.Element === 'undefined' || 'classList' in document.documentElement)) {
       var i = Array.prototype
       var e = i.push
       var s = i.splice
@@ -36,7 +36,7 @@
           this.contains(t) || (e.call(this, t), this.el.className = this.toString())
         },
         contains: function (t) {
-          return -1 !== this.el.className.indexOf(t)
+          return this.el.className.indexOf(t) !== -1
         },
         item: function (t) {
           return this[t] || null
@@ -44,7 +44,8 @@
         remove: function (t) {
           if (this.contains(t)) {
             for (var n = 0; n < this.length && this[n] !== t; n++) {
-              s.call(this, n, 1), this.el.className = this.toString()
+              s.call(this, n, 1)
+              this.el.className = this.toString()
             }
           }
         },
@@ -52,13 +53,16 @@
           return o.call(this, ' ')
         },
         toggle: function (t) {
-          return this.contains(t) ? this.remove(t) : this.add(t), this.contains(t)
+          this.contains(t) ? this.remove(t) : this.add(t)
+          return this.contains(t)
         }
-      }, window.DOMTokenList = t, n(Element.prototype, 'classList', function () {
-        return new t(this)
+      }
+      window.DOMTokenList = t
+      n(Element.prototype, 'classList', function () {
+        return new t(this) // eslint-disable-line new-cap
       })
     }
-  }()
+  })()
 
   // Vars.
   var $body = document.querySelector('body')

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -748,7 +748,7 @@ var Store = {
   getOption: function (key) {
     var option = StoreOptions[key]
     if (!option) {
-      throw 'Store key was not defined ' + key
+      throw new Error('Store key was not defined ' + key)
     }
     return option
   },
@@ -777,24 +777,24 @@ var Store = {
 // Functions
 //
 
-function excludePokemon (id) {
+function excludePokemon (id) { // eslint-disable-line no-unused-vars
   $selectExclude.val(
     $selectExclude.val().concat(id)
   ).trigger('change')
 }
 
-function notifyAboutPokemon (id) {
+function notifyAboutPokemon (id) { // eslint-disable-line no-unused-vars
   $selectNotify.val(
     $selectNotify.val().concat(id)
   ).trigger('change')
 }
 
-function removePokemonMarker (encounterId) {
+function removePokemonMarker (encounterId) { // eslint-disable-line no-unused-vars
   mapData.pokemons[encounterId].marker.setMap(null)
   mapData.pokemons[encounterId].hidden = true
 }
 
-function initMap () {
+function initMap () { // eslint-disable-line no-unused-vars
   map = new google.maps.Map(document.getElementById('map'), {
     center: {
       lat: centerLat,
@@ -821,10 +821,10 @@ function initMap () {
     }
   })
 
-  var style_NoLabels = new google.maps.StyledMapType(noLabelsStyle, {
+  var styleNoLabels = new google.maps.StyledMapType(noLabelsStyle, {
     name: 'No Labels'
   })
-  map.mapTypes.set('nolabels_style', style_NoLabels)
+  map.mapTypes.set('nolabels_style', styleNoLabels)
 
   var styleDark = new google.maps.StyledMapType(darkStyle, {
     name: 'Dark'
@@ -863,7 +863,7 @@ function initMap () {
   map.setMapTypeId(Store.get('map_style'))
   google.maps.event.addListener(map, 'idle', updateMap)
 
-  var marker = createSearchMarker()
+  createSearchMarker()
 
   addMyLocationButton()
   initSidebar()
@@ -878,7 +878,7 @@ function initMap () {
 }
 
 function createSearchMarker () {
-  marker = new google.maps.Marker({ // need to keep reference.
+  var marker = new google.maps.Marker({ // need to keep reference.
     position: {
       lat: centerLat,
       lng: centerLng
@@ -1129,7 +1129,7 @@ function getGoogleSprite (index, sprite, displayHeight) {
 
 function setupPokemonMarker (item, skipNotification, isBounceDisabled) {
   // Scale icon size up with the map exponentially
-  var iconSize = 2 + (map.getZoom() - 3) * (map.getZoom() - 3) * .2 + Store.get('iconSizeModifier')
+  var iconSize = 2 + (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
   var pokemonIndex = item['pokemon_id'] - 1
   var sprite = pokemonSprites[Store.get('pokemonIcons')] || pokemonSprites['highres']
   var icon = getGoogleSprite(pokemonIndex, sprite, iconSize)
@@ -1203,7 +1203,7 @@ function updateGymMarker (item, marker) {
 }
 
 function setupPokestopMarker (item) {
-  var imagename = !!item['lure_expiration'] ? 'PstopLured' : 'Pstop'
+  var imagename = item['lure_expiration'] ? 'PstopLured' : 'Pstop'
   var marker = new google.maps.Marker({
     position: {
       lat: item['latitude'],
@@ -1698,7 +1698,7 @@ function centerMap (lat, lng, zoom) {
   }
 }
 
-function i8ln(word) {
+function i8ln (word) {
   if ($.isEmptyObject(i8lnDictionary) && language !== 'en' && languageLookups < languageLookupThreshold) {
     $.ajax({
       url: 'static/dist/locales/' + language + '.min.json',

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -111,63 +111,63 @@ var StoreTypes = {
 };
 
 var StoreOptions = {
-  map_style: {
+  'map_style': {
     default: 'roadmap',
     type: StoreTypes.String
   },
-  remember_select_exclude: {
+  'remember_select_exclude': {
     default: [],
     type: StoreTypes.JSON
   },
-  remember_select_notify: {
+  'remember_select_notify': {
     default: [],
     type: StoreTypes.JSON
   },
-  showGyms: {
+  'showGyms': {
     default: false,
     type: StoreTypes.Boolean
   },
-  showPokemon: {
+  'showPokemon': {
     default: true,
     type: StoreTypes.Boolean
   },
-  showLuredPokemon: {
+  'showLuredPokemon': {
     default: true,
     type: StoreTypes.Boolean
   },
-  showPokestops: {
+  'showPokestops': {
     default: true,
     type: StoreTypes.Boolean
   },
-  showLuredPokestopsOnly: {
+  'showLuredPokestopsOnly': {
     default: 0,
     type: StoreTypes.Number
   },
-  showScanned: {
+  'showScanned': {
     default: false,
     type: StoreTypes.Boolean
   },
-  playSound: {
+  'playSound': {
     default: false,
     type: StoreTypes.Boolean
   },
-  geoLocate: {
+  'geoLocate': {
     default: false,
     type: StoreTypes.Boolean
   },
-  startAtUserLocation: {
+  'startAtUserLocation': {
     default: false,
     type: StoreTypes.Boolean
   },
-  playSound: {
+  'playSound': {
     default: false,
     type: StoreTypes.Boolean
   },
-  pokemonIcons: {
+  'pokemonIcons': {
     default: 'highres',
     type: StoreTypes.String
   },
-  iconSizeModifier: {
+  'iconSizeModifier': {
     default: 0,
     type: StoreTypes.Number
   }
@@ -560,7 +560,7 @@ function getGoogleSprite(index, sprite, display_height) {
 function setupPokemonMarker(item, skipNotification, isBounceDisabled) {
   // Scale icon size up with the map exponentially
   var icon_size = 2 + (map.getZoom() - 3) * (map.getZoom() - 3) * .2 + Store.get('iconSizeModifier');
-  var pokemon_index = item.pokemon_id - 1;
+  var pokemon_index = item['pokemon_id'] - 1;
   var sprite = pokemon_sprites[Store.get('pokemonIcons')] || pokemon_sprites['highres']
   var icon = getGoogleSprite(pokemon_index, sprite, icon_size);
 
@@ -571,8 +571,8 @@ function setupPokemonMarker(item, skipNotification, isBounceDisabled) {
 
   var marker = new google.maps.Marker({
     position: {
-      lat: item.latitude,
-      lng: item.longitude
+      lat: item['latitude'],
+      lng: item['longitude']
     },
     zIndex: 9999,
     optimized: false,
@@ -587,16 +587,16 @@ function setupPokemonMarker(item, skipNotification, isBounceDisabled) {
   });
 
   marker.infoWindow = new google.maps.InfoWindow({
-    content: pokemonLabel(item.pokemon_name, item.pokemon_rarity, item.pokemon_types, item.disappear_time, item.pokemon_id, item.latitude, item.longitude, item.encounter_id),
+    content: pokemonLabel(item['pokemon_name'], item['pokemon_rarity'], item['pokemon_types'], item['disappear_time'], item['pokemon_id'], item['latitude'], item['longitude'], item['encounter_id']),
     disableAutoPan: true
   });
 
-  if (notifiedPokemon.indexOf(item.pokemon_id) > -1) {
+  if (notifiedPokemon.indexOf(item['pokemon_id']) > -1) {
     if (!skipNotification) {
       if (Store.get('playSound')) {
         audio.play();
       }
-      sendNotification('A wild ' + item.pokemon_name + ' appeared!', 'Click to load map', 'static/icons/' + item.pokemon_id + '.png', item.latitude, item.longitude);
+      sendNotification('A wild ' + item['pokemon_name'] + ' appeared!', 'Click to load map', 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude']);
     }
     if (marker.animationDisabled != true) {
       marker.setAnimation(google.maps.Animation.BOUNCE);
@@ -610,15 +610,15 @@ function setupPokemonMarker(item, skipNotification, isBounceDisabled) {
 function setupGymMarker(item) {
   var marker = new google.maps.Marker({
     position: {
-      lat: item.latitude,
-      lng: item.longitude
+      lat: item['latitude'],
+      lng: item['longitude']
     },
     map: map,
-    icon: 'static/forts/' + gym_types[item.team_id] + '.png'
+    icon: 'static/forts/' + gym_types[item['team_id']] + '.png'
   });
 
   marker.infoWindow = new google.maps.InfoWindow({
-    content: gymLabel(gym_types[item.team_id], item.team_id, item.gym_points, item.latitude, item.longitude),
+    content: gymLabel(gym_types[item['team_id']], item['team_id'], item['gym_points'], item['latitude'], item['longitude']),
     disableAutoPan: true
   });
 
@@ -627,17 +627,17 @@ function setupGymMarker(item) {
 }
 
 function updateGymMarker(item, marker) {
-  marker.setIcon('static/forts/' + gym_types[item.team_id] + '.png');
-  marker.infoWindow.setContent(gymLabel(gym_types[item.team_id], item.team_id, item.gym_points, item.latitude, item.longitude));
+  marker.setIcon('static/forts/' + gym_types[item['team_id']] + '.png');
+  marker.infoWindow.setContent(gymLabel(gym_types[item['team_id']], item['team_id'], item['gym_points'], item['latitude'], item['longitude']));
   return marker;
 }
 
 function setupPokestopMarker(item) {
-  var imagename = !!item.lure_expiration ? "PstopLured" : "Pstop";
+  var imagename = !!item['lure_expiration'] ? "PstopLured" : "Pstop";
   var marker = new google.maps.Marker({
     position: {
-      lat: item.latitude,
-      lng: item.longitude,
+      lat: item['latitude'],
+      lng: item['longitude'],
     },
     map: map,
     zIndex: 2,
@@ -646,7 +646,7 @@ function setupPokestopMarker(item) {
   });
 
   marker.infoWindow = new google.maps.InfoWindow({
-    content: pokestopLabel(!!item.lure_expiration, item.last_modified, item.active_pokemon_id, item.latitude, item.longitude),
+    content: pokestopLabel(!!item['lure_expiration'], item['last_modified'], item['active_pokemon_id'], item['latitude'], item['longitude']),
     disableAutoPan: true
   });
 
@@ -668,14 +668,14 @@ function getColorByDate(value) {
 }
 
 function setupScannedMarker(item) {
-  var circleCenter = new google.maps.LatLng(item.latitude, item.longitude);
+  var circleCenter = new google.maps.LatLng(item['latitude'], item['longitude']);
 
   var marker = new google.maps.Circle({
     map: map,
     clickable: false,
     center: circleCenter,
     radius: 70, // metres
-    fillColor: getColorByDate(item.last_modified),
+    fillColor: getColorByDate(item['last_modified']),
     strokeWeight: 1
   });
 
@@ -814,13 +814,13 @@ function processPokemons(i, item) {
     return false; // in case the checkbox was unchecked in the meantime.
   }
 
-  if (!(item.encounter_id in map_data.pokemons) &&
-    excludedPokemon.indexOf(item.pokemon_id) < 0) {
+  if (!(item['encounter_id'] in map_data.pokemons) &&
+    excludedPokemon.indexOf(item['pokemon_id']) < 0) {
     // add marker to map and item to dict
     if (item.marker) item.marker.setMap(null);
     if (!item.hidden) {
       item.marker = setupPokemonMarker(item);
-      map_data.pokemons[item.encounter_id] = item;
+      map_data.pokemons[item['encounter_id']] = item;
     }
   }
 }
@@ -830,25 +830,25 @@ function processPokestops(i, item) {
     return false;
   }
 
-  if (Store.get('showLuredPokestopsOnly') && !item.lure_expiration) {
-    if (map_data.pokestops[item.pokestop_id] && map_data.pokestops[item.pokestop_id].marker) {
-      map_data.pokestops[item.pokestop_id].marker.setMap(null);
-      delete map_data.pokestops[item.pokestop_id];
+  if (Store.get('showLuredPokestopsOnly') && !item['lure_expiration']) {
+    if (map_data.pokestops[item['pokestop_id']] && map_data.pokestops[item['pokestop_id']].marker) {
+      map_data.pokestops[item['pokestop_id']].marker.setMap(null);
+      delete map_data.pokestops[item['pokestop_id']];
     }
     return true;
   }
 
-  if (map_data.pokestops[item.pokestop_id] == null) { // add marker to map and item to dict
+  if (map_data.pokestops[item['pokestop_id']] == null) { // add marker to map and item to dict
     // add marker to map and item to dict
     if (item.marker) item.marker.setMap(null);
     item.marker = setupPokestopMarker(item);
-    map_data.pokestops[item.pokestop_id] = item;
+    map_data.pokestops[item['pokestop_id']] = item;
   } else {
-    var item2 = map_data.pokestops[item.pokestop_id];
-    if (!!item.lure_expiration != !!item2.lure_expiration || item.active_pokemon_id != item2.active_pokemon_id) {
+    var item2 = map_data.pokestops[item['pokestop_id']];
+    if (!!item['lure_expiration'] != !!item2['lure_expiration'] || item['active_pokemon_id'] != item2['active_pokemon_id']) {
       item2.marker.setMap(null);
       item.marker = setupPokestopMarker(item);
-      map_data.pokestops[item.pokestop_id] = item;
+      map_data.pokestops[item['pokestop_id']] = item;
     }
   }
 }
@@ -858,34 +858,34 @@ function processLuredPokemon(i, item) {
     return false;
   }
   var item2 = {
-    pokestop_id: item.pokestop_id,
-    lure_expiration: item.lure_expiration,
-    pokemon_id: item.active_pokemon_id,
-    latitude: item.latitude + 0.00005,
-    longitude: item.longitude + 0.00005,
-    pokemon_name: item.active_pokemon_id in idToPokemon ? idToPokemon[item.active_pokemon_id]['name'] : null,
-    pokemon_rarity: item.active_pokemon_id in idToPokemon ? idToPokemon[item.active_pokemon_id]['rarity'] : null,
-    disappear_time: item.lure_expiration
+    pokestop_id: item['pokestop_id'],
+    lure_expiration: item['lure_expiration'],
+    pokemon_id: item['active_pokemon_id'],
+    latitude: item['latitude'] + 0.00005,
+    longitude: item['longitude'] + 0.00005,
+    pokemon_name: item['active_pokemon_id'] in idToPokemon ? idToPokemon[item['active_pokemon_id']]['name'] : null,
+    pokemon_rarity: item['active_pokemon_id'] in idToPokemon ? idToPokemon[item['active_pokemon_id']]['rarity'] : null,
+    disappear_time: item['lure_expiration']
   };
 
-  if (item2.pokemon_id == null) {
+  if (item2['pokemon_id'] == null) {
     return;
   }
 
-  if (map_data.lure_pokemons[item2.pokestop_id] == null && item2.lure_expiration) {
+  if (map_data.lure_pokemons[item2['pokestop_id']] == null && item2['lure_expiration']) {
     //if (item.marker) item.marker.setMap(null);
     if (!item2.hidden) {
       item2.marker = setupPokemonMarker(item2);
-      map_data.lure_pokemons[item2.pokestop_id] = item2;
+      map_data.lure_pokemons[item2['pokestop_id']] = item2;
     }
 
   }
-  if (map_data.lure_pokemons[item.pokestop_id] != null && item2.lure_expiration && item2.active_pokemon_id != map_data.lure_pokemons[item2.pokestop_id].active_pokemon_id) {
+  if (map_data.lure_pokemons[item['pokestop_id']] != null && item2['lure_expiration'] && item2['active_pokemon_id'] != map_data.lure_pokemons[item2['pokestop_id']].active_pokemon_id) {
     //if (item.marker) item.marker.setMap(null);
-    map_data.lure_pokemons[item2.pokestop_id].marker.setMap(null);
+    map_data.lure_pokemons[item2['pokestop_id']].marker.setMap(null);
     if (!item2.hidden) {
       item2.marker = setupPokemonMarker(item2);
-      map_data.lure_pokemons[item2.pokestop_id] = item2;
+      map_data.lure_pokemons[item2['pokestop_id']] = item2;
     }
   }
 }
@@ -895,12 +895,12 @@ function processGyms(i, item) {
     return false; // in case the checkbox was unchecked in the meantime.
   }
 
-  if (item.gym_id in map_data.gyms) {
-    item.marker = updateGymMarker(item, map_data.gyms[item.gym_id].marker);
+  if (item['gym_id'] in map_data.gyms) {
+    item.marker = updateGymMarker(item, map_data.gyms[item['gym_id']].marker);
   } else { // add marker to map and item to dict
     item.marker = setupGymMarker(item);
   }
-  map_data.gyms[item.gym_id] = item;
+  map_data.gyms[item['gym_id']] = item;
 
 }
 
@@ -910,14 +910,14 @@ function processScanned(i, item) {
     return false;
   }
 
-  if (item.scanned_id in map_data.scanned) {
-    map_data.scanned[item.scanned_id].marker.setOptions({
-      fillColor: getColorByDate(item.last_modified)
+  if (item['scanned_id'] in map_data.scanned) {
+    map_data.scanned[item['scanned_id']].marker.setOptions({
+      fillColor: getColorByDate(item['last_modified'])
     });
   } else { // add marker to map and item to dict
     if (item.marker) item.marker.setMap(null);
     item.marker = setupScannedMarker(item);
-    map_data.scanned[item.scanned_id] = item;
+    map_data.scanned[item['scanned_id']] = item;
   }
 }
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1,68 +1,643 @@
-
 //
 // Global map.js variables
 //
 
-var $selectExclude;
-var $selectNotify;
-var $selectStyle;
-var $selectIconResolution;
-var $selectIconSize;
-var $selectLuredPokestopsOnly;
+var $selectExclude
+var $selectNotify
+var $selectStyle
+var $selectIconResolution
+var $selectIconSize
+var $selectLuredPokestopsOnly
 
-var language = document.documentElement.lang == "" ? "en" : document.documentElement.lang;
-var idToPokemon = {};
-var i8ln_dictionary = {};
-var language_lookups = 0;
-var language_lookup_threshold = 3;
+var language = document.documentElement.lang === '' ? 'en' : document.documentElement.lang
+var idToPokemon = {}
+var i8lnDictionary = {}
+var languageLookups = 0
+var languageLookupThreshold = 3
 
-var excludedPokemon = [];
-var notifiedPokemon = [];
+var excludedPokemon = []
+var notifiedPokemon = []
 
-var map;
-var rawDataIsLoading = false;
-var locationMarker;
-var marker;
+var map
+var rawDataIsLoading = false
+var locationMarker
+var marker
 
-var noLabelsStyle=[{featureType:"poi",elementType:"labels",stylers:[{visibility:"off"}]},{"featureType":"all","elementType":"labels.icon","stylers":[{"visibility":"off"}]}];
-var light2Style=[{"elementType":"geometry","stylers":[{"hue":"#ff4400"},{"saturation":-68},{"lightness":-4},{"gamma":0.72}]},{"featureType":"road","elementType":"labels.icon"},{"featureType":"landscape.man_made","elementType":"geometry","stylers":[{"hue":"#0077ff"},{"gamma":3.1}]},{"featureType":"water","stylers":[{"hue":"#00ccff"},{"gamma":0.44},{"saturation":-33}]},{"featureType":"poi.park","stylers":[{"hue":"#44ff00"},{"saturation":-23}]},{"featureType":"water","elementType":"labels.text.fill","stylers":[{"hue":"#007fff"},{"gamma":0.77},{"saturation":65},{"lightness":99}]},{"featureType":"water","elementType":"labels.text.stroke","stylers":[{"gamma":0.11},{"weight":5.6},{"saturation":99},{"hue":"#0091ff"},{"lightness":-86}]},{"featureType":"transit.line","elementType":"geometry","stylers":[{"lightness":-48},{"hue":"#ff5e00"},{"gamma":1.2},{"saturation":-23}]},{"featureType":"transit","elementType":"labels.text.stroke","stylers":[{"saturation":-64},{"hue":"#ff9100"},{"lightness":16},{"gamma":0.47},{"weight":2.7}]}];
-var darkStyle=[{"featureType":"all","elementType":"labels.text.fill","stylers":[{"saturation":36},{"color":"#b39964"},{"lightness":40}]},{"featureType":"all","elementType":"labels.text.stroke","stylers":[{"visibility":"on"},{"color":"#000000"},{"lightness":16}]},{"featureType":"all","elementType":"labels.icon","stylers":[{"visibility":"off"}]},{"featureType":"administrative","elementType":"geometry.fill","stylers":[{"color":"#000000"},{"lightness":20}]},{"featureType":"administrative","elementType":"geometry.stroke","stylers":[{"color":"#000000"},{"lightness":17},{"weight":1.2}]},{"featureType":"landscape","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":20}]},{"featureType":"poi","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":21}]},{"featureType":"road.highway","elementType":"geometry.fill","stylers":[{"color":"#000000"},{"lightness":17}]},{"featureType":"road.highway","elementType":"geometry.stroke","stylers":[{"color":"#000000"},{"lightness":29},{"weight":0.2}]},{"featureType":"road.arterial","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":18}]},{"featureType":"road.local","elementType":"geometry","stylers":[{"color":"#181818"},{"lightness":16}]},{"featureType":"transit","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":19}]},{"featureType":"water","elementType":"geometry","stylers":[{"lightness":17},{"color":"#525252"}]}];
-var pGoStyle=[{"featureType":"landscape.man_made","elementType":"geometry.fill","stylers":[{"color":"#a1f199"}]},{"featureType":"landscape.natural.landcover","elementType":"geometry.fill","stylers":[{"color":"#37bda2"}]},{"featureType":"landscape.natural.terrain","elementType":"geometry.fill","stylers":[{"color":"#37bda2"}]},{"featureType":"poi.attraction","elementType":"geometry.fill","stylers":[{"visibility":"on"}]},{"featureType":"poi.business","elementType":"geometry.fill","stylers":[{"color":"#e4dfd9"}]},{"featureType":"poi.business","elementType":"labels.icon","stylers":[{"visibility":"off"}]},{"featureType":"poi.park","elementType":"geometry.fill","stylers":[{"color":"#37bda2"}]},{"featureType":"road","elementType":"geometry.fill","stylers":[{"color":"#84b09e"}]},{"featureType":"road","elementType":"geometry.stroke","stylers":[{"color":"#fafeb8"},{"weight":"1.25"}]},{"featureType":"road.highway","elementType":"labels.icon","stylers":[{"visibility":"off"}]},{"featureType":"water","elementType":"geometry.fill","stylers":[{"color":"#5ddad6"}]}];
-var light2StyleNoLabels=[{"elementType":"geometry","stylers":[{"hue":"#ff4400"},{"saturation":-68},{"lightness":-4},{"gamma":0.72}]},{"featureType":"road","elementType":"labels.icon"},{"featureType":"landscape.man_made","elementType":"geometry","stylers":[{"hue":"#0077ff"},{"gamma":3.1}]},{"featureType":"water","stylers":[{"hue":"#00ccff"},{"gamma":0.44},{"saturation":-33}]},{"featureType":"poi.park","stylers":[{"hue":"#44ff00"},{"saturation":-23}]},{"featureType":"water","elementType":"labels.text.fill","stylers":[{"hue":"#007fff"},{"gamma":0.77},{"saturation":65},{"lightness":99}]},{"featureType":"water","elementType":"labels.text.stroke","stylers":[{"gamma":0.11},{"weight":5.6},{"saturation":99},{"hue":"#0091ff"},{"lightness":-86}]},{"featureType":"transit.line","elementType":"geometry","stylers":[{"lightness":-48},{"hue":"#ff5e00"},{"gamma":1.2},{"saturation":-23}]},{"featureType":"transit","elementType":"labels.text.stroke","stylers":[{"saturation":-64},{"hue":"#ff9100"},{"lightness":16},{"gamma":0.47},{"weight":2.7}]},{"featureType":"all","elementType":"labels.text.stroke","stylers":[{"visibility":"off"}]},{"featureType":"all","elementType":"labels.text.fill","stylers":[{"visibility":"off"}]},{"featureType":"all","elementType":"labels.icon","stylers":[{"visibility":"off"}]}];
-var darkStyleNoLabels=[{"featureType":"all","elementType":"labels.text.fill","stylers":[{"visibility":"off"}]},{"featureType":"all","elementType":"labels.text.stroke","stylers":[{"visibility":"off"}]},{"featureType":"all","elementType":"labels.icon","stylers":[{"visibility":"off"}]},{"featureType":"administrative","elementType":"geometry.fill","stylers":[{"color":"#000000"},{"lightness":20}]},{"featureType":"administrative","elementType":"geometry.stroke","stylers":[{"color":"#000000"},{"lightness":17},{"weight":1.2}]},{"featureType":"landscape","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":20}]},{"featureType":"poi","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":21}]},{"featureType":"road.highway","elementType":"geometry.fill","stylers":[{"color":"#000000"},{"lightness":17}]},{"featureType":"road.highway","elementType":"geometry.stroke","stylers":[{"color":"#000000"},{"lightness":29},{"weight":0.2}]},{"featureType":"road.arterial","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":18}]},{"featureType":"road.local","elementType":"geometry","stylers":[{"color":"#181818"},{"lightness":16}]},{"featureType":"transit","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":19}]},{"featureType":"water","elementType":"geometry","stylers":[{"lightness":17},{"color":"#525252"}]}];
-var pGoStyleNoLabels=[{"featureType":"landscape.man_made","elementType":"geometry.fill","stylers":[{"color":"#a1f199"}]},{"featureType":"landscape.natural.landcover","elementType":"geometry.fill","stylers":[{"color":"#37bda2"}]},{"featureType":"landscape.natural.terrain","elementType":"geometry.fill","stylers":[{"color":"#37bda2"}]},{"featureType":"poi.attraction","elementType":"geometry.fill","stylers":[{"visibility":"on"}]},{"featureType":"poi.business","elementType":"geometry.fill","stylers":[{"color":"#e4dfd9"}]},{"featureType":"poi.business","elementType":"labels.icon","stylers":[{"visibility":"off"}]},{"featureType":"poi.park","elementType":"geometry.fill","stylers":[{"color":"#37bda2"}]},{"featureType":"road","elementType":"geometry.fill","stylers":[{"color":"#84b09e"}]},{"featureType":"road","elementType":"geometry.stroke","stylers":[{"color":"#fafeb8"},{"weight":"1.25"}]},{"featureType":"road.highway","elementType":"labels.icon","stylers":[{"visibility":"off"}]},{"featureType":"water","elementType":"geometry.fill","stylers":[{"color":"#5ddad6"}]},{"featureType":"all","elementType":"labels.text.stroke","stylers":[{"visibility":"off"}]},{"featureType":"all","elementType":"labels.text.fill","stylers":[{"visibility":"off"}]},{"featureType":"all","elementType":"labels.icon","stylers":[{"visibility":"off"}]}];
+var noLabelsStyle = [{
+  featureType: 'poi',
+  elementType: 'labels',
+  stylers: [{
+    visibility: 'off'
+  }]
+}, {
+  'featureType': 'all',
+  'elementType': 'labels.icon',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}]
+var light2Style = [{
+  'elementType': 'geometry',
+  'stylers': [{
+    'hue': '#ff4400'
+  }, {
+    'saturation': -68
+  }, {
+    'lightness': -4
+  }, {
+    'gamma': 0.72
+  }]
+}, {
+  'featureType': 'road',
+  'elementType': 'labels.icon'
+}, {
+  'featureType': 'landscape.man_made',
+  'elementType': 'geometry',
+  'stylers': [{
+    'hue': '#0077ff'
+  }, {
+    'gamma': 3.1
+  }]
+}, {
+  'featureType': 'water',
+  'stylers': [{
+    'hue': '#00ccff'
+  }, {
+    'gamma': 0.44
+  }, {
+    'saturation': -33
+  }]
+}, {
+  'featureType': 'poi.park',
+  'stylers': [{
+    'hue': '#44ff00'
+  }, {
+    'saturation': -23
+  }]
+}, {
+  'featureType': 'water',
+  'elementType': 'labels.text.fill',
+  'stylers': [{
+    'hue': '#007fff'
+  }, {
+    'gamma': 0.77
+  }, {
+    'saturation': 65
+  }, {
+    'lightness': 99
+  }]
+}, {
+  'featureType': 'water',
+  'elementType': 'labels.text.stroke',
+  'stylers': [{
+    'gamma': 0.11
+  }, {
+    'weight': 5.6
+  }, {
+    'saturation': 99
+  }, {
+    'hue': '#0091ff'
+  }, {
+    'lightness': -86
+  }]
+}, {
+  'featureType': 'transit.line',
+  'elementType': 'geometry',
+  'stylers': [{
+    'lightness': -48
+  }, {
+    'hue': '#ff5e00'
+  }, {
+    'gamma': 1.2
+  }, {
+    'saturation': -23
+  }]
+}, {
+  'featureType': 'transit',
+  'elementType': 'labels.text.stroke',
+  'stylers': [{
+    'saturation': -64
+  }, {
+    'hue': '#ff9100'
+  }, {
+    'lightness': 16
+  }, {
+    'gamma': 0.47
+  }, {
+    'weight': 2.7
+  }]
+}]
+var darkStyle = [{
+  'featureType': 'all',
+  'elementType': 'labels.text.fill',
+  'stylers': [{
+    'saturation': 36
+  }, {
+    'color': '#b39964'
+  }, {
+    'lightness': 40
+  }]
+}, {
+  'featureType': 'all',
+  'elementType': 'labels.text.stroke',
+  'stylers': [{
+    'visibility': 'on'
+  }, {
+    'color': '#000000'
+  }, {
+    'lightness': 16
+  }]
+}, {
+  'featureType': 'all',
+  'elementType': 'labels.icon',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'administrative',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 20
+  }]
+}, {
+  'featureType': 'administrative',
+  'elementType': 'geometry.stroke',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 17
+  }, {
+    'weight': 1.2
+  }]
+}, {
+  'featureType': 'landscape',
+  'elementType': 'geometry',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 20
+  }]
+}, {
+  'featureType': 'poi',
+  'elementType': 'geometry',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 21
+  }]
+}, {
+  'featureType': 'road.highway',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 17
+  }]
+}, {
+  'featureType': 'road.highway',
+  'elementType': 'geometry.stroke',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 29
+  }, {
+    'weight': 0.2
+  }]
+}, {
+  'featureType': 'road.arterial',
+  'elementType': 'geometry',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 18
+  }]
+}, {
+  'featureType': 'road.local',
+  'elementType': 'geometry',
+  'stylers': [{
+    'color': '#181818'
+  }, {
+    'lightness': 16
+  }]
+}, {
+  'featureType': 'transit',
+  'elementType': 'geometry',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 19
+  }]
+}, {
+  'featureType': 'water',
+  'elementType': 'geometry',
+  'stylers': [{
+    'lightness': 17
+  }, {
+    'color': '#525252'
+  }]
+}]
+var pGoStyle = [{
+  'featureType': 'landscape.man_made',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#a1f199'
+  }]
+}, {
+  'featureType': 'landscape.natural.landcover',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#37bda2'
+  }]
+}, {
+  'featureType': 'landscape.natural.terrain',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#37bda2'
+  }]
+}, {
+  'featureType': 'poi.attraction',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'visibility': 'on'
+  }]
+}, {
+  'featureType': 'poi.business',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#e4dfd9'
+  }]
+}, {
+  'featureType': 'poi.business',
+  'elementType': 'labels.icon',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'poi.park',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#37bda2'
+  }]
+}, {
+  'featureType': 'road',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#84b09e'
+  }]
+}, {
+  'featureType': 'road',
+  'elementType': 'geometry.stroke',
+  'stylers': [{
+    'color': '#fafeb8'
+  }, {
+    'weight': '1.25'
+  }]
+}, {
+  'featureType': 'road.highway',
+  'elementType': 'labels.icon',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'water',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#5ddad6'
+  }]
+}]
+var light2StyleNoLabels = [{
+  'elementType': 'geometry',
+  'stylers': [{
+    'hue': '#ff4400'
+  }, {
+    'saturation': -68
+  }, {
+    'lightness': -4
+  }, {
+    'gamma': 0.72
+  }]
+}, {
+  'featureType': 'road',
+  'elementType': 'labels.icon'
+}, {
+  'featureType': 'landscape.man_made',
+  'elementType': 'geometry',
+  'stylers': [{
+    'hue': '#0077ff'
+  }, {
+    'gamma': 3.1
+  }]
+}, {
+  'featureType': 'water',
+  'stylers': [{
+    'hue': '#00ccff'
+  }, {
+    'gamma': 0.44
+  }, {
+    'saturation': -33
+  }]
+}, {
+  'featureType': 'poi.park',
+  'stylers': [{
+    'hue': '#44ff00'
+  }, {
+    'saturation': -23
+  }]
+}, {
+  'featureType': 'water',
+  'elementType': 'labels.text.fill',
+  'stylers': [{
+    'hue': '#007fff'
+  }, {
+    'gamma': 0.77
+  }, {
+    'saturation': 65
+  }, {
+    'lightness': 99
+  }]
+}, {
+  'featureType': 'water',
+  'elementType': 'labels.text.stroke',
+  'stylers': [{
+    'gamma': 0.11
+  }, {
+    'weight': 5.6
+  }, {
+    'saturation': 99
+  }, {
+    'hue': '#0091ff'
+  }, {
+    'lightness': -86
+  }]
+}, {
+  'featureType': 'transit.line',
+  'elementType': 'geometry',
+  'stylers': [{
+    'lightness': -48
+  }, {
+    'hue': '#ff5e00'
+  }, {
+    'gamma': 1.2
+  }, {
+    'saturation': -23
+  }]
+}, {
+  'featureType': 'transit',
+  'elementType': 'labels.text.stroke',
+  'stylers': [{
+    'saturation': -64
+  }, {
+    'hue': '#ff9100'
+  }, {
+    'lightness': 16
+  }, {
+    'gamma': 0.47
+  }, {
+    'weight': 2.7
+  }]
+}, {
+  'featureType': 'all',
+  'elementType': 'labels.text.stroke',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'all',
+  'elementType': 'labels.text.fill',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'all',
+  'elementType': 'labels.icon',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}]
+var darkStyleNoLabels = [{
+  'featureType': 'all',
+  'elementType': 'labels.text.fill',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'all',
+  'elementType': 'labels.text.stroke',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'all',
+  'elementType': 'labels.icon',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'administrative',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 20
+  }]
+}, {
+  'featureType': 'administrative',
+  'elementType': 'geometry.stroke',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 17
+  }, {
+    'weight': 1.2
+  }]
+}, {
+  'featureType': 'landscape',
+  'elementType': 'geometry',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 20
+  }]
+}, {
+  'featureType': 'poi',
+  'elementType': 'geometry',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 21
+  }]
+}, {
+  'featureType': 'road.highway',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 17
+  }]
+}, {
+  'featureType': 'road.highway',
+  'elementType': 'geometry.stroke',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 29
+  }, {
+    'weight': 0.2
+  }]
+}, {
+  'featureType': 'road.arterial',
+  'elementType': 'geometry',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 18
+  }]
+}, {
+  'featureType': 'road.local',
+  'elementType': 'geometry',
+  'stylers': [{
+    'color': '#181818'
+  }, {
+    'lightness': 16
+  }]
+}, {
+  'featureType': 'transit',
+  'elementType': 'geometry',
+  'stylers': [{
+    'color': '#000000'
+  }, {
+    'lightness': 19
+  }]
+}, {
+  'featureType': 'water',
+  'elementType': 'geometry',
+  'stylers': [{
+    'lightness': 17
+  }, {
+    'color': '#525252'
+  }]
+}]
+var pGoStyleNoLabels = [{
+  'featureType': 'landscape.man_made',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#a1f199'
+  }]
+}, {
+  'featureType': 'landscape.natural.landcover',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#37bda2'
+  }]
+}, {
+  'featureType': 'landscape.natural.terrain',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#37bda2'
+  }]
+}, {
+  'featureType': 'poi.attraction',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'visibility': 'on'
+  }]
+}, {
+  'featureType': 'poi.business',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#e4dfd9'
+  }]
+}, {
+  'featureType': 'poi.business',
+  'elementType': 'labels.icon',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'poi.park',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#37bda2'
+  }]
+}, {
+  'featureType': 'road',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#84b09e'
+  }]
+}, {
+  'featureType': 'road',
+  'elementType': 'geometry.stroke',
+  'stylers': [{
+    'color': '#fafeb8'
+  }, {
+    'weight': '1.25'
+  }]
+}, {
+  'featureType': 'road.highway',
+  'elementType': 'labels.icon',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'water',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#5ddad6'
+  }]
+}, {
+  'featureType': 'all',
+  'elementType': 'labels.text.stroke',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'all',
+  'elementType': 'labels.text.fill',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'all',
+  'elementType': 'labels.icon',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}]
 
-var selectedStyle = 'light';
+var selectedStyle = 'light'
 
-var map_data = {
+var mapData = {
   pokemons: {},
   gyms: {},
   pokestops: {},
-  lure_pokemons: {},
+  lurePokemons: {},
   scanned: {}
-};
-var gym_types = ["Uncontested", "Mystic", "Valor", "Instinct"];
-var audio = new Audio('static/sounds/ding.mp3');
-var pokemon_sprites = {
+}
+var gymTypes = ['Uncontested', 'Mystic', 'Valor', 'Instinct']
+var audio = new Audio('static/sounds/ding.mp3')
+var pokemonSprites = {
   normal: {
     columns: 12,
-    icon_width: 30,
-    icon_height: 30,
-    sprite_width: 360,
-    sprite_height: 390,
+    iconWidth: 30,
+    iconHeight: 30,
+    spriteWidth: 360,
+    spriteHeight: 390,
     filename: 'static/icons-sprite.png',
     name: 'Normal'
   },
   highres: {
     columns: 7,
-    icon_width: 65,
-    icon_height: 65,
-    sprite_width: 455,
-    sprite_height: 1430,
+    iconWidth: 65,
+    iconHeight: 65,
+    spriteWidth: 455,
+    spriteHeight: 1430,
     filename: 'static/icons-large-sprite.png',
     name: 'High-Res'
   }
-};
+}
 
 //
 // LocalStorage helpers
@@ -70,45 +645,45 @@ var pokemon_sprites = {
 
 var StoreTypes = {
   Boolean: {
-    parse: function(str) {
+    parse: function (str) {
       switch (str.toLowerCase()) {
         case '1':
         case 'true':
         case 'yes':
-          return true;
+          return true
         default:
-          return false;
+          return false
       }
     },
-    stringify: function(b) {
-      return b ? 'true' : 'false';
+    stringify: function (b) {
+      return b ? 'true' : 'false'
     }
   },
   JSON: {
-    parse: function(str) {
-      return JSON.parse(str);
+    parse: function (str) {
+      return JSON.parse(str)
     },
-    stringify: function(json) {
-      return JSON.stringify(json);
+    stringify: function (json) {
+      return JSON.stringify(json)
     }
   },
   String: {
-    parse: function(str) {
-      return str;
+    parse: function (str) {
+      return str
     },
-    stringify: function(str) {
-      return str;
+    stringify: function (str) {
+      return str
     }
   },
   Number: {
-    parse: function(str) {
-      return parseInt(str, 10);
+    parse: function (str) {
+      return parseInt(str, 10)
     },
-    stringify: function(number) {
-      return number.toString();
+    stringify: function (number) {
+      return number.toString()
     }
   }
-};
+}
 
 var StoreOptions = {
   'map_style': {
@@ -159,10 +734,6 @@ var StoreOptions = {
     default: false,
     type: StoreTypes.Boolean
   },
-  'playSound': {
-    default: false,
-    type: StoreTypes.Boolean
-  },
   'pokemonIcons': {
     default: 'highres',
     type: StoreTypes.String
@@ -171,63 +742,63 @@ var StoreOptions = {
     default: 0,
     type: StoreTypes.Number
   }
-};
+}
 
 var Store = {
-  getOption: function(key) {
-    var option = StoreOptions[key];
+  getOption: function (key) {
+    var option = StoreOptions[key]
     if (!option) {
-      throw "Store key was not defined " + key;
+      throw 'Store key was not defined ' + key
     }
-    return option;
+    return option
   },
-  get: function(key) {
-    var option = this.getOption(key);
-    var optionType = option.type;
-    var rawValue = localStorage[key];
+  get: function (key) {
+    var option = this.getOption(key)
+    var optionType = option.type
+    var rawValue = localStorage[key]
     if (rawValue === null || rawValue === undefined) {
-      return option.default;
+      return option.default
     }
-    var value = optionType.parse(rawValue);
-    return value;
+    var value = optionType.parse(rawValue)
+    return value
   },
-  set: function(key, value) {
-    var option = this.getOption(key);
-    var optionType = option.type || StoreTypes.String;
-    var rawValue = optionType.stringify(value);
-    localStorage[key] = rawValue;
+  set: function (key, value) {
+    var option = this.getOption(key)
+    var optionType = option.type || StoreTypes.String
+    var rawValue = optionType.stringify(value)
+    localStorage[key] = rawValue
   },
-  reset: function(key) {
-    localStorage.removeItem(key);
+  reset: function (key) {
+    localStorage.removeItem(key)
   }
-};
+}
 
 //
 // Functions
 //
 
-function excludePokemon(id) {
+function excludePokemon (id) {
   $selectExclude.val(
     $selectExclude.val().concat(id)
   ).trigger('change')
 }
 
-function notifyAboutPokemon(id) {
+function notifyAboutPokemon (id) {
   $selectNotify.val(
     $selectNotify.val().concat(id)
   ).trigger('change')
 }
 
-function removePokemonMarker(encounter_id) {
-  map_data.pokemons[encounter_id].marker.setMap(null);
-  map_data.pokemons[encounter_id].hidden = true;
+function removePokemonMarker (encounterId) {
+  mapData.pokemons[encounterId].marker.setMap(null)
+  mapData.pokemons[encounterId].hidden = true
 }
 
-function initMap() {
+function initMap () {
   map = new google.maps.Map(document.getElementById('map'), {
     center: {
-      lat: center_lat,
-      lng: center_lng
+      lat: centerLat,
+      lng: centerLng
     },
     zoom: 16,
     fullscreenControl: true,
@@ -247,157 +818,157 @@ function initMap() {
         'style_light2_nl',
         'style_pgo_nl'
       ]
-    },
-  });
+    }
+  })
 
   var style_NoLabels = new google.maps.StyledMapType(noLabelsStyle, {
-    name: "No Labels"
-  });
-  map.mapTypes.set('nolabels_style', style_NoLabels);
+    name: 'No Labels'
+  })
+  map.mapTypes.set('nolabels_style', style_NoLabels)
 
-  var style_dark = new google.maps.StyledMapType(darkStyle, {
-    name: "Dark"
-  });
-  map.mapTypes.set('dark_style', style_dark);
+  var styleDark = new google.maps.StyledMapType(darkStyle, {
+    name: 'Dark'
+  })
+  map.mapTypes.set('dark_style', styleDark)
 
-  var style_light2 = new google.maps.StyledMapType(light2Style, {
-    name: "Light2"
-  });
-  map.mapTypes.set('style_light2', style_light2);
+  var styleLight2 = new google.maps.StyledMapType(light2Style, {
+    name: 'Light2'
+  })
+  map.mapTypes.set('style_light2', styleLight2)
 
-  var style_pgo = new google.maps.StyledMapType(pGoStyle, {
-    name: "PokemonGo"
-  });
-  map.mapTypes.set('style_pgo', style_pgo);
+  var stylePgo = new google.maps.StyledMapType(pGoStyle, {
+    name: 'PokemonGo'
+  })
+  map.mapTypes.set('style_pgo', stylePgo)
 
-  var style_dark_nl = new google.maps.StyledMapType(darkStyleNoLabels, {
-    name: "Dark (No Labels)"
-  });
-  map.mapTypes.set('dark_style_nl', style_dark_nl);
+  var styleDarkNl = new google.maps.StyledMapType(darkStyleNoLabels, {
+    name: 'Dark (No Labels)'
+  })
+  map.mapTypes.set('dark_style_nl', styleDarkNl)
 
-  var style_light2_nl = new google.maps.StyledMapType(light2StyleNoLabels, {
-    name: "Light2 (No Labels)"
-  });
-  map.mapTypes.set('style_light2_nl', style_light2_nl);
+  var styleLight2Nl = new google.maps.StyledMapType(light2StyleNoLabels, {
+    name: 'Light2 (No Labels)'
+  })
+  map.mapTypes.set('style_light2_nl', styleLight2Nl)
 
-  var style_pgo_nl = new google.maps.StyledMapType(pGoStyleNoLabels, {
-    name: "PokemonGo (No Labels)"
-  });
-  map.mapTypes.set('style_pgo_nl', style_pgo_nl);
+  var stylePgoNl = new google.maps.StyledMapType(pGoStyleNoLabels, {
+    name: 'PokemonGo (No Labels)'
+  })
+  map.mapTypes.set('style_pgo_nl', stylePgoNl)
 
-  map.addListener('maptypeid_changed', function(s) {
-    Store.set('map_style', this.mapTypeId);
-  });
+  map.addListener('maptypeid_changed', function (s) {
+    Store.set('map_style', this.mapTypeId)
+  })
 
-  map.setMapTypeId(Store.get('map_style'));
-  google.maps.event.addListener(map, 'idle', updateMap);
+  map.setMapTypeId(Store.get('map_style'))
+  google.maps.event.addListener(map, 'idle', updateMap)
 
-  var marker = createSearchMarker();
+  var marker = createSearchMarker()
 
-  addMyLocationButton();
-  initSidebar();
-  google.maps.event.addListenerOnce(map, 'idle', function() {
-    updateMap();
-  });
+  addMyLocationButton()
+  initSidebar()
+  google.maps.event.addListenerOnce(map, 'idle', function () {
+    updateMap()
+  })
 
-  google.maps.event.addListener(map, 'zoom_changed', function() {
-    redrawPokemon(map_data.pokemons);
-    redrawPokemon(map_data.lure_pokemons);
-  });
+  google.maps.event.addListener(map, 'zoom_changed', function () {
+    redrawPokemon(mapData.pokemons)
+    redrawPokemon(mapData.lurePokemons)
+  })
 }
 
-function createSearchMarker() {
-  marker = new google.maps.Marker({ //need to keep reference.
+function createSearchMarker () {
+  marker = new google.maps.Marker({ // need to keep reference.
     position: {
-      lat: center_lat,
-      lng: center_lng
+      lat: centerLat,
+      lng: centerLng
     },
     map: map,
     animation: google.maps.Animation.DROP,
     draggable: true
-  });
+  })
 
-  var oldLocation = null;
-  google.maps.event.addListener(marker, 'dragstart', function() {
-    oldLocation = marker.getPosition();
-  });
+  var oldLocation = null
+  google.maps.event.addListener(marker, 'dragstart', function () {
+    oldLocation = marker.getPosition()
+  })
 
-  google.maps.event.addListener(marker, 'dragend', function() {
-    var newLocation = marker.getPosition();
+  google.maps.event.addListener(marker, 'dragend', function () {
+    var newLocation = marker.getPosition()
     changeSearchLocation(newLocation.lat(), newLocation.lng())
-      .done(function() {
-        oldLocation = null;
+      .done(function () {
+        oldLocation = null
       })
-      .fail(function() {
+      .fail(function () {
         if (oldLocation) {
-          marker.setPosition(oldLocation);
+          marker.setPosition(oldLocation)
         }
-      });
-  });
+      })
+  })
 
-  return marker;
+  return marker
 }
 
-var searchControlURI = 'search_control';
-function searchControl(action) {
-  $.post(searchControlURI + '?action='+encodeURIComponent(action));
+var searchControlURI = 'search_control'
+function searchControl (action) {
+  $.post(searchControlURI + '?action=' + encodeURIComponent(action))
 }
-function updateSearchStatus() {
-  $.getJSON(searchControlURI).then(function(data){
-    $('#search-switch').prop('checked', data.status);
+function updateSearchStatus () {
+  $.getJSON(searchControlURI).then(function (data) {
+    $('#search-switch').prop('checked', data.status)
   })
 }
 
-function initSidebar() {
-  $('#gyms-switch').prop('checked', Store.get('showGyms'));
-  $('#pokemon-switch').prop('checked', Store.get('showPokemon'));
-  $('#pokestops-switch').prop('checked', Store.get('showPokestops'));
-  $('#lured-pokestops-only-switch').val(Store.get('showLuredPokestopsOnly'));
-  $('#lured-pokestops-only-wrapper').toggle(Store.get('showPokestops'));
-  $('#geoloc-switch').prop('checked', Store.get('geoLocate'));
-  $('#start-at-user-location-switch').prop('checked', Store.get('startAtUserLocation'));
-  $('#scanned-switch').prop('checked', Store.get('showScanned'));
-  $('#sound-switch').prop('checked', Store.get('playSound'));
-  var searchBox = new google.maps.places.SearchBox(document.getElementById('next-location'));
-  $("#next-location").css("background-color", $('#geoloc-switch').prop('checked') ? "#e0e0e0" : "#ffffff");
+function initSidebar () {
+  $('#gyms-switch').prop('checked', Store.get('showGyms'))
+  $('#pokemon-switch').prop('checked', Store.get('showPokemon'))
+  $('#pokestops-switch').prop('checked', Store.get('showPokestops'))
+  $('#lured-pokestops-only-switch').val(Store.get('showLuredPokestopsOnly'))
+  $('#lured-pokestops-only-wrapper').toggle(Store.get('showPokestops'))
+  $('#geoloc-switch').prop('checked', Store.get('geoLocate'))
+  $('#start-at-user-location-switch').prop('checked', Store.get('startAtUserLocation'))
+  $('#scanned-switch').prop('checked', Store.get('showScanned'))
+  $('#sound-switch').prop('checked', Store.get('playSound'))
+  var searchBox = new google.maps.places.SearchBox(document.getElementById('next-location'))
+  $('#next-location').css('background-color', $('#geoloc-switch').prop('checked') ? '#e0e0e0' : '#ffffff')
 
-  updateSearchStatus();
-  setInterval(updateSearchStatus,5000);
+  updateSearchStatus()
+  setInterval(updateSearchStatus, 5000)
 
-  searchBox.addListener('places_changed', function() {
-    var places = searchBox.getPlaces();
+  searchBox.addListener('places_changed', function () {
+    var places = searchBox.getPlaces()
 
-    if (places.length == 0) {
-      return;
+    if (places.length === 0) {
+      return
     }
 
-    var loc = places[0].geometry.location;
-    changeLocation(loc.lat(), loc.lng());
-  });
+    var loc = places[0].geometry.location
+    changeLocation(loc.lat(), loc.lng())
+  })
 
-  var icons = $('#pokemon-icons');
-  $.each(pokemon_sprites, function(key, value) {
-    icons.append($('<option></option>').attr("value", key).text(value.name));
-  });
-  icons.val((pokemon_sprites[Store.get('pokemonIcons')]) ? Store.get('pokemonIcons') : 'highres');
-  $('#pokemon-icon-size').val(Store.get('iconSizeModifier'));
+  var icons = $('#pokemon-icons')
+  $.each(pokemonSprites, function (key, value) {
+    icons.append($('<option></option>').attr('value', key).text(value.name))
+  })
+  icons.val((pokemonSprites[Store.get('pokemonIcons')]) ? Store.get('pokemonIcons') : 'highres')
+  $('#pokemon-icon-size').val(Store.get('iconSizeModifier'))
 }
 
-function pad(number) {
-  return number <= 99 ? ("0" + number).slice(-2) : number;
+function pad (number) {
+  return number <= 99 ? ('0' + number).slice(-2) : number
 }
 
-function getTypeSpan(type) {
-  return `<span style='padding: 2px 5px; text-transform: uppercase; color: white; margin-right: 2px; border-radius: 4px; font-size: 0.8em; vertical-align: text-bottom; background-color: ${type['color']}'>${type['type']}</span>`;
+function getTypeSpan (type) {
+  return `<span style='padding: 2px 5px; text-transform: uppercase; color: white; margin-right: 2px; border-radius: 4px; font-size: 0.8em; vertical-align: text-bottom; background-color: ${type['color']}'>${type['type']}</span>`
 }
 
-function pokemonLabel(name, rarity, types, disappear_time, id, latitude, longitude, encounter_id) {
-  var disappear_date = new Date(disappear_time);
-  var rarity_display = rarity ? '(' + rarity + ')' : "";
-  var types_display = "";
-  $.each(types, function(index, type) {
-    types_display += getTypeSpan(type);
-  });
+function pokemonLabel (name, rarity, types, disappearTime, id, latitude, longitude, encounterId) {
+  var disappearDate = new Date(disappearTime)
+  var rarityDisplay = rarity ? '(' + rarity + ')' : ''
+  var typesDisplay = ''
+  $.each(types, function (index, type) {
+    typesDisplay += getTypeSpan(type)
+  })
 
   var contentstring = `
     <div>
@@ -406,36 +977,36 @@ function pokemonLabel(name, rarity, types, disappear_time, id, latitude, longitu
       <small>
         <a href='http://www.pokemon.com/us/pokedex/${id}' target='_blank' title='View in Pokedex'>#${id}</a>
       </small>
-      <span> ${rarity_display}</span>
+      <span> ${rarityDisplay}</span>
       <span> - </span>
-      <small>${types_display}</small>
+      <small>${typesDisplay}</small>
     </div>
     <div>
-      Disappears at ${pad(disappear_date.getHours())}:${pad(disappear_date.getMinutes())}:${pad(disappear_date.getSeconds())}
-      <span class='label-countdown' disappears-at='${disappear_time}'>(00m00s)</span>
+      Disappears at ${pad(disappearDate.getHours())}:${pad(disappearDate.getMinutes())}:${pad(disappearDate.getSeconds())}
+      <span class='label-countdown' disappears-at='${disappearTime}'>(00m00s)</span>
     </div>
     <div>
       Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
     </div>
     <div>
-      <a href='javascript:excludePokemon(${id})'>Exclude</a>&nbsp;&nbsp;
-      <a href='javascript:notifyAboutPokemon(${id})'>Notify</a>&nbsp;&nbsp;
-      <a href='javascript:removePokemonMarker("${encounter_id}")'>Remove</a>&nbsp;&nbsp;
+      <a href='javascript:excludePokemon(${id})'>Exclude</a>&nbsp;&nbsp
+      <a href='javascript:notifyAboutPokemon(${id})'>Notify</a>&nbsp;&nbsp
+      <a href='javascript:removePokemonMarker("${encounterId}")'>Remove</a>&nbsp;&nbsp
       <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}' target='_blank' title='View in Maps'>Get directions</a>
-    </div>`;
-  return contentstring;
+    </div>`
+  return contentstring
 }
 
-function gymLabel(team_name, team_id, gym_points, latitude, longitude) {
-  var gym_color = ["0, 0, 0, .4", "74, 138, 202, .6", "240, 68, 58, .6", "254, 217, 40, .6"];
-  var str;
-  if (team_id == 0) {
+function gymLabel (teamName, teamId, gymPoints, latitude, longitude) {
+  var gymColor = ['0, 0, 0, .4', '74, 138, 202, .6', '240, 68, 58, .6', '254, 217, 40, .6']
+  var str
+  if (teamId === 0) {
     str = `
       <div>
         <center>
           <div>
-            <b style='color:rgba(${gym_color[team_id]})'>${team_name}</b><br>
-            <img height='70px' style='padding: 5px;' src='static/forts/${team_name}_large.png'>
+            <b style='color:rgba(${gymColor[teamId]})'>${teamName}</b><br>
+            <img height='70px' style='padding: 5px;' src='static/forts/${teamName}_large.png'>
           </div>
           <div>
             Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
@@ -444,12 +1015,12 @@ function gymLabel(team_name, team_id, gym_points, latitude, longitude) {
             <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}' target='_blank' title='View in Maps'>Get directions</a>
           </div>
         </center>
-      </div>`;
+      </div>`
   } else {
-    var gym_prestige = [2000, 4000, 8000, 12000, 16000, 20000, 30000, 40000, 50000];
-    var gym_level = 1;
-    while (gym_points >= gym_prestige[gym_level - 1]) {
-      gym_level++;
+    var gymPrestige = [2000, 4000, 8000, 12000, 16000, 20000, 30000, 40000, 50000]
+    var gymLevel = 1
+    while (gymPoints >= gymPrestige[gymLevel - 1]) {
+      gymLevel++
     }
     str = `
       <div>
@@ -458,11 +1029,11 @@ function gymLabel(team_name, team_id, gym_points, latitude, longitude) {
             Gym owned by:
           </div>
           <div>
-            <b style='color:rgba(${gym_color[team_id]})'>Team ${team_name}</b><br>
-            <img height='70px' style='padding: 5px;' src='static/forts/${team_name}_large.png'>
+            <b style='color:rgba(${gymColor[teamId]})'>Team ${teamName}</b><br>
+            <img height='70px' style='padding: 5px;' src='static/forts/${teamName}_large.png'>
           </div>
           <div>
-            Level: ${gym_level} | Prestige: ${gym_points}
+            Level: ${gymLevel} | Prestige: ${gymPoints}
           </div>
           <div>
             Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
@@ -471,55 +1042,55 @@ function gymLabel(team_name, team_id, gym_points, latitude, longitude) {
             <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}' target='_blank' title='View in Maps'>Get directions</a>
           </div>
         </center>
-      </div>`;
+      </div>`
   }
 
-  return str;
+  return str
 }
 
-function pokestopLabel(lured, last_modified, active_pokemon_id, latitude, longitude) {
-  var str;
+function pokestopLabel (lured, lastModified, activePokemonId, latitude, longitude) {
+  var str
   if (lured) {
-    var active_pokemon_name = active_pokemon_id in idToPokemon ? idToPokemon[active_pokemon_id]['name'] : "";
-    var active_pokemon_rarity = active_pokemon_id in idToPokemon ? idToPokemon[active_pokemon_id]['rarity'] : "";
-    var active_pokemon_types = active_pokemon_id in idToPokemon ? idToPokemon[active_pokemon_id]['types'] : "";
-    var rarity_display = active_pokemon_rarity ? '(' + active_pokemon_rarity + ')' : "";
-    var types_display = "";
-    $.each(active_pokemon_types, function(index, type) {
-      types_display += getTypeSpan(type);
-    });
-    var last_modified_date = new Date(last_modified);
-    var current_date = new Date();
+    var activePokemonName = activePokemonId in idToPokemon ? idToPokemon[activePokemonId]['name'] : ''
+    var activePokemonRarity = activePokemonId in idToPokemon ? idToPokemon[activePokemonId]['rarity'] : ''
+    var activePokemonTypes = activePokemonId in idToPokemon ? idToPokemon[activePokemonId]['types'] : ''
+    var rarityDisplay = activePokemonRarity ? '(' + activePokemonRarity + ')' : ''
+    var typesDisplay = ''
+    $.each(activePokemonTypes, function (index, type) {
+      typesDisplay += getTypeSpan(type)
+    })
+    var lastModifiedDate = new Date(lastModified)
+    var currentDate = new Date()
 
-    var time_until_expire = current_date.getTime() - last_modified_date.getTime();
+    var timeUntilExpire = currentDate.getTime() - lastModifiedDate.getTime()
 
-    var expire_date = new Date(current_date.getTime() + time_until_expire);
-    var expire_time = expire_date.getTime();
+    var expireDate = new Date(currentDate.getTime() + timeUntilExpire)
+    var expireTime = expireDate.getTime()
 
     str = `
       <div>
         <b>Lured Pokéstop</b>
       </div>
       <div>
-        Lured Pokémon: ${active_pokemon_name}
+        Lured Pokémon: ${activePokemonName}
         <span> - </span>
         <small>
-          <a href='http://www.pokemon.com/us/pokedex/${active_pokemon_id}' target='_blank' title='View in Pokedex'>#${active_pokemon_id}</a>
+          <a href='http://www.pokemon.com/us/pokedex/${activePokemonId}' target='_blank' title='View in Pokedex'>#${activePokemonId}</a>
         </small>
-        <span> ${rarity_display}</span>
+        <span> ${rarityDisplay}</span>
         <span> - </span>
-        <span>${types_display}</span>
+        <span>${typesDisplay}</span>
       </div>
       <div>
-        Lure expires at ${pad(expire_date.getHours())}:${pad(expire_date.getMinutes())}:${pad(expire_date.getSeconds())}
-        <span class='label-countdown' disappears-at='${expire_time}'>(00m00s)</span>
+        Lure expires at ${pad(expireDate.getHours())}:${pad(expireDate.getMinutes())}:${pad(expireDate.getSeconds())}
+        <span class='label-countdown' disappears-at='${expireTime}'>(00m00s)</span>
       </div>
       <div>
         Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
       </div>
       <div>
         <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}' target='_blank' title='View in Maps'>Get directions</a>
-      </div>`;
+      </div>`
   } else {
     str = `
       <div>
@@ -530,43 +1101,42 @@ function pokestopLabel(lured, last_modified, active_pokemon_id, latitude, longit
       </div>
       <div>
         <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}' target='_blank' title='View in Maps'>Get directions</a>
-      </div>`;
+      </div>`
   }
 
-  return str;
+  return str
 }
 
-
-function getGoogleSprite(index, sprite, display_height) {
-  display_height = Math.max(display_height, 3);
-  var scale = display_height / sprite.icon_height;
+function getGoogleSprite (index, sprite, displayHeight) {
+  displayHeight = Math.max(displayHeight, 3)
+  var scale = displayHeight / sprite.iconHeight
   // Crop icon just a tiny bit to avoid bleedover from neighbor
-  var scaled_icon_size = new google.maps.Size(scale * sprite.icon_width - 1, scale * sprite.icon_height - 1);
-  var scaled_icon_offset = new google.maps.Point(
-    (index % sprite.columns) * sprite.icon_width * scale + 0.5,
-    Math.floor(index / sprite.columns) * sprite.icon_height * scale + 0.5);
-  var scaled_sprite_size = new google.maps.Size(scale * sprite.sprite_width, scale * sprite.sprite_height);
-  var scaled_icon_center_offset = new google.maps.Point(scale * sprite.icon_width / 2, scale * sprite.icon_height / 2);
+  var scaledIconSize = new google.maps.Size(scale * sprite.iconWidth - 1, scale * sprite.iconHeight - 1)
+  var scaledIconOffset = new google.maps.Point(
+    (index % sprite.columns) * sprite.iconWidth * scale + 0.5,
+    Math.floor(index / sprite.columns) * sprite.iconHeight * scale + 0.5)
+  var scaledSpriteSize = new google.maps.Size(scale * sprite.spriteWidth, scale * sprite.spriteHeight)
+  var scaledIconCenterOffset = new google.maps.Point(scale * sprite.iconWidth / 2, scale * sprite.iconHeight / 2)
 
   return {
     url: sprite.filename,
-    size: scaled_icon_size,
-    scaledSize: scaled_sprite_size,
-    origin: scaled_icon_offset,
-    anchor: scaled_icon_center_offset
-  };
+    size: scaledIconSize,
+    scaledSize: scaledSpriteSize,
+    origin: scaledIconOffset,
+    anchor: scaledIconCenterOffset
+  }
 }
 
-function setupPokemonMarker(item, skipNotification, isBounceDisabled) {
+function setupPokemonMarker (item, skipNotification, isBounceDisabled) {
   // Scale icon size up with the map exponentially
-  var icon_size = 2 + (map.getZoom() - 3) * (map.getZoom() - 3) * .2 + Store.get('iconSizeModifier');
-  var pokemon_index = item['pokemon_id'] - 1;
-  var sprite = pokemon_sprites[Store.get('pokemonIcons')] || pokemon_sprites['highres']
-  var icon = getGoogleSprite(pokemon_index, sprite, icon_size);
+  var iconSize = 2 + (map.getZoom() - 3) * (map.getZoom() - 3) * .2 + Store.get('iconSizeModifier')
+  var pokemonIndex = item['pokemon_id'] - 1
+  var sprite = pokemonSprites[Store.get('pokemonIcons')] || pokemonSprites['highres']
+  var icon = getGoogleSprite(pokemonIndex, sprite, iconSize)
 
-  var animationDisabled = false;
-  if (isBounceDisabled == true) {
-    animationDisabled = true;
+  var animationDisabled = false
+  if (isBounceDisabled === true) {
+    animationDisabled = true
   }
 
   var marker = new google.maps.Marker({
@@ -578,97 +1148,97 @@ function setupPokemonMarker(item, skipNotification, isBounceDisabled) {
     optimized: false,
     map: map,
     icon: icon,
-    animationDisabled: animationDisabled,
-  });
+    animationDisabled: animationDisabled
+  })
 
-  marker.addListener('click', function() {
-    this.setAnimation(null);
-    this.animationDisabled = true;
-  });
+  marker.addListener('click', function () {
+    this.setAnimation(null)
+    this.animationDisabled = true
+  })
 
   marker.infoWindow = new google.maps.InfoWindow({
     content: pokemonLabel(item['pokemon_name'], item['pokemon_rarity'], item['pokemon_types'], item['disappear_time'], item['pokemon_id'], item['latitude'], item['longitude'], item['encounter_id']),
     disableAutoPan: true
-  });
+  })
 
   if (notifiedPokemon.indexOf(item['pokemon_id']) > -1) {
     if (!skipNotification) {
       if (Store.get('playSound')) {
-        audio.play();
+        audio.play()
       }
-      sendNotification('A wild ' + item['pokemon_name'] + ' appeared!', 'Click to load map', 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude']);
+      sendNotification('A wild ' + item['pokemon_name'] + ' appeared!', 'Click to load map', 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
     }
-    if (marker.animationDisabled != true) {
-      marker.setAnimation(google.maps.Animation.BOUNCE);
+    if (marker.animationDisabled !== true) {
+      marker.setAnimation(google.maps.Animation.BOUNCE)
     }
   }
 
-  addListeners(marker);
-  return marker;
+  addListeners(marker)
+  return marker
 }
 
-function setupGymMarker(item) {
+function setupGymMarker (item) {
   var marker = new google.maps.Marker({
     position: {
       lat: item['latitude'],
       lng: item['longitude']
     },
     map: map,
-    icon: 'static/forts/' + gym_types[item['team_id']] + '.png'
-  });
+    icon: 'static/forts/' + gymTypes[item['team_id']] + '.png'
+  })
 
   marker.infoWindow = new google.maps.InfoWindow({
-    content: gymLabel(gym_types[item['team_id']], item['team_id'], item['gym_points'], item['latitude'], item['longitude']),
+    content: gymLabel(gymTypes[item['team_id']], item['team_id'], item['gym_points'], item['latitude'], item['longitude']),
     disableAutoPan: true
-  });
+  })
 
-  addListeners(marker);
-  return marker;
+  addListeners(marker)
+  return marker
 }
 
-function updateGymMarker(item, marker) {
-  marker.setIcon('static/forts/' + gym_types[item['team_id']] + '.png');
-  marker.infoWindow.setContent(gymLabel(gym_types[item['team_id']], item['team_id'], item['gym_points'], item['latitude'], item['longitude']));
-  return marker;
+function updateGymMarker (item, marker) {
+  marker.setIcon('static/forts/' + gymTypes[item['team_id']] + '.png')
+  marker.infoWindow.setContent(gymLabel(gymTypes[item['team_id']], item['team_id'], item['gym_points'], item['latitude'], item['longitude']))
+  return marker
 }
 
-function setupPokestopMarker(item) {
-  var imagename = !!item['lure_expiration'] ? "PstopLured" : "Pstop";
+function setupPokestopMarker (item) {
+  var imagename = !!item['lure_expiration'] ? 'PstopLured' : 'Pstop'
   var marker = new google.maps.Marker({
     position: {
       lat: item['latitude'],
-      lng: item['longitude'],
+      lng: item['longitude']
     },
     map: map,
     zIndex: 2,
     optimized: false,
-    icon: 'static/forts/' + imagename + '.png',
-  });
+    icon: 'static/forts/' + imagename + '.png'
+  })
 
   marker.infoWindow = new google.maps.InfoWindow({
     content: pokestopLabel(!!item['lure_expiration'], item['last_modified'], item['active_pokemon_id'], item['latitude'], item['longitude']),
     disableAutoPan: true
-  });
+  })
 
-  addListeners(marker);
-  return marker;
+  addListeners(marker)
+  return marker
 }
 
-function getColorByDate(value) {
-  //Changes the color from red to green over 15 mins
-  var diff = (Date.now() - value) / 1000 / 60 / 15;
+function getColorByDate (value) {
+  // Changes the color from red to green over 15 mins
+  var diff = (Date.now() - value) / 1000 / 60 / 15
 
   if (diff > 1) {
-    diff = 1;
+    diff = 1
   }
 
-  //value from 0 to 1 - Green to Red
-  var hue = ((1 - diff) * 120).toString(10);
-  return ["hsl(", hue, ",100%,50%)"].join("");
+  // value from 0 to 1 - Green to Red
+  var hue = ((1 - diff) * 120).toString(10)
+  return ['hsl(', hue, ',100%,50%)'].join('')
 }
 
-function setupScannedMarker(item) {
-  var circleCenter = new google.maps.LatLng(item['latitude'], item['longitude']);
+function setupScannedMarker (item) {
+  var circleCenter = new google.maps.LatLng(item['latitude'], item['longitude'])
 
   var marker = new google.maps.Circle({
     map: map,
@@ -677,112 +1247,112 @@ function setupScannedMarker(item) {
     radius: 70, // metres
     fillColor: getColorByDate(item['last_modified']),
     strokeWeight: 1
-  });
-
-  return marker;
-}
-
-function clearSelection() {
-    if (document.selection ) {
-        document.selection.empty();
-    } else if (window.getSelection) {
-        window.getSelection().removeAllRanges();
-    }
-};
-
-function addListeners(marker) {
-  marker.addListener('click', function() {
-    marker.infoWindow.open(map, marker);
-    clearSelection();
-    updateLabelDiffTime();
-    marker.persist = true;
-  });
-
-  google.maps.event.addListener(marker.infoWindow, 'closeclick', function() {
-    marker.persist = null;
-  });
-
-  marker.addListener('mouseover', function() {
-    marker.infoWindow.open(map, marker);
-    clearSelection();
-    updateLabelDiffTime();
-  });
-
-  marker.addListener('mouseout', function() {
-    if (!marker.persist) {
-      marker.infoWindow.close();
-    }
-  });
+  })
 
   return marker
 }
 
-function clearStaleMarkers() {
-  $.each(map_data.pokemons, function(key, value) {
-    if (map_data.pokemons[key]['disappear_time'] < new Date().getTime() ||
-      excludedPokemon.indexOf(map_data.pokemons[key]['pokemon_id']) >= 0) {
-      map_data.pokemons[key].marker.setMap(null);
-      delete map_data.pokemons[key];
-    }
-  });
-
-  $.each(map_data.lure_pokemons, function(key, value) {
-    if (map_data.lure_pokemons[key]['lure_expiration'] < new Date().getTime() ||
-      excludedPokemon.indexOf(map_data.lure_pokemons[key]['pokemon_id']) >= 0) {
-      map_data.lure_pokemons[key].marker.setMap(null);
-      delete map_data.lure_pokemons[key];
-    }
-  });
-
-  $.each(map_data.scanned, function(key, value) {
-    //If older than 15mins remove
-    if (map_data.scanned[key]['last_modified'] < (new Date().getTime() - 15 * 60 * 1000)) {
-      map_data.scanned[key].marker.setMap(null);
-      delete map_data.scanned[key];
-    }
-  });
+function clearSelection () {
+  if (document.selection) {
+    document.selection.empty()
+  } else if (window.getSelection) {
+    window.getSelection().removeAllRanges()
+  }
 }
 
-function showInBoundsMarkers(markers) {
-  $.each(markers, function(key, value) {
-    var marker = markers[key].marker;
-    var show = false;
+function addListeners (marker) {
+  marker.addListener('click', function () {
+    marker.infoWindow.open(map, marker)
+    clearSelection()
+    updateLabelDiffTime()
+    marker.persist = true
+  })
+
+  google.maps.event.addListener(marker.infoWindow, 'closeclick', function () {
+    marker.persist = null
+  })
+
+  marker.addListener('mouseover', function () {
+    marker.infoWindow.open(map, marker)
+    clearSelection()
+    updateLabelDiffTime()
+  })
+
+  marker.addListener('mouseout', function () {
+    if (!marker.persist) {
+      marker.infoWindow.close()
+    }
+  })
+
+  return marker
+}
+
+function clearStaleMarkers () {
+  $.each(mapData.pokemons, function (key, value) {
+    if (mapData.pokemons[key]['disappear_time'] < new Date().getTime() ||
+      excludedPokemon.indexOf(mapData.pokemons[key]['pokemon_id']) >= 0) {
+      mapData.pokemons[key].marker.setMap(null)
+      delete mapData.pokemons[key]
+    }
+  })
+
+  $.each(mapData.lurePokemons, function (key, value) {
+    if (mapData.lurePokemons[key]['lure_expiration'] < new Date().getTime() ||
+      excludedPokemon.indexOf(mapData.lurePokemons[key]['pokemon_id']) >= 0) {
+      mapData.lurePokemons[key].marker.setMap(null)
+      delete mapData.lurePokemons[key]
+    }
+  })
+
+  $.each(mapData.scanned, function (key, value) {
+    // If older than 15mins remove
+    if (mapData.scanned[key]['last_modified'] < (new Date().getTime() - 15 * 60 * 1000)) {
+      mapData.scanned[key].marker.setMap(null)
+      delete mapData.scanned[key]
+    }
+  })
+}
+
+function showInBoundsMarkers (markers) {
+  $.each(markers, function (key, value) {
+    var marker = markers[key].marker
+    var show = false
     if (!markers[key].hidden) {
       if (typeof marker.getBounds === 'function') {
         if (map.getBounds().intersects(marker.getBounds())) {
-          show = true;
+          show = true
         }
       } else if (typeof marker.getPosition === 'function') {
         if (map.getBounds().contains(marker.getPosition())) {
-          show = true;
+          show = true
         }
       }
     }
 
     if (show && !markers[key].marker.getMap()) {
-      markers[key].marker.setMap(map);
+      markers[key].marker.setMap(map)
     } else if (!show && markers[key].marker.getMap()) {
-      markers[key].marker.setMap(null);
+      markers[key].marker.setMap(null)
     }
-  });
+  })
 }
 
-function loadRawData() {
-  var loadPokemon = Store.get('showPokemon');
-  var loadGyms = Store.get('showGyms');
-  var loadPokestops = Store.get('showPokestops') || Store.get('showPokemon');
-  var loadScanned = Store.get('showScanned');
+function loadRawData () {
+  var loadPokemon = Store.get('showPokemon')
+  var loadGyms = Store.get('showGyms')
+  var loadPokestops = Store.get('showPokestops') || Store.get('showPokemon')
+  var loadScanned = Store.get('showScanned')
 
-  var bounds = map.getBounds();
-  var swPoint = bounds.getSouthWest();
-  var nePoint = bounds.getNorthEast();
-  var swLat = swPoint.lat();
-  var swLng = swPoint.lng();
-  var neLat = nePoint.lat();
-  var neLng = nePoint.lng();
+  var bounds = map.getBounds()
+  var swPoint = bounds.getSouthWest()
+  var nePoint = bounds.getNorthEast()
+  var swLat = swPoint.lat()
+  var swLng = swPoint.lng()
+  var neLat = nePoint.lat()
+  var neLng = nePoint.lng()
 
   return $.ajax({
-    url: "raw_data",
+    url: 'raw_data',
     type: 'GET',
     data: {
       'pokemon': loadPokemon,
@@ -794,288 +1364,294 @@ function loadRawData() {
       'neLat': neLat,
       'neLng': neLng
     },
-    dataType: "json",
+    dataType: 'json',
     cache: false,
-    beforeSend: function() {
+    beforeSend: function () {
       if (rawDataIsLoading) {
-        return false;
+        return false
       } else {
-        rawDataIsLoading = true;
+        rawDataIsLoading = true
       }
     },
-    complete: function() {
-      rawDataIsLoading = false;
+    complete: function () {
+      rawDataIsLoading = false
     }
   })
 }
 
-function processPokemons(i, item) {
+function processPokemons (i, item) {
   if (!Store.get('showPokemon')) {
     return false; // in case the checkbox was unchecked in the meantime.
   }
 
-  if (!(item['encounter_id'] in map_data.pokemons) &&
+  if (!(item['encounter_id'] in mapData.pokemons) &&
     excludedPokemon.indexOf(item['pokemon_id']) < 0) {
     // add marker to map and item to dict
-    if (item.marker) item.marker.setMap(null);
+    if (item.marker) {
+      item.marker.setMap(null)
+    }
     if (!item.hidden) {
-      item.marker = setupPokemonMarker(item);
-      map_data.pokemons[item['encounter_id']] = item;
+      item.marker = setupPokemonMarker(item)
+      mapData.pokemons[item['encounter_id']] = item
     }
   }
 }
 
-function processPokestops(i, item) {
+function processPokestops (i, item) {
   if (!Store.get('showPokestops')) {
-    return false;
+    return false
   }
 
   if (Store.get('showLuredPokestopsOnly') && !item['lure_expiration']) {
-    if (map_data.pokestops[item['pokestop_id']] && map_data.pokestops[item['pokestop_id']].marker) {
-      map_data.pokestops[item['pokestop_id']].marker.setMap(null);
-      delete map_data.pokestops[item['pokestop_id']];
+    if (mapData.pokestops[item['pokestop_id']] && mapData.pokestops[item['pokestop_id']].marker) {
+      mapData.pokestops[item['pokestop_id']].marker.setMap(null)
+      delete mapData.pokestops[item['pokestop_id']]
     }
-    return true;
+    return true
   }
 
-  if (map_data.pokestops[item['pokestop_id']] == null) { // add marker to map and item to dict
+  if (!mapData.pokestops[item['pokestop_id']]) { // add marker to map and item to dict
     // add marker to map and item to dict
-    if (item.marker) item.marker.setMap(null);
-    item.marker = setupPokestopMarker(item);
-    map_data.pokestops[item['pokestop_id']] = item;
+    if (item.marker) {
+      item.marker.setMap(null)
+    }
+    item.marker = setupPokestopMarker(item)
+    mapData.pokestops[item['pokestop_id']] = item
   } else {
-    var item2 = map_data.pokestops[item['pokestop_id']];
-    if (!!item['lure_expiration'] != !!item2['lure_expiration'] || item['active_pokemon_id'] != item2['active_pokemon_id']) {
-      item2.marker.setMap(null);
-      item.marker = setupPokestopMarker(item);
-      map_data.pokestops[item['pokestop_id']] = item;
+    var item2 = mapData.pokestops[item['pokestop_id']]
+    if (!!item['lure_expiration'] !== !!item2['lure_expiration'] || item['active_pokemon_id'] !== item2['active_pokemon_id']) {
+      item2.marker.setMap(null)
+      item.marker = setupPokestopMarker(item)
+      mapData.pokestops[item['pokestop_id']] = item
     }
   }
 }
 
-function processLuredPokemon(i, item) {
+function processLuredPokemon (i, item) {
   if (!Store.get('showPokemon')) {
-    return false;
+    return false
   }
   var item2 = {
-    pokestop_id: item['pokestop_id'],
-    lure_expiration: item['lure_expiration'],
-    pokemon_id: item['active_pokemon_id'],
+    pokestopId: item['pokestop_id'],
+    lureExpiration: item['lure_expiration'],
+    pokemonId: item['active_pokemon_id'],
     latitude: item['latitude'] + 0.00005,
     longitude: item['longitude'] + 0.00005,
-    pokemon_name: item['active_pokemon_id'] in idToPokemon ? idToPokemon[item['active_pokemon_id']]['name'] : null,
-    pokemon_rarity: item['active_pokemon_id'] in idToPokemon ? idToPokemon[item['active_pokemon_id']]['rarity'] : null,
-    disappear_time: item['lure_expiration']
-  };
-
-  if (item2['pokemon_id'] == null) {
-    return;
+    pokemonName: item['active_pokemon_id'] in idToPokemon ? idToPokemon[item['active_pokemon_id']]['name'] : null,
+    pokemonRarity: item['active_pokemon_id'] in idToPokemon ? idToPokemon[item['active_pokemon_id']]['rarity'] : null,
+    disappearTime: item['lure_expiration']
   }
 
-  if (map_data.lure_pokemons[item2['pokestop_id']] == null && item2['lure_expiration']) {
-    //if (item.marker) item.marker.setMap(null);
+  if (!item2['pokemon_id']) {
+    return
+  }
+
+  if (!mapData.lurePokemons[item2['pokestop_id']] && item2['lure_expiration']) {
+    // if (item.marker) item.marker.setMap(null)
     if (!item2.hidden) {
-      item2.marker = setupPokemonMarker(item2);
-      map_data.lure_pokemons[item2['pokestop_id']] = item2;
+      item2.marker = setupPokemonMarker(item2)
+      mapData.lurePokemons[item2['pokestop_id']] = item2
     }
-
   }
-  if (map_data.lure_pokemons[item['pokestop_id']] != null && item2['lure_expiration'] && item2['active_pokemon_id'] != map_data.lure_pokemons[item2['pokestop_id']].active_pokemon_id) {
-    //if (item.marker) item.marker.setMap(null);
-    map_data.lure_pokemons[item2['pokestop_id']].marker.setMap(null);
+  if (mapData.lurePokemons[item['pokestop_id']] && item2['lure_expiration'] && item2['active_pokemon_id'] !== mapData.lurePokemons[item2['pokestop_id']].activePokemonId) {
+    // if (item.marker) item.marker.setMap(null)
+    mapData.lurePokemons[item2['pokestop_id']].marker.setMap(null)
     if (!item2.hidden) {
-      item2.marker = setupPokemonMarker(item2);
-      map_data.lure_pokemons[item2['pokestop_id']] = item2;
+      item2.marker = setupPokemonMarker(item2)
+      mapData.lurePokemons[item2['pokestop_id']] = item2
     }
   }
 }
 
-function processGyms(i, item) {
+function processGyms (i, item) {
   if (!Store.get('showGyms')) {
     return false; // in case the checkbox was unchecked in the meantime.
   }
 
-  if (item['gym_id'] in map_data.gyms) {
-    item.marker = updateGymMarker(item, map_data.gyms[item['gym_id']].marker);
+  if (item['gym_id'] in mapData.gyms) {
+    item.marker = updateGymMarker(item, mapData.gyms[item['gym_id']].marker)
   } else { // add marker to map and item to dict
-    item.marker = setupGymMarker(item);
+    item.marker = setupGymMarker(item)
   }
-  map_data.gyms[item['gym_id']] = item;
-
+  mapData.gyms[item['gym_id']] = item
 }
 
-
-function processScanned(i, item) {
+function processScanned (i, item) {
   if (!Store.get('showScanned')) {
-    return false;
+    return false
   }
 
-  if (item['scanned_id'] in map_data.scanned) {
-    map_data.scanned[item['scanned_id']].marker.setOptions({
+  if (item['scanned_id'] in mapData.scanned) {
+    mapData.scanned[item['scanned_id']].marker.setOptions({
       fillColor: getColorByDate(item['last_modified'])
-    });
+    })
   } else { // add marker to map and item to dict
-    if (item.marker) item.marker.setMap(null);
-    item.marker = setupScannedMarker(item);
-    map_data.scanned[item['scanned_id']] = item;
+    if (item.marker) {
+      item.marker.setMap(null)
+    }
+    item.marker = setupScannedMarker(item)
+    mapData.scanned[item['scanned_id']] = item
   }
 }
 
-
-function updateMap() {
-  loadRawData().done(function(result) {
-    $.each(result.pokemons, processPokemons);
-    $.each(result.pokestops, processPokestops);
-    $.each(result.pokestops, processLuredPokemon);
-    $.each(result.gyms, processGyms);
-    $.each(result.scanned, processScanned);
-    showInBoundsMarkers(map_data.pokemons);
-    showInBoundsMarkers(map_data.lure_pokemons);
-    showInBoundsMarkers(map_data.gyms);
-    showInBoundsMarkers(map_data.pokestops);
-    showInBoundsMarkers(map_data.scanned);
-    clearStaleMarkers();
-    if ($("#stats").hasClass("visible")) {
-      countMarkers();
+function updateMap () {
+  loadRawData().done(function (result) {
+    $.each(result.pokemons, processPokemons)
+    $.each(result.pokestops, processPokestops)
+    $.each(result.pokestops, processLuredPokemon)
+    $.each(result.gyms, processGyms)
+    $.each(result.scanned, processScanned)
+    showInBoundsMarkers(mapData.pokemons)
+    showInBoundsMarkers(mapData.lurePokemons)
+    showInBoundsMarkers(mapData.gyms)
+    showInBoundsMarkers(mapData.pokestops)
+    showInBoundsMarkers(mapData.scanned)
+    clearStaleMarkers()
+    if ($('#stats').hasClass('visible')) {
+      countMarkers()
     }
-  });
+  })
 }
 
-
-
-function redrawPokemon(pokemon_list) {
-  var skipNotification = true;
-  $.each(pokemon_list, function(key, value) {
-    var item = pokemon_list[key];
+function redrawPokemon (pokemonList) {
+  var skipNotification = true
+  $.each(pokemonList, function (key, value) {
+    var item = pokemonList[key]
     if (!item.hidden) {
-      var new_marker = setupPokemonMarker(item, skipNotification, this.marker.animationDisabled);
-      item.marker.setMap(null);
-      pokemon_list[key].marker = new_marker;
+      var newMarker = setupPokemonMarker(item, skipNotification, this.marker.animationDisabled)
+      item.marker.setMap(null)
+      pokemonList[key].marker = newMarker
     }
-  });
-};
+  })
+}
 
-var updateLabelDiffTime = function() {
-  $('.label-countdown').each(function(index, element) {
-    var disappearsAt = new Date(parseInt(element.getAttribute("disappears-at")));
-    var now = new Date();
+var updateLabelDiffTime = function () {
+  $('.label-countdown').each(function (index, element) {
+    var disappearsAt = new Date(parseInt(element.getAttribute('disappears-at')))
+    var now = new Date()
 
-    var difference = Math.abs(disappearsAt - now);
-    var hours = Math.floor(difference / 36e5);
-    var minutes = Math.floor((difference - (hours * 36e5)) / 6e4);
-    var seconds = Math.floor((difference - (hours * 36e5) - (minutes * 6e4)) / 1e3);
-    var timestring = "";
+    var difference = Math.abs(disappearsAt - now)
+    var hours = Math.floor(difference / 36e5)
+    var minutes = Math.floor((difference - (hours * 36e5)) / 6e4)
+    var seconds = Math.floor((difference - (hours * 36e5) - (minutes * 6e4)) / 1e3)
+    var timestring = ''
 
     if (disappearsAt < now) {
-      timestring = "(expired)";
+      timestring = '(expired)'
     } else {
-      timestring = "(";
-      if (hours > 0)
-        timestring = hours + "h";
+      timestring = '('
+      if (hours > 0) {
+        timestring = hours + 'h'
+      }
 
-      timestring += ("0" + minutes).slice(-2) + "m";
-      timestring += ("0" + seconds).slice(-2) + "s";
-      timestring += ")";
+      timestring += ('0' + minutes).slice(-2) + 'm'
+      timestring += ('0' + seconds).slice(-2) + 's'
+      timestring += ')'
     }
 
     $(element).text(timestring)
-  });
-};
-
-function getPointDistance(pointA, pointB) {
-  return google.maps.geometry.spherical.computeDistanceBetween(pointA, pointB);
+  })
 }
 
-function sendNotification(title, text, icon, lat, lng) {
-  if (!("Notification" in window)) {
-    return false; // Notifications are not present in browser
+function getPointDistance (pointA, pointB) {
+  return google.maps.geometry.spherical.computeDistanceBetween(pointA, pointB)
+}
+
+function sendNotification (title, text, icon, lat, lng) {
+  if (!('Notification' in window)) {
+    return false // Notifications are not present in browser
   }
 
-  if (Notification.permission !== "granted") {
-    Notification.requestPermission();
+  if (Notification.permission !== 'granted') {
+    Notification.requestPermission()
   } else {
     var notification = new Notification(title, {
       icon: icon,
       body: text,
       sound: 'sounds/ding.mp3'
-    });
+    })
 
-    notification.onclick = function() {
-      window.focus();
-      notification.close();
+    notification.onclick = function () {
+      window.focus()
+      notification.close()
 
-      centerMap(lat, lng, 20);
-    };
+      centerMap(lat, lng, 20)
+    }
   }
 }
 
-function myLocationButton(map, marker) {
-  var locationContainer = document.createElement('div');
+function myLocationButton (map, marker) {
+  var locationContainer = document.createElement('div')
 
-  var locationButton = document.createElement('button');
-  locationButton.style.backgroundColor = '#fff';
-  locationButton.style.border = 'none';
-  locationButton.style.outline = 'none';
-  locationButton.style.width = '28px';
-  locationButton.style.height = '28px';
-  locationButton.style.borderRadius = '2px';
-  locationButton.style.boxShadow = '0 1px 4px rgba(0,0,0,0.3)';
-  locationButton.style.cursor = 'pointer';
-  locationButton.style.marginRight = '10px';
-  locationButton.style.padding = '0px';
-  locationButton.title = 'Your Location';
-  locationContainer.appendChild(locationButton);
+  var locationButton = document.createElement('button')
+  locationButton.style.backgroundColor = '#fff'
+  locationButton.style.border = 'none'
+  locationButton.style.outline = 'none'
+  locationButton.style.width = '28px'
+  locationButton.style.height = '28px'
+  locationButton.style.borderRadius = '2px'
+  locationButton.style.boxShadow = '0 1px 4px rgba(0,0,0,0.3)'
+  locationButton.style.cursor = 'pointer'
+  locationButton.style.marginRight = '10px'
+  locationButton.style.padding = '0px'
+  locationButton.title = 'Your Location'
+  locationContainer.appendChild(locationButton)
 
-  var locationIcon = document.createElement('div');
-  locationIcon.style.margin = '5px';
-  locationIcon.style.width = '18px';
-  locationIcon.style.height = '18px';
-  locationIcon.style.backgroundImage = 'url(static/mylocation-sprite-1x.png)';
-  locationIcon.style.backgroundSize = '180px 18px';
-  locationIcon.style.backgroundPosition = '0px 0px';
-  locationIcon.style.backgroundRepeat = 'no-repeat';
-  locationIcon.id = 'current-location';
-  locationButton.appendChild(locationIcon);
+  var locationIcon = document.createElement('div')
+  locationIcon.style.margin = '5px'
+  locationIcon.style.width = '18px'
+  locationIcon.style.height = '18px'
+  locationIcon.style.backgroundImage = 'url(static/mylocation-sprite-1x.png)'
+  locationIcon.style.backgroundSize = '180px 18px'
+  locationIcon.style.backgroundPosition = '0px 0px'
+  locationIcon.style.backgroundRepeat = 'no-repeat'
+  locationIcon.id = 'current-location'
+  locationButton.appendChild(locationIcon)
 
-  locationButton.addEventListener('click', function() { centerMapOnLocation() });
+  locationButton.addEventListener('click', function () {
+    centerMapOnLocation()
+  })
 
-  locationContainer.index = 1;
-  map.controls[google.maps.ControlPosition.RIGHT_BOTTOM].push(locationContainer);
+  locationContainer.index = 1
+  map.controls[google.maps.ControlPosition.RIGHT_BOTTOM].push(locationContainer)
 }
 
-function centerMapOnLocation() {
-  var currentLocation = document.getElementById('current-location');
-  var imgX = '0';
-  var animationInterval = setInterval(function() {
-    if (imgX == '-18') imgX = '0';
-    else imgX = '-18';
-    currentLocation.style.backgroundPosition = imgX + 'px 0';
-  }, 500);
+function centerMapOnLocation () {
+  var currentLocation = document.getElementById('current-location')
+  var imgX = '0'
+  var animationInterval = setInterval(function () {
+    if (imgX === '-18') {
+      imgX = '0'
+    } else {
+      imgX = '-18'
+    }
+    currentLocation.style.backgroundPosition = imgX + 'px 0'
+  }, 500)
   if (navigator.geolocation) {
-    navigator.geolocation.getCurrentPosition(function(position) {
-      var latlng = new google.maps.LatLng(position.coords.latitude, position.coords.longitude);
-      locationMarker.setVisible(true);
+    navigator.geolocation.getCurrentPosition(function (position) {
+      var latlng = new google.maps.LatLng(position.coords.latitude, position.coords.longitude)
+      locationMarker.setVisible(true)
       locationMarker.setOptions({
         'opacity': 1
-      });
-      locationMarker.setPosition(latlng);
-      map.setCenter(latlng);
-      clearInterval(animationInterval);
-      currentLocation.style.backgroundPosition = '-144px 0px';
-    });
+      })
+      locationMarker.setPosition(latlng)
+      map.setCenter(latlng)
+      clearInterval(animationInterval)
+      currentLocation.style.backgroundPosition = '-144px 0px'
+    })
   } else {
-    clearInterval(animationInterval);
-    currentLocation.style.backgroundPosition = '0px 0px';
+    clearInterval(animationInterval)
+    currentLocation.style.backgroundPosition = '0px 0px'
   }
 }
 
-function addMyLocationButton() {
+function addMyLocationButton () {
   locationMarker = new google.maps.Marker({
     map: map,
     animation: google.maps.Animation.DROP,
     position: {
-      lat: center_lat,
-      lng: center_lng
+      lat: centerLat,
+      lng: centerLng
     },
     icon: {
       path: google.maps.SymbolPath.CIRCLE,
@@ -1086,36 +1662,36 @@ function addMyLocationButton() {
       strokeWeight: 8,
       strokeOpacity: 0.3
     }
-  });
-  locationMarker.setVisible(false);
+  })
+  locationMarker.setVisible(false)
 
-  myLocationButton(map, locationMarker);
+  myLocationButton(map, locationMarker)
 
-  google.maps.event.addListener(map, 'dragend', function() {
-    var currentLocation = document.getElementById('current-location');
-    currentLocation.style.backgroundPosition = '0px 0px';
+  google.maps.event.addListener(map, 'dragend', function () {
+    var currentLocation = document.getElementById('current-location')
+    currentLocation.style.backgroundPosition = '0px 0px'
     locationMarker.setOptions({
       'opacity': 0.5
-    });
-  });
+    })
+  })
 }
 
-function changeLocation(lat, lng) {
-  var loc = new google.maps.LatLng(lat, lng);
-  changeSearchLocation(lat, lng).done(function() {
-    map.setCenter(loc);
-    marker.setPosition(loc);
-  });
+function changeLocation (lat, lng) {
+  var loc = new google.maps.LatLng(lat, lng)
+  changeSearchLocation(lat, lng).done(function () {
+    map.setCenter(loc)
+    marker.setPosition(loc)
+  })
 }
 
-function changeSearchLocation(lat, lng) {
-  return $.post("next_loc?lat=" + lat + "&lon=" + lng, {});
+function changeSearchLocation (lat, lng) {
+  return $.post('next_loc?lat=' + lat + '&lon=' + lng, {})
 }
 
-function centerMap(lat, lng, zoom) {
-  var loc = new google.maps.LatLng(lat, lng);
+function centerMap (lat, lng, zoom) {
+  var loc = new google.maps.LatLng(lat, lng)
 
-  map.setCenter(loc);
+  map.setCenter(loc)
 
   if (zoom) {
     map.setZoom(zoom)
@@ -1123,22 +1699,22 @@ function centerMap(lat, lng, zoom) {
 }
 
 function i8ln(word) {
-  if ($.isEmptyObject(i8ln_dictionary) && language != "en" && language_lookups < language_lookup_threshold) {
+  if ($.isEmptyObject(i8lnDictionary) && language !== 'en' && languageLookups < languageLookupThreshold) {
     $.ajax({
-      url: "static/dist/locales/" + language + ".min.json",
+      url: 'static/dist/locales/' + language + '.min.json',
       dataType: 'json',
       async: false,
-      success: function(data) {
-        i8ln_dictionary = data;
+      success: function (data) {
+        i8lnDictionary = data
       },
-      error: function(jqXHR, status, error) {
-        console.log('Error loading i8ln dictionary: ' + error);
-        language_lookups++;
+      error: function (jqXHR, status, error) {
+        console.log('Error loading i8ln dictionary: ' + error)
+        languageLookups++
       }
-    });
+    })
   }
-  if (word in i8ln_dictionary) {
-    return i8ln_dictionary[word];
+  if (word in i8lnDictionary) {
+    return i8lnDictionary[word]
   } else {
     // Word doesn't exist in dictionary return it as is
     return word
@@ -1149,244 +1725,242 @@ function i8ln(word) {
 // Page Ready Exection
 //
 
-$(function() {
+$(function () {
   if (!Notification) {
-    console.log('could not load notifications');
-    return;
+    console.log('could not load notifications')
+    return
   }
 
-  if (Notification.permission !== "granted") {
-    Notification.requestPermission();
+  if (Notification.permission !== 'granted') {
+    Notification.requestPermission()
   }
-});
+})
 
-$(function() {
+$(function () {
   // populate Navbar Style menu
-  $selectStyle = $("#map-style")
+  $selectStyle = $('#map-style')
 
   // Load Stylenames, translate entries, and populate lists
-  $.getJSON("static/dist/data/mapstyle.min.json").done(function(data){
+  $.getJSON('static/dist/data/mapstyle.min.json').done(function (data) {
     var styleList = []
 
-    $.each(data, function(key, value){
-    styleList.push( { id: key, text: i8ln(value) } );
-  });
+    $.each(data, function (key, value) {
+      styleList.push({
+        id: key,
+        text: i8ln(value)
+      })
+    })
 
+    // setup the stylelist
+    $selectStyle.select2({
+      placeholder: 'Select Style',
+      data: styleList,
+      minimumResultsForSearch: Infinity
+    })
 
-  // setup the stylelist
-  $selectStyle.select2({
-    placeholder: "Select Style",
-    data: styleList,
-    minimumResultsForSearch: Infinity,
-  });
+    // setup the list change behavior
+    $selectStyle.on('change', function (e) {
+      selectedStyle = $selectStyle.val()
+      map.setMapTypeId(selectedStyle)
+      Store.set('map_style', selectedStyle)
+    })
 
-  // setup the list change behavior
-  $selectStyle.on("change", function (e) {
-    selectedStyle = $selectStyle.val();
-    map.setMapTypeId(selectedStyle);
-    Store.set('map_style', selectedStyle);
-  });
+    // recall saved mapstyle
+    $selectStyle.val(Store.get('map_style')).trigger('change')
+  })
 
-
-  // recall saved mapstyle
-  $selectStyle.val(Store.get('map_style')).trigger("change");
-
-  });
-
-  $selectIconResolution =  $('#pokemon-icons');
+  $selectIconResolution = $('#pokemon-icons')
 
   $selectIconResolution.select2({
-    placeholder: "Select Icon Resolution",
-    minimumResultsForSearch: Infinity,
-  });
+    placeholder: 'Select Icon Resolution',
+    minimumResultsForSearch: Infinity
+  })
 
-  $selectIconResolution.on("change", function() {
-    Store.set('pokemonIcons', this.value);
-    redrawPokemon(map_data.pokemons);
-    redrawPokemon(map_data.lure_pokemons);
-  });
+  $selectIconResolution.on('change', function () {
+    Store.set('pokemonIcons', this.value)
+    redrawPokemon(mapData.pokemons)
+    redrawPokemon(mapData.lurePokemons)
+  })
 
-
-  $selectIconSize = $('#pokemon-icon-size');
+  $selectIconSize = $('#pokemon-icon-size')
 
   $selectIconSize.select2({
-    placeholder: "Select Icon Size",
-    minimumResultsForSearch: Infinity,
-  });
+    placeholder: 'Select Icon Size',
+    minimumResultsForSearch: Infinity
+  })
 
-  $selectIconSize.on("change", function() {
-    Store.set('iconSizeModifier', this.value);
-    redrawPokemon(map_data.pokemons);
-    redrawPokemon(map_data.lure_pokemons);
-  });
+  $selectIconSize.on('change', function () {
+    Store.set('iconSizeModifier', this.value)
+    redrawPokemon(mapData.pokemons)
+    redrawPokemon(mapData.lurePokemons)
+  })
 
-  $selectLuredPokestopsOnly = $('#lured-pokestops-only-switch');
+  $selectLuredPokestopsOnly = $('#lured-pokestops-only-switch')
 
   $selectLuredPokestopsOnly.select2({
-    placeholder: "Only Show Lured Pokestops",
-    minimumResultsForSearch: Infinity,
-  });
+    placeholder: 'Only Show Lured Pokestops',
+    minimumResultsForSearch: Infinity
+  })
 
-  $selectLuredPokestopsOnly.on("change", function() {
-    Store.set("showLuredPokestopsOnly", this.value);
-    updateMap();
-  });
+  $selectLuredPokestopsOnly.on('change', function () {
+    Store.set('showLuredPokestopsOnly', this.value)
+    updateMap()
+  })
+})
 
-});
-
-$(function() {
-  function formatState(state) {
+$(function () {
+  function formatState (state) {
     if (!state.id) {
-      return state.text;
+      return state.text
     }
     var $state = $(
       '<span><i class="pokemon-sprite n' + state.element.value.toString() + '"></i> ' + state.text + '</span>'
-    );
-    return $state;
-  };
-
-  if (Store.get('startAtUserLocation')) {
-    centerMapOnLocation();
+    )
+    return $state
   }
 
-  $selectExclude = $("#exclude-pokemon");
-  $selectNotify = $("#notify-pokemon");
-  var numberOfPokemon = 151;
+  if (Store.get('startAtUserLocation')) {
+    centerMapOnLocation()
+  }
+
+  $selectExclude = $('#exclude-pokemon')
+  $selectNotify = $('#notify-pokemon')
+  var numberOfPokemon = 151
 
   // Load pokemon names and populate lists
-  $.getJSON("static/dist/data/pokemon.min.json").done(function(data) {
-    var pokeList = [];
+  $.getJSON('static/dist/data/pokemon.min.json').done(function (data) {
+    var pokeList = []
 
-    $.each(data, function(key, value) {
+    $.each(data, function (key, value) {
       if (key > numberOfPokemon) {
-        return false;
+        return false
       }
-      var _types = [];
+      var _types = []
       pokeList.push({
         id: key,
         text: i8ln(value['name']) + ' - #' + key
-      });
-      value['name'] = i8ln(value['name']);
-      value['rarity'] = i8ln(value['rarity']);
-      $.each(value['types'], function(key, pokemon_type) {
+      })
+      value['name'] = i8ln(value['name'])
+      value['rarity'] = i8ln(value['rarity'])
+      $.each(value['types'], function (key, pokemonType) {
         _types.push({
-          "type": i8ln(pokemon_type['type']),
-          "color": pokemon_type['color']
-        });
-      });
-      value['types'] = _types;
+          'type': i8ln(pokemonType['type']),
+          'color': pokemonType['color']
+        })
+      })
+      value['types'] = _types
       idToPokemon[key] = value
-    });
+    })
 
     // setup the filter lists
     $selectExclude.select2({
-      placeholder: i8ln("Select Pokémon"),
+      placeholder: i8ln('Select Pokémon'),
       data: pokeList,
       templateResult: formatState
-    });
+    })
     $selectNotify.select2({
-      placeholder: i8ln("Select Pokémon"),
+      placeholder: i8ln('Select Pokémon'),
       data: pokeList,
       templateResult: formatState
-    });
+    })
 
     // setup list change behavior now that we have the list to work from
-    $selectExclude.on("change", function(e) {
-      excludedPokemon = $selectExclude.val().map(Number);
-      clearStaleMarkers();
-      Store.set('remember_select_exclude', excludedPokemon);
-    });
-    $selectNotify.on("change", function(e) {
-      notifiedPokemon = $selectNotify.val().map(Number);
-      Store.set('remember_select_notify', notifiedPokemon);
-    });
+    $selectExclude.on('change', function (e) {
+      excludedPokemon = $selectExclude.val().map(Number)
+      clearStaleMarkers()
+      Store.set('remember_select_exclude', excludedPokemon)
+    })
+    $selectNotify.on('change', function (e) {
+      notifiedPokemon = $selectNotify.val().map(Number)
+      Store.set('remember_select_notify', notifiedPokemon)
+    })
 
     // recall saved lists
-    $selectExclude.val(Store.get('remember_select_exclude')).trigger("change");
-    $selectNotify.val(Store.get('remember_select_notify')).trigger("change");
-  });
+    $selectExclude.val(Store.get('remember_select_exclude')).trigger('change')
+    $selectNotify.val(Store.get('remember_select_notify')).trigger('change')
+  })
 
   // run interval timers to regularly update map and timediffs
-  window.setInterval(updateLabelDiffTime, 1000);
-  window.setInterval(updateMap, 5000);
-  window.setInterval(function() {
+  window.setInterval(updateLabelDiffTime, 1000)
+  window.setInterval(updateMap, 5000)
+  window.setInterval(function () {
     if (navigator.geolocation && Store.get('geoLocate')) {
-      navigator.geolocation.getCurrentPosition(function(position) {
-        var baseURL = location.protocol + "//" + location.hostname + (location.port ? ":" + location.port : "");
-        var lat = position.coords.latitude;
-        var lon = position.coords.longitude;
+      navigator.geolocation.getCurrentPosition(function (position) {
+        var baseURL = location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '')
+        var lat = position.coords.latitude
+        var lon = position.coords.longitude
 
-        //the search function makes any small movements cause a loop. Need to increase resolution
+        // the search function makes any small movements cause a loop. Need to increase resolution
         if (getPointDistance(marker.getPosition(), (new google.maps.LatLng(lat, lon))) > 40) {
-          $.post(baseURL + "/next_loc?lat=" + lat + "&lon=" + lon).done(function() {
-            var center = new google.maps.LatLng(lat, lon);
-            map.panTo(center);
-            marker.setPosition(center);
-          });
+          $.post(baseURL + '/next_loc?lat=' + lat + '&lon=' + lon).done(function () {
+            var center = new google.maps.LatLng(lat, lon)
+            map.panTo(center)
+            marker.setPosition(center)
+          })
         }
-      });
+      })
     }
-  }, 1000);
+  }, 1000)
 
-  //Wipe off/restore map icons when switches are toggled
-  function buildSwitchChangeListener(data, data_type, storageKey) {
+  // Wipe off/restore map icons when switches are toggled
+  function buildSwitchChangeListener (data, dataType, storageKey) {
     return function () {
-      Store.set(storageKey, this.checked);
+      Store.set(storageKey, this.checked)
       if (this.checked) {
-        updateMap();
+        updateMap()
       } else {
-        $.each(data_type, function(d, d_type) {
-          $.each(data[d_type], function (key, value) {
-            data[d_type][key].marker.setMap(null);
-          });
-          data[d_type] = {}
-        });
+        $.each(dataType, function (d, dType) {
+          $.each(data[dType], function (key, value) {
+            data[dType][key].marker.setMap(null)
+          })
+          data[dType] = {}
+        })
       }
-    };
+    }
   }
 
   // Setup UI element interactions
-  $('#gyms-switch').change(buildSwitchChangeListener(map_data, ["gyms"], "showGyms"));
-  $('#pokemon-switch').change(buildSwitchChangeListener(map_data, ["pokemons", "lure_pokemons"], "showPokemon"));
-  $('#scanned-switch').change(buildSwitchChangeListener(map_data, ["scanned"], "showScanned"));
+  $('#gyms-switch').change(buildSwitchChangeListener(mapData, ['gyms'], 'showGyms'))
+  $('#pokemon-switch').change(buildSwitchChangeListener(mapData, ['pokemons', 'lure_pokemons'], 'showPokemon'))
+  $('#scanned-switch').change(buildSwitchChangeListener(mapData, ['scanned'], 'showScanned'))
 
-  $('#pokestops-switch').change(function() {
+  $('#pokestops-switch').change(function () {
     var options = {
-        'duration': 500
-      },
-      wrapper = $('#lured-pokestops-only-wrapper');
-    if (this.checked) {
-      wrapper.show(options);
-    } else {
-      wrapper.hide(options);
+      'duration': 500
     }
-    return buildSwitchChangeListener(map_data, ["pokestops"], "showPokestops").bind(this)();
-  });
+    var wrapper = $('#lured-pokestops-only-wrapper')
+    if (this.checked) {
+      wrapper.show(options)
+    } else {
+      wrapper.hide(options)
+    }
+    return buildSwitchChangeListener(mapData, ['pokestops'], 'showPokestops').bind(this)()
+  })
 
-  $('#sound-switch').change(function() {
-    Store.set("playSound", this.checked);
-  });
+  $('#sound-switch').change(function () {
+    Store.set('playSound', this.checked)
+  })
 
-  $('#geoloc-switch').change(function() {
-    $("#next-location").prop("disabled", this.checked);
-    $("#next-location").css("background-color", this.checked ? "#e0e0e0" : "#ffffff");
-    if (!navigator.geolocation)
-      this.checked = false;
-    else
-      Store.set('geoLocate', this.checked);
-  });
+  $('#geoloc-switch').change(function () {
+    $('#next-location').prop('disabled', this.checked)
+    $('#next-location').css('background-color', this.checked ? '#e0e0e0' : '#ffffff')
+    if (!navigator.geolocation) {
+      this.checked = false
+    } else {
+      Store.set('geoLocate', this.checked)
+    }
+  })
 
-  $('#search-switch').change(function() {
-    searchControl(this.checked?'on':'off');
-  });
+  $('#search-switch').change(function () {
+    searchControl(this.checked ? 'on' : 'off')
+  })
 
-  $('#start-at-user-location-switch').change(function() {
-    Store.set("startAtUserLocation", this.checked);
-  });
+  $('#start-at-user-location-switch').change(function () {
+    Store.set('startAtUserLocation', this.checked)
+  })
 
-  $("#nav-accordion").accordion({
+  $('#nav-accordion').accordion({
     active: false,
-    collapsible: true,
-  });
-
-});
+    collapsible: true
+  })
+})

--- a/static/js/mobile.js
+++ b/static/js/mobile.js
@@ -1,64 +1,59 @@
-var useLoc = document.getElementById('use-loc');
-useLoc.checked = localStorage.useLoc === 'true';
-useLoc.onchange = function() {
-  localStorage.useLoc = useLoc.checked;
-};
+var useLoc = document.getElementById('use-loc')
+useLoc.checked = localStorage.useLoc === 'true'
+useLoc.onchange = function () {
+  localStorage.useLoc = useLoc.checked
+}
 
-
-var navBtn = document.querySelector('#nav button');
-navBtn.onclick = function() {
+var navBtn = document.querySelector('#nav button')
+navBtn.onclick = function () {
   if (localStorage.useLoc !== 'true') {
-    navBtn.disabled = true;
-    return (location.href="mobile");
-  }
-  else if ("geolocation" in navigator) {
+    navBtn.disabled = true
+    return (location.href = 'mobile')
+  } else if ('geolocation' in navigator) {
     // Getting the GPS position can be very slow on some devices
-    navBtn.disabled = true;
-    navBtn.innerText = 'Locating...';
+    navBtn.disabled = true
+    navBtn.innerText = 'Locating...'
 
     // Get location and use it!
-    navigator.geolocation.getCurrentPosition(function(p) {
-      navBtn.innerText = 'Reloading...';
-      location.href='mobile?lat='+p.coords.latitude+'&lon='+p.coords.longitude;
-
-    }, function(err) {
-      navBtn.innerText = 'Reload';
-      navBtn.disabled = false;
-      alert('Failed to get location: ' + err.message);
-
+    navigator.geolocation.getCurrentPosition(function (p) {
+      navBtn.innerText = 'Reloading...'
+      location.href = 'mobile?lat=' + p.coords.latitude + '&lon=' + p.coords.longitude
+    }, function (err) {
+      navBtn.innerText = 'Reload'
+      navBtn.disabled = false
+      alert('Failed to get location: ' + err.message)
     }, {
       enableHighAccuracy: true,
       timeout: 5000,
       maximumAge: 5000
-    });
+    })
+  } else {
+    alert('Your device does not support web geolocation')
   }
-  else {
-    alert('Your device does not support web geolocation');
-  }
-};
+}
 
-function updateTimes() {
+function updateTimes () {
   // server tells us how many seconds are left we note the
   // pageload time and count down from there.
   // Yes, this could be a smidge innaccurate, but not by
   // more than 1 second or so which doesn't matter.
   // And now we don't have to deal with timestamps and dates!
-  var remains = document.querySelectorAll('div.remain');
+  var remains = document.querySelectorAll('div.remain')
   for (var i = 0; i < remains.length; ++i) {
-    var element = remains[i];
-    var now = new Date().getTime();
-    var secondsPassed = Math.floor((now - page_loaded)/1000);
-    var alivefor =  element.getAttribute('disappear');
-    var remain = alivefor - secondsPassed;
-    var min = Math.floor(remain / 60);
-    var sec = remain % 60;
-    element.innerText = (remain > 0) ? min + ' min ' + sec + ' sec' : '(expired)';
+    var element = remains[i]
+    var now = new Date().getTime()
+    var secondsPassed = Math.floor((now - pageLoaded) / 1000)
+    var alivefor = element.getAttribute('disappear')
+    var remain = alivefor - secondsPassed
+    var min = Math.floor(remain / 60)
+    var sec = remain % 60
+    element.innerText = (remain > 0) ? min + ' min ' + sec + ' sec' : '(expired)'
   }
-};
-setInterval(updateTimes, 1000);
+}
+setInterval(updateTimes, 1000)
 
-document.querySelectorAll("li").forEach(function(listItem) {
-  listItem.onclick = function() {
-    window.document.location = this.getAttribute('href');
-  };
-});
+document.querySelectorAll('li').forEach(function (listItem) {
+  listItem.onclick = function () {
+    window.document.location = this.getAttribute('href')
+  }
+})

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -1,7 +1,7 @@
-/*Shared*/
+/* Shared */
 var monthArray = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 
-/*Main stats page*/
+/* Main stats page */
 var rawDataIsLoading = false
 var totalPokemon = 151
 
@@ -95,8 +95,9 @@ function addElement (pokemonId, name) {
 }
 
 function processSeen (seen) {
+  var i;
   var total = seen.total
-  var shown = Array()
+  var shown = []
 
   seen.pokemon.sort(function (a, b) {
     var sort = document.getElementById('sort')
@@ -120,15 +121,14 @@ function processSeen (seen) {
       return 0
     } else {
       // Default to count
-      if (a['count'] === b['count']) // Same count: order by id
-      {
+      if (a['count'] === b['count']) { // Same count: order by id
         return b['pokemon_id'] - a['pokemon_id']
       }
       return a['count'] - b['count']
     }
   })
 
-  for (var i = seen.pokemon.length - 1; i >= 0; i--) {
+  for (i = seen.pokemon.length - 1; i >= 0; i--) {
     var item = seen.pokemon[i]
     var percentage = (item['count'] / total * 100).toFixed(2)
     var lastSeen = new Date(item['disappear_time'])
@@ -152,7 +152,7 @@ function processSeen (seen) {
   }
 
   // Hide any unneeded items
-  for (var i = 1; i <= totalPokemon; i++) {
+  for (i = 1; i <= totalPokemon; i++) {
     if (shown.indexOf(i) < 0) {
       $('#seen_' + i).hide()
     }
@@ -183,7 +183,7 @@ function updateMap (firstRun) {
 
 updateMap()
 
-/*Overlay*/
+/* Overlay */
 var detailsLoading = false
 var detailInterval = null
 var lastappearance = 1
@@ -192,7 +192,7 @@ var mapLoaded = false
 var detailsPersist = false
 var map = null
 var heatmap = null
-var heatmap_numPoints = -1
+var heatmapNumPoints = -1
 var heatmapPoints = []
 mapData.appearances = {}
 
@@ -235,7 +235,7 @@ function closeTimes () {
 }
 
 // Overrides addListeners in map.js
-function addListeners (marker) {
+function addListeners (marker) { // eslint-disable-line no-unused-vars
   marker.addListener('click', function () {
     showTimes(marker)
     detailsPersist = true
@@ -282,10 +282,10 @@ function initMap () {
     }
   })
 
-  var style_NoLabels = new google.maps.StyledMapType(noLabelsStyle, {
+  var styleNoLabels = new google.maps.StyledMapType(noLabelsStyle, {
     name: 'No Labels'
   })
-  map.mapTypes.set('nolabels_style', style_NoLabels)
+  map.mapTypes.set('nolabels_style', styleNoLabels)
 
   var styleDark = new google.maps.StyledMapType(darkStyle, {
     name: 'Dark'
@@ -338,7 +338,7 @@ function resetMap () {
   })
 
   heatmapPoints = []
-  heatmap_numPoints = 0
+  heatmapNumPoints = 0
   if (heatmap) {
     heatmap.setMap(null)
   }
@@ -361,7 +361,7 @@ function showOverlay (id) {
   return false
 }
 
-function closeOverlay () {
+function closeOverlay () { // eslint-disable-line no-unused-vars
   $('#location_details').hide()
   window.clearInterval(detailInterval)
   closeTimes()
@@ -438,7 +438,7 @@ function updateDetails () {
     $.each(result.appearances, processAppearance)
 
     // Redraw the heatmap with all the new appearances
-    if (heatmap_numPoints !== heatmapPoints.length) {
+    if (heatmapNumPoints !== heatmapPoints.length) {
       if (heatmap) {
         heatmap.setMap(null)
       }
@@ -447,7 +447,7 @@ function updateDetails () {
         map: map,
         radius: 50
       })
-      heatmap_numPoints = heatmapPoints.length
+      heatmapNumPoints = heatmapPoints.length
     }
   })
 }

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -109,41 +109,41 @@ function processSeen(seen){
                             }
 
                             if(sort.options[sort.selectedIndex].value == "id"){
-                                return a.pokemon_id-b.pokemon_id;
+                                return a['pokemon_id']-b['pokemon_id'];
                             }else if(sort.options[sort.selectedIndex].value == "name"){
-                                if(a.pokemon_name.toLowerCase() < b.pokemon_name.toLowerCase()) return 1;
-                                if(a.pokemon_name.toLowerCase() > b.pokemon_name.toLowerCase()) return -1;
+                                if(a['pokemon_name'].toLowerCase() < b['pokemon_name'].toLowerCase()) return 1;
+                                if(a['pokemon_name'].toLowerCase() > b['pokemon_name'].toLowerCase()) return -1;
                                 return 0;
                             }else{
                                 //Default to count
-                                if(a.count == b.count) //Same count: order by id
-                                    return b.pokemon_id-a.pokemon_id;
+                                if(a['count'] == b['count']) //Same count: order by id
+                                    return b['pokemon_id']-a['pokemon_id'];
 
-                                return a.count-b.count;
+                                return a['count']-b['count'];
                             }
 
                         });
 
     for(var i = seen.pokemon.length - 1; i >= 0; i--){
         var item = seen.pokemon[i];
-        var percentage = (item.count / total * 100).toFixed(2);
-        var lastSeen = new Date(item.disappear_time);
+        var percentage = (item['count'] / total * 100).toFixed(2);
+        var lastSeen = new Date(item['disappear_time']);
         lastSeen =  lastSeen.getHours() + ':' +
                     ("0" + lastSeen.getMinutes()).slice(-2) + ':' +
                     ("0" + lastSeen.getSeconds()).slice(-2) + ' ' +
                     lastSeen.getDate() + ' ' +
                     monthArray[lastSeen.getMonth()] + ' ' +
                     lastSeen.getFullYear();
-        var location = (item.latitude * 1).toFixed(7) + ', ' + (item.longitude * 1).toFixed(7);
-        if(!$('#seen_' + item.pokemon_id).length)
-            addElement(item.pokemon_id, item.pokemon_name);
-        $('#count_' + item.pokemon_id).html('<strong>Seen:</strong> ' + item.count.toLocaleString() + ' (' + percentage + '%)');
-        $('#lastseen_' + item.pokemon_id).html('<strong>Last Seen:</strong> ' + lastSeen);
-        $('#location_' + item.pokemon_id).html('<strong>Location:</strong> ' + location);
-        $('#seen_' + item.pokemon_id).show();
+        var location = (item['latitude'] * 1).toFixed(7) + ', ' + (item['longitude'] * 1).toFixed(7);
+        if(!$('#seen_' + item['pokemon_id']).length)
+            addElement(item['pokemon_id'], item['pokemon_name']);
+        $('#count_' + item['pokemon_id']).html('<strong>Seen:</strong> ' + item['count'].toLocaleString() + ' (' + percentage + '%)');
+        $('#lastseen_' + item['pokemon_id']).html('<strong>Last Seen:</strong> ' + lastSeen);
+        $('#location_' + item['pokemon_id']).html('<strong>Location:</strong> ' + location);
+        $('#seen_' + item['pokemon_id']).show();
         //Reverting to classic javascript here as it's supposed to increase performance
-        document.getElementById('seen_container').insertBefore(document.getElementById('seen_' + item.pokemon_id), document.getElementById('seen_container').childNodes[0]);
-        shown.push(item.pokemon_id);
+        document.getElementById('seen_container').insertBefore(document.getElementById('seen_' + item['pokemon_id']), document.getElementById('seen_container').childNodes[0]);
+        shown.push(item['pokemon_id']);
     }
 
     //Hide any unneeded items
@@ -360,37 +360,37 @@ function closeOverlay(){
 }
 
 function processAppearance(i, item){
-    var saw = new Date(item.disappear_time);
+    var saw = new Date(item['disappear_time']);
     saw =   saw.getHours() + ":" +
             ("0" + saw.getMinutes()).slice(-2) + ":" +
             ("0" + saw.getSeconds()).slice(-2) + " " +
             saw.getDate() + " " +
             monthArray[saw.getMonth()] + " " +
             saw.getFullYear();
-    var uuid = item.latitude.toFixed(7) + "_" + item.longitude.toFixed(7);
+    var uuid = item['latitude'].toFixed(7) + "_" + item['longitude'].toFixed(7);
     if(!((uuid) in map_data.appearances)){
-        if (item.marker) item.marker.setMap(null);
-          item.count = 1;
-          item.times = [saw];
-          item.uuid = uuid;
-          item.marker = setupPokemonMarker(item, true);
+        if (item['marker']) item['marker'].setMap(null);
+          item['count'] = 1;
+          item['times'] = [saw];
+          item['uuid'] = uuid;
+          item['marker'] = setupPokemonMarker(item, true);
 
-          map_data.appearances[item.uuid] = item;
+          map_data.appearances[item['uuid']] = item;
     }else{
         map_data.appearances[uuid].count++;
         map_data.appearances[uuid].times.push(saw);
     }
 
-    heatmapPoints.push(new google.maps.LatLng(item.latitude, item.longitude));
-    lastappearance = Math.max(lastappearance, item.disappear_time);
+    heatmapPoints.push(new google.maps.LatLng(item['latitude'], item['longitude']));
+    lastappearance = Math.max(lastappearance, item['disappear_time']);
 }
 
 function redrawAppearances(appearances){
     $.each(appearances, function(key, value) {
         var item = appearances[key];
-        if (!item.hidden) {
+        if (!item['hidden']) {
           var new_marker = setupPokemonMarker(item, true);
-          item.marker.setMap(null);
+          item['marker'].setMap(null);
           appearances[key].marker = new_marker;
         }
     });
@@ -399,7 +399,7 @@ function redrawAppearances(appearances){
 function appearanceTab(item){
     var times = '';
 
-    $.each(item.times, function(key, value){
+    $.each(item['times'], function(key, value){
         times = '<div class="row' + (key % 2) + '">' + value + '</div>' + times;
     });
 
@@ -407,13 +407,13 @@ function appearanceTab(item){
                 <a href="javascript:closeTimes();">Close this tab</a>
             </div>
             <div class="row1">
-                <strong>Lat:</strong> ${item.latitude.toFixed(7)}
+                <strong>Lat:</strong> ${item['latitude'].toFixed(7)}
             </div>
             <div class="row0">
-                <strong>Long:</strong> ${item.longitude.toFixed(7)}
+                <strong>Long:</strong> ${item['longitude'].toFixed(7)}
             </div>
             <div class="row1">
-              <strong>Appearances:</strong> ${item.count.toLocaleString()}
+              <strong>Appearances:</strong> ${item['count'].toLocaleString()}
             </div>
             <div class="row0"><strong>Times:</strong></div>
             <div>

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -1,409 +1,421 @@
 /*Shared*/
-var monthArray = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+var monthArray = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 
 /*Main stats page*/
-var rawDataIsLoading = false;
-var totalPokemon = 151;
+var rawDataIsLoading = false
+var totalPokemon = 151
 
-function loadRawData(){
-    return $.ajax({
-        url: "raw_data",
-        type: 'GET',
-        data: {
-            'pokemon': false,
-            'pokestops': false,
-            'gyms': false,
-            'scanned': false,
-            'seen': true,
-            'duration': document.getElementById('duration').options[document.getElementById('duration').selectedIndex].value
-        },
-        dataType: "json",
-        beforeSend: function() {
-            if (rawDataIsLoading) {
-                return false;
-            } else {
-                rawDataIsLoading = true;
-            }
-        },
-        complete: function() {
-            rawDataIsLoading = false;
-        }
-    })
+function loadRawData () {
+  return $.ajax({
+    url: 'raw_data',
+    type: 'GET',
+    data: {
+      'pokemon': false,
+      'pokestops': false,
+      'gyms': false,
+      'scanned': false,
+      'seen': true,
+      'duration': document.getElementById('duration').options[document.getElementById('duration').selectedIndex].value
+    },
+    dataType: 'json',
+    beforeSend: function () {
+      if (rawDataIsLoading) {
+        return false
+      } else {
+        rawDataIsLoading = true
+      }
+    },
+    complete: function () {
+      rawDataIsLoading = false
+    }
+  })
 }
 
-function addElement(pokemon_id, name){
-    jQuery('<div/>', {
-        id: 'seen_' + pokemon_id,
-        class: 'item'
-    }).appendTo('#seen_container');
+function addElement (pokemonId, name) {
+  jQuery('<div/>', {
+    id: 'seen_' + pokemonId,
+    class: 'item'
+  }).appendTo('#seen_container')
 
-    jQuery('<div/>',{
-        id: 'seen_' + pokemon_id + '_base',
-        class: 'container'
-    }).appendTo('#seen_' + pokemon_id);
+  jQuery('<div/>', {
+    id: 'seen_' + pokemonId + '_base',
+    class: 'container'
+  }).appendTo('#seen_' + pokemonId)
 
-    var imageContainer = jQuery('<div/>',{
-                            class: 'image',
-                        }).appendTo('#seen_' + pokemon_id + '_base');
+  var imageContainer = jQuery('<div/>', {
+    class: 'image'
+  }).appendTo('#seen_' + pokemonId + '_base')
 
-    jQuery('<img/>', {
-        src: 'static/icons/' + pokemon_id + '.png',
-        alt: 'Image for Pokemon #' + pokemon_id
-    }).appendTo(imageContainer);
+  jQuery('<img/>', {
+    src: 'static/icons/' + pokemonId + '.png',
+    alt: 'Image for Pokemon #' + pokemonId
+  }).appendTo(imageContainer)
 
-    var baseDetailContainer = jQuery('<div/>', {
-                                    class: 'info'
-                                }).appendTo('#seen_' + pokemon_id + '_base');
+  var baseDetailContainer = jQuery('<div/>', {
+    class: 'info'
+  }).appendTo('#seen_' + pokemonId + '_base')
 
-    jQuery('<div/>', {
-        id: 'name_' + pokemon_id,
-        class: 'name'
-    }).appendTo(baseDetailContainer);
+  jQuery('<div/>', {
+    id: 'name_' + pokemonId,
+    class: 'name'
+  }).appendTo(baseDetailContainer)
 
-    jQuery('<a/>',{
-        id: 'link_' + pokemon_id,
-        href: 'http://www.pokemon.com/us/pokedex/' + pokemon_id,
-        target: '_blank',
-        title: 'View in Pokedex',
-        text: name
-    }).appendTo('#name_' + pokemon_id);
+  jQuery('<a/>', {
+    id: 'link_' + pokemonId,
+    href: 'http://www.pokemon.com/us/pokedex/' + pokemonId,
+    target: '_blank',
+    title: 'View in Pokedex',
+    text: name
+  }).appendTo('#name_' + pokemonId)
 
-    jQuery('<div/>', {
-        id: 'seen_' + pokemon_id + '_details',
-        class: 'details',
-    }).appendTo('#seen_' + pokemon_id);
+  jQuery('<div/>', {
+    id: 'seen_' + pokemonId + '_details',
+    class: 'details'
+  }).appendTo('#seen_' + pokemonId)
 
-    jQuery('<div/>', {
-        id: 'count_' + pokemon_id,
-        class: 'seen'
-    }).appendTo('#seen_' + pokemon_id + '_details');
+  jQuery('<div/>', {
+    id: 'count_' + pokemonId,
+    class: 'seen'
+  }).appendTo('#seen_' + pokemonId + '_details')
 
-    jQuery('<div/>', {
-        id: 'lastseen_' + pokemon_id,
-        class: 'lastseen'
-    }).appendTo('#seen_' + pokemon_id + '_details');
+  jQuery('<div/>', {
+    id: 'lastseen_' + pokemonId,
+    class: 'lastseen'
+  }).appendTo('#seen_' + pokemonId + '_details')
 
-    jQuery('<div/>',{
-        id: 'location_' + pokemon_id,
-        class: 'location'
-    }).appendTo('#seen_' + pokemon_id + '_details');
+  jQuery('<div/>', {
+    id: 'location_' + pokemonId,
+    class: 'location'
+  }).appendTo('#seen_' + pokemonId + '_details')
 
-    jQuery('<a/>',{
-        href: 'javascript:showOverlay(' + pokemon_id + ');',
-        text: 'All Locations'
-    }).appendTo('#seen_' + pokemon_id + '_details');
+  jQuery('<a/>', {
+    href: 'javascript:showOverlay(' + pokemonId + ');',
+    text: 'All Locations'
+  }).appendTo('#seen_' + pokemonId + '_details')
 }
 
-function processSeen(seen){
-    var total = seen.total;
-    var shown = Array();
+function processSeen (seen) {
+  var total = seen.total
+  var shown = Array()
 
-    seen.pokemon.sort(function(a, b){
-                            var sort = document.getElementById("sort");
-                            var order = document.getElementById("order");
+  seen.pokemon.sort(function (a, b) {
+    var sort = document.getElementById('sort')
+    var order = document.getElementById('order')
 
-                            if(order.options[order.selectedIndex].value == "desc"){
-                                var tmp = b;
-                                b = a;
-                                a = tmp;
-                            }
-
-                            if(sort.options[sort.selectedIndex].value == "id"){
-                                return a['pokemon_id']-b['pokemon_id'];
-                            }else if(sort.options[sort.selectedIndex].value == "name"){
-                                if(a['pokemon_name'].toLowerCase() < b['pokemon_name'].toLowerCase()) return 1;
-                                if(a['pokemon_name'].toLowerCase() > b['pokemon_name'].toLowerCase()) return -1;
-                                return 0;
-                            }else{
-                                //Default to count
-                                if(a['count'] == b['count']) //Same count: order by id
-                                    return b['pokemon_id']-a['pokemon_id'];
-
-                                return a['count']-b['count'];
-                            }
-
-                        });
-
-    for(var i = seen.pokemon.length - 1; i >= 0; i--){
-        var item = seen.pokemon[i];
-        var percentage = (item['count'] / total * 100).toFixed(2);
-        var lastSeen = new Date(item['disappear_time']);
-        lastSeen =  lastSeen.getHours() + ':' +
-                    ("0" + lastSeen.getMinutes()).slice(-2) + ':' +
-                    ("0" + lastSeen.getSeconds()).slice(-2) + ' ' +
-                    lastSeen.getDate() + ' ' +
-                    monthArray[lastSeen.getMonth()] + ' ' +
-                    lastSeen.getFullYear();
-        var location = (item['latitude'] * 1).toFixed(7) + ', ' + (item['longitude'] * 1).toFixed(7);
-        if(!$('#seen_' + item['pokemon_id']).length)
-            addElement(item['pokemon_id'], item['pokemon_name']);
-        $('#count_' + item['pokemon_id']).html('<strong>Seen:</strong> ' + item['count'].toLocaleString() + ' (' + percentage + '%)');
-        $('#lastseen_' + item['pokemon_id']).html('<strong>Last Seen:</strong> ' + lastSeen);
-        $('#location_' + item['pokemon_id']).html('<strong>Location:</strong> ' + location);
-        $('#seen_' + item['pokemon_id']).show();
-        //Reverting to classic javascript here as it's supposed to increase performance
-        document.getElementById('seen_container').insertBefore(document.getElementById('seen_' + item['pokemon_id']), document.getElementById('seen_container').childNodes[0]);
-        shown.push(item['pokemon_id']);
+    if (order.options[order.selectedIndex].value === 'desc') {
+      var tmp = b
+      b = a
+      a = tmp
     }
 
-    //Hide any unneeded items
-    for(var i = 1; i <= totalPokemon; i++){
-        if(shown.indexOf(i) < 0)
-            $('#seen_' + i).hide();
+    if (sort.options[sort.selectedIndex].value === 'id') {
+      return a['pokemon_id'] - b['pokemon_id']
+    } else if (sort.options[sort.selectedIndex].value === 'name') {
+      if (a['pokemon_name'].toLowerCase() < b['pokemon_name'].toLowerCase()) {
+        return 1
+      }
+      if (a['pokemon_name'].toLowerCase() > b['pokemon_name'].toLowerCase()) {
+        return -1
+      }
+      return 0
+    } else {
+      // Default to count
+      if (a['count'] === b['count']) // Same count: order by id
+      {
+        return b['pokemon_id'] - a['pokemon_id']
+      }
+      return a['count'] - b['count']
     }
+  })
 
-    document.getElementById("seen_total").innerHTML = 'Total: ' + total.toLocaleString();
+  for (var i = seen.pokemon.length - 1; i >= 0; i--) {
+    var item = seen.pokemon[i]
+    var percentage = (item['count'] / total * 100).toFixed(2)
+    var lastSeen = new Date(item['disappear_time'])
+    lastSeen = lastSeen.getHours() + ':' +
+    ('0' + lastSeen.getMinutes()).slice(-2) + ':' +
+    ('0' + lastSeen.getSeconds()).slice(-2) + ' ' +
+    lastSeen.getDate() + ' ' +
+    monthArray[lastSeen.getMonth()] + ' ' +
+    lastSeen.getFullYear()
+    var location = (item['latitude'] * 1).toFixed(7) + ', ' + (item['longitude'] * 1).toFixed(7)
+    if (!$('#seen_' + item['pokemon_id']).length) {
+      addElement(item['pokemon_id'], item['pokemon_name'])
+    }
+    $('#count_' + item['pokemon_id']).html('<strong>Seen:</strong> ' + item['count'].toLocaleString() + ' (' + percentage + '%)')
+    $('#lastseen_' + item['pokemon_id']).html('<strong>Last Seen:</strong> ' + lastSeen)
+    $('#location_' + item['pokemon_id']).html('<strong>Location:</strong> ' + location)
+    $('#seen_' + item['pokemon_id']).show()
+    // Reverting to classic javascript here as it's supposed to increase performance
+    document.getElementById('seen_container').insertBefore(document.getElementById('seen_' + item['pokemon_id']), document.getElementById('seen_container').childNodes[0])
+    shown.push(item['pokemon_id'])
+  }
+
+  // Hide any unneeded items
+  for (var i = 1; i <= totalPokemon; i++) {
+    if (shown.indexOf(i) < 0) {
+      $('#seen_' + i).hide()
+    }
+  }
+
+  document.getElementById('seen_total').innerHTML = 'Total: ' + total.toLocaleString()
 }
 
-//Override UpdateMap in map.js to take advantage of a pre-existing interval.
-function updateMap(firstRun){
-    var duration = document.getElementById("duration");
-    var header = 'Pokemon Seen in ' + duration.options[duration.selectedIndex].text;
-    if($('#seen_header').html() != header){
-            $('#seen_container').hide();
-            $('#loading').show();
-            $('#seen_header').html('');
-            $('#seen_total').html('');
+// Override UpdateMap in map.js to take advantage of a pre-existing interval.
+function updateMap (firstRun) {
+  var duration = document.getElementById('duration')
+  var header = 'Pokemon Seen in ' + duration.options[duration.selectedIndex].text
+  if ($('#seen_header').html() !== header) {
+    $('#seen_container').hide()
+    $('#loading').show()
+    $('#seen_header').html('')
+    $('#seen_total').html('')
+  }
+  loadRawData().done(function (result) {
+    processSeen(result.seen)
+    if ($('#seen_header').html() !== header) {
+      $('#seen_header').html(header)
+      $('#loading').hide()
+      $('#seen_container').show()
     }
-    loadRawData().done(function (result) {
-        processSeen(result.seen);
-        if($('#seen_header').html() != header){
-            $('#seen_header').html(header);
-            $('#loading').hide();
-            $('#seen_container').show();
-        }
-    });
+  })
 }
 
-updateMap();
+updateMap()
 
 /*Overlay*/
-var detailsLoading = false;
-var detailInterval = null;
-var lastappearance = 1;
-var pokemonid = 0;
-var mapLoaded = false;
-var detailsPersist = false;
-var map = null;
-var heatmap = null;
-var heatmap_numPoints = -1;
-var heatmapPoints = [];
-map_data.appearances = {};
+var detailsLoading = false
+var detailInterval = null
+var lastappearance = 1
+var pokemonid = 0
+var mapLoaded = false
+var detailsPersist = false
+var map = null
+var heatmap = null
+var heatmap_numPoints = -1
+var heatmapPoints = []
+mapData.appearances = {}
 
-function loadDetails(){
-    return $.ajax({
-        url: "raw_data",
-        type: 'GET',
-        data: {
-            'pokemon': false,
-            'pokestops': false,
-            'gyms': false,
-            'scanned': false,
-            'appearances': true,
-            'pokemonid': pokemonid,
-            'last': lastappearance
-        },
-        dataType: "json",
-        beforeSend: function() {
-            if (detailsLoading) {
-                return false;
-            } else {
-                detailsLoading = true;
-            }
-        },
-        complete: function() {
-            detailsLoading = false;
-        }
-    })
+function loadDetails () {
+  return $.ajax({
+    url: 'raw_data',
+    type: 'GET',
+    data: {
+      'pokemon': false,
+      'pokestops': false,
+      'gyms': false,
+      'scanned': false,
+      'appearances': true,
+      'pokemonid': pokemonid,
+      'last': lastappearance
+    },
+    dataType: 'json',
+    beforeSend: function () {
+      if (detailsLoading) {
+        return false
+      } else {
+        detailsLoading = true
+      }
+    },
+    complete: function () {
+      detailsLoading = false
+    }
+  })
 }
 
-function showTimes(marker){
-    var uuid = marker.position.lat().toFixed(7) + "_" + marker.position.lng().toFixed(7);
-    $('#times_list').html(appearanceTab(map_data.appearances[uuid]));
-    $('#times_list').show();
+function showTimes (marker) {
+  var uuid = marker.position.lat().toFixed(7) + '_' + marker.position.lng().toFixed(7)
+  $('#times_list').html(appearanceTab(mapData.appearances[uuid]))
+  $('#times_list').show()
 }
 
-function closeTimes(){
-    $('#times_list').hide();
-    detailsPersist = false;
+function closeTimes () {
+  $('#times_list').hide()
+  detailsPersist = false
 }
 
-//Overrides addListeners in map.js
-function addListeners(marker){
+// Overrides addListeners in map.js
+function addListeners (marker) {
+  marker.addListener('click', function () {
+    showTimes(marker)
+    detailsPersist = true
+  })
 
-    marker.addListener('click', function() {
-        showTimes(marker);
-        detailsPersist = true;
-      });
+  marker.addListener('mouseover', function () {
+    showTimes(marker)
+  })
 
-      marker.addListener('mouseover', function() {
-        showTimes(marker);
-      });
+  marker.addListener('mouseout', function () {
+    if (!detailsPersist) {
+      $('#times_list').hide()
+    }
+  })
 
-      marker.addListener('mouseout', function() {
-        if(!detailsPersist)
-            $('#times_list').hide();
-      });
-
-    return marker;
+  return marker
 }
 
-//Override map.js initMap
-function initMap(){
-    map = new google.maps.Map(document.getElementById('location_map'), {
-        zoom: 16,
-        center: {lat: center_lat, lng: center_lng},
-        fullscreenControl: false,
-        streetViewControl: false,
-        mapTypeControl: true,
-        mapTypeControlOptions: {
-          style: google.maps.MapTypeControlStyle.DROPDOWN_MENU,
-          position: google.maps.ControlPosition.RIGHT_TOP,
-          mapTypeIds: [
-            google.maps.MapTypeId.ROADMAP,
-            google.maps.MapTypeId.SATELLITE,
-            'nolabels_style',
-            'dark_style',
-            'style_light2',
-            'style_pgo',
-            'dark_style_nl',
-            'style_light2_nl',
-            'style_pgo_nl'
-          ]
-        }
-  });
+// Override map.js initMap
+function initMap () {
+  map = new google.maps.Map(document.getElementById('location_map'), {
+    zoom: 16,
+    center: {
+      lat: centerLat,
+      lng: centerLng
+    },
+    fullscreenControl: false,
+    streetViewControl: false,
+    mapTypeControl: true,
+    mapTypeControlOptions: {
+      style: google.maps.MapTypeControlStyle.DROPDOWN_MENU,
+      position: google.maps.ControlPosition.RIGHT_TOP,
+      mapTypeIds: [
+        google.maps.MapTypeId.ROADMAP,
+        google.maps.MapTypeId.SATELLITE,
+        'nolabels_style',
+        'dark_style',
+        'style_light2',
+        'style_pgo',
+        'dark_style_nl',
+        'style_light2_nl',
+        'style_pgo_nl'
+      ]
+    }
+  })
 
   var style_NoLabels = new google.maps.StyledMapType(noLabelsStyle, {
-    name: "No Labels"
-  });
-  map.mapTypes.set('nolabels_style', style_NoLabels);
+    name: 'No Labels'
+  })
+  map.mapTypes.set('nolabels_style', style_NoLabels)
 
-  var style_dark = new google.maps.StyledMapType(darkStyle, {
-    name: "Dark"
-  });
-  map.mapTypes.set('dark_style', style_dark);
+  var styleDark = new google.maps.StyledMapType(darkStyle, {
+    name: 'Dark'
+  })
+  map.mapTypes.set('dark_style', styleDark)
 
-  var style_light2 = new google.maps.StyledMapType(light2Style, {
-    name: "Light2"
-  });
-  map.mapTypes.set('style_light2', style_light2);
+  var styleLight2 = new google.maps.StyledMapType(light2Style, {
+    name: 'Light2'
+  })
+  map.mapTypes.set('style_light2', styleLight2)
 
-  var style_pgo = new google.maps.StyledMapType(pGoStyle, {
-    name: "PokemonGo"
-  });
-  map.mapTypes.set('style_pgo', style_pgo);
+  var stylePgo = new google.maps.StyledMapType(pGoStyle, {
+    name: 'PokemonGo'
+  })
+  map.mapTypes.set('style_pgo', stylePgo)
 
-  var style_dark_nl = new google.maps.StyledMapType(darkStyleNoLabels, {
-    name: "Dark (No Labels)"
-  });
-  map.mapTypes.set('dark_style_nl', style_dark_nl);
+  var styleDarkNl = new google.maps.StyledMapType(darkStyleNoLabels, {
+    name: 'Dark (No Labels)'
+  })
+  map.mapTypes.set('dark_style_nl', styleDarkNl)
 
-  var style_light2_nl = new google.maps.StyledMapType(light2StyleNoLabels, {
-    name: "Light2 (No Labels)"
-  });
-  map.mapTypes.set('style_light2_nl', style_light2_nl);
+  var styleLight2Nl = new google.maps.StyledMapType(light2StyleNoLabels, {
+    name: 'Light2 (No Labels)'
+  })
+  map.mapTypes.set('style_light2_nl', styleLight2Nl)
 
-  var style_pgo_nl = new google.maps.StyledMapType(pGoStyleNoLabels, {
-    name: "PokemonGo (No Labels)"
-  });
-  map.mapTypes.set('style_pgo_nl', style_pgo_nl);
+  var stylePgoNl = new google.maps.StyledMapType(pGoStyleNoLabels, {
+    name: 'PokemonGo (No Labels)'
+  })
+  map.mapTypes.set('style_pgo_nl', stylePgoNl)
 
-  map.addListener('maptypeid_changed', function(s) {
-    Store.set('map_style', this.mapTypeId);
-  });
+  map.addListener('maptypeid_changed', function (s) {
+    Store.set('map_style', this.mapTypeId)
+  })
 
-  map.setMapTypeId(Store.get('map_style'));
-  google.maps.event.addListener(map, 'idle', updateMap);
+  map.setMapTypeId(Store.get('map_style'))
+  google.maps.event.addListener(map, 'idle', updateMap)
 
-  mapLoaded = true;
+  mapLoaded = true
 
-  google.maps.event.addListener(map, 'zoom_changed', function() {
-    redrawAppearances(map_data.appearances);
-  });
+  google.maps.event.addListener(map, 'zoom_changed', function () {
+    redrawAppearances(mapData.appearances)
+  })
 }
 
-function resetMap(){
-    $.each(map_data.appearances, function(key, value) {
-          map_data.appearances[key].marker.setMap(null);
-          delete map_data.appearances[key];
-    });
+function resetMap () {
+  $.each(mapData.appearances, function (key, value) {
+    mapData.appearances[key].marker.setMap(null)
+    delete mapData.appearances[key]
+  })
 
-    heatmapPoints = [];
-    heatmap_numPoints = 0;
-    if(heatmap){
-        heatmap.setMap(null);
+  heatmapPoints = []
+  heatmap_numPoints = 0
+  if (heatmap) {
+    heatmap.setMap(null)
+  }
+
+  lastappearance = 0
+}
+
+function showOverlay (id) {
+  // Only load google maps once, and only if requested
+  if (!mapLoaded) {
+    initMap()
+  }
+  resetMap()
+  pokemonid = id
+  $('#location_details').show()
+  location.hash = 'overlay_' + pokemonid
+  updateDetails()
+  detailInterval = window.setInterval(updateDetails, 5000)
+
+  return false
+}
+
+function closeOverlay () {
+  $('#location_details').hide()
+  window.clearInterval(detailInterval)
+  closeTimes()
+  location.hash = ''
+  return false
+}
+
+function processAppearance (i, item) {
+  var saw = new Date(item['disappear_time'])
+  saw = saw.getHours() + ':' +
+  ('0' + saw.getMinutes()).slice(-2) + ':' +
+  ('0' + saw.getSeconds()).slice(-2) + ' ' +
+  saw.getDate() + ' ' +
+  monthArray[saw.getMonth()] + ' ' +
+  saw.getFullYear()
+  var uuid = item['latitude'].toFixed(7) + '_' + item['longitude'].toFixed(7)
+  if (!((uuid) in mapData.appearances)) {
+    if (item['marker']) {
+      item['marker'].setMap(null)
     }
+    item['count'] = 1
+    item['times'] = [saw]
+    item['uuid'] = uuid
+    item['marker'] = setupPokemonMarker(item, true)
 
-    lastappearance = 0;
+    mapData.appearances[item['uuid']] = item
+  } else {
+    mapData.appearances[uuid].count++
+    mapData.appearances[uuid].times.push(saw)
+  }
+
+  heatmapPoints.push(new google.maps.LatLng(item['latitude'], item['longitude']))
+  lastappearance = Math.max(lastappearance, item['disappear_time'])
 }
 
-function showOverlay(id){
-    //Only load google maps once, and only if requested
-    if(!mapLoaded)
-        initMap();
-    resetMap();
-    pokemonid = id;
-    $('#location_details').show();
-    location.hash = 'overlay_' + pokemonid;
-    updateDetails();
-    detailInterval = window.setInterval(updateDetails, 5000);
-
-    return false;
-}
-
-function closeOverlay(){
-    $('#location_details').hide();
-    window.clearInterval(detailInterval);
-    closeTimes();
-    location.hash = '';
-    return false;
-}
-
-function processAppearance(i, item){
-    var saw = new Date(item['disappear_time']);
-    saw =   saw.getHours() + ":" +
-            ("0" + saw.getMinutes()).slice(-2) + ":" +
-            ("0" + saw.getSeconds()).slice(-2) + " " +
-            saw.getDate() + " " +
-            monthArray[saw.getMonth()] + " " +
-            saw.getFullYear();
-    var uuid = item['latitude'].toFixed(7) + "_" + item['longitude'].toFixed(7);
-    if(!((uuid) in map_data.appearances)){
-        if (item['marker']) item['marker'].setMap(null);
-          item['count'] = 1;
-          item['times'] = [saw];
-          item['uuid'] = uuid;
-          item['marker'] = setupPokemonMarker(item, true);
-
-          map_data.appearances[item['uuid']] = item;
-    }else{
-        map_data.appearances[uuid].count++;
-        map_data.appearances[uuid].times.push(saw);
+function redrawAppearances (appearances) {
+  $.each(appearances, function (key, value) {
+    var item = appearances[key]
+    if (!item['hidden']) {
+      var newMarker = setupPokemonMarker(item, true)
+      item['marker'].setMap(null)
+      appearances[key].marker = newMarker
     }
-
-    heatmapPoints.push(new google.maps.LatLng(item['latitude'], item['longitude']));
-    lastappearance = Math.max(lastappearance, item['disappear_time']);
+  })
 }
 
-function redrawAppearances(appearances){
-    $.each(appearances, function(key, value) {
-        var item = appearances[key];
-        if (!item['hidden']) {
-          var new_marker = setupPokemonMarker(item, true);
-          item['marker'].setMap(null);
-          appearances[key].marker = new_marker;
-        }
-    });
-}
+function appearanceTab (item) {
+  var times = ''
 
-function appearanceTab(item){
-    var times = '';
+  $.each(item['times'], function (key, value) {
+    times = '<div class="row' + (key % 2) + '">' + value + '</div>' + times
+  })
 
-    $.each(item['times'], function(key, value){
-        times = '<div class="row' + (key % 2) + '">' + value + '</div>' + times;
-    });
-
-    return `<div>
+  return `<div>
                 <a href="javascript:closeTimes();">Close this tab</a>
             </div>
             <div class="row1">
@@ -418,27 +430,28 @@ function appearanceTab(item){
             <div class="row0"><strong>Times:</strong></div>
             <div>
                 ${times}
-            </div>`;
+            </div>`
 }
 
-function updateDetails(){
-    loadDetails().done(function (result) {
-        $.each(result.appearances, processAppearance);
+function updateDetails () {
+  loadDetails().done(function (result) {
+    $.each(result.appearances, processAppearance)
 
-        //Redraw the heatmap with all the new appearances
-        if(heatmap_numPoints != heatmapPoints.length){
-            if(heatmap){
-                heatmap.setMap(null);
-            }
-            heatmap = new google.maps.visualization.HeatmapLayer({
-                                data: heatmapPoints,
-                                map: map,
-                                radius: 50
-                            });
-            heatmap_numPoints = heatmapPoints.length;
-        }
-    });
+    // Redraw the heatmap with all the new appearances
+    if (heatmap_numPoints !== heatmapPoints.length) {
+      if (heatmap) {
+        heatmap.setMap(null)
+      }
+      heatmap = new google.maps.visualization.HeatmapLayer({
+        data: heatmapPoints,
+        map: map,
+        radius: 50
+      })
+      heatmap_numPoints = heatmapPoints.length
+    }
+  })
 }
 
-if(location.href.match(/overlay_[0-9]+/g))
-    showOverlay(location.href.replace(/^.*overlay_([0-9]+).*$/, '$1'));
+if (location.href.match(/overlay_[0-9]+/g)) {
+  showOverlay(location.href.replace(/^.*overlay_([0-9]+).*$/, '$1'))
+}

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -1,4 +1,4 @@
-function countMarkers () {
+function countMarkers () { // eslint-disable-line no-unused-vars
   document.getElementById('stats-pkmn-label').innerHTML = 'Pokémons'
   document.getElementById('stats-gym-label').innerHTML = 'Gyms'
   document.getElementById('stats-pkstop-label').innerHTML = 'PokéStops'
@@ -66,7 +66,6 @@ function countMarkers () {
   }
   if (Store.get('showPokestops')) {
     $.each(mapData.pokestops, function (key, value) {
-      var pokestopLured = false
       if (mapData.pokestops[key]['lure_expiration'] && mapData.pokestops[key]['lure_expiration'] > 0) {
         if (pokestopCount[1] === 0 || !pokestopCount[1]) {
           pokestopCount[1] = 1
@@ -111,6 +110,8 @@ var sortBy = function (field, reverse, primer) {
   reverse = !reverse ? 1 : -1
 
   return function (a, b) {
-    return a = key(a), b = key(b), reverse * ((a > b) - (b > a))
+    a = key(a)
+    b = key(b)
+    return reverse * ((a > b) - (b > a))
   }
 }

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -1,116 +1,116 @@
-function countMarkers() {
-  document.getElementById("stats-pkmn-label").innerHTML = "Pokémons";
-  document.getElementById("stats-gym-label").innerHTML = "Gyms";
-  document.getElementById("stats-pkstop-label").innerHTML = "PokéStops";
+function countMarkers () {
+  document.getElementById('stats-pkmn-label').innerHTML = 'Pokémons'
+  document.getElementById('stats-gym-label').innerHTML = 'Gyms'
+  document.getElementById('stats-pkstop-label').innerHTML = 'PokéStops'
 
-  var arenaCount = [];
-  var arenaTotal = 0;
-  var pkmnCount = [];
-  var pkmnTotal = 0;
-  var pokestopCount = [];
-  var pokestopTotal = 0;
+  var arenaCount = []
+  var arenaTotal = 0
+  var pkmnCount = []
+  var pkmnTotal = 0
+  var pokestopCount = []
+  var pokestopTotal = 0
   if (Store.get('showPokemon')) {
-    $.each(map_data.pokemons, function(key, value) {
-      if (pkmnCount[map_data.pokemons[key]['pokemon_id']] == 0 || pkmnCount[map_data.pokemons[key]['pokemon_id']] == null) {
-        pkmnCount[map_data.pokemons[key]['pokemon_id']] = {
-          "ID": map_data.pokemons[key]['pokemon_id'],
-          "Count": 1,
-          "Name": map_data.pokemons[key]['pokemon_name']
-        };
+    $.each(mapData.pokemons, function (key, value) {
+      if (pkmnCount[mapData.pokemons[key]['pokemon_id']] === 0 || !pkmnCount[mapData.pokemons[key]['pokemon_id']]) {
+        pkmnCount[mapData.pokemons[key]['pokemon_id']] = {
+          'ID': mapData.pokemons[key]['pokemon_id'],
+          'Count': 1,
+          'Name': mapData.pokemons[key]['pokemon_name']
+        }
       } else {
-        pkmnCount[map_data.pokemons[key]['pokemon_id']].Count += 1;
+        pkmnCount[mapData.pokemons[key]['pokemon_id']].Count += 1
       }
-      pkmnTotal++;
-    });
-    pkmnCount.sort(sort_by('Name', false));
-    $.each(map_data.pokemons, function(key, value) {
-      var pkmnListString = "<table><thead><tr><th>Icon</th><th>Name</th><th>Count</th><th>%</th></tr></thead><tbody><tr><td></td><td>Total</td><td>" + pkmnTotal + "</td><td></td></tr>";
+      pkmnTotal++
+    })
+    pkmnCount.sort(sortBy('Name', false))
+    $.each(mapData.pokemons, function (key, value) {
+      var pkmnListString = '<table><thead><tr><th>Icon</th><th>Name</th><th>Count</th><th>%</th></tr></thead><tbody><tr><td></td><td>Total</td><td>' + pkmnTotal + '</td><td></td></tr>'
       for (var i = 0; i < pkmnCount.length; i++) {
-        if (pkmnCount[i] != null && pkmnCount[i].Count > 0) {
-          pkmnListString += "<tr><td><img src=\"static/icons/" + pkmnCount[i].ID + ".png\" /></td><td><a href='http://www.pokemon.com/us/pokedex/" + pkmnCount[i].ID + "' target='_blank' title='View in Pokedex' style=\"color: black;\">" + pkmnCount[i].Name + "</a></td><td>" + pkmnCount[i].Count + "</td><td>" + Math.round(pkmnCount[i].Count * 100 / pkmnTotal * 10) / 10 + "%</td></tr>";
+        if (pkmnCount[i] && pkmnCount[i].Count > 0) {
+          pkmnListString += '<tr><td><img src="static/icons/' + pkmnCount[i].ID + '.png" /></td><td><a href=\'http://www.pokemon.com/us/pokedex/' + pkmnCount[i].ID + '\' target=\'_blank\' title=\'View in Pokedex\' style="color: black;">' + pkmnCount[i].Name + '</a></td><td>' + pkmnCount[i].Count + '</td><td>' + Math.round(pkmnCount[i].Count * 100 / pkmnTotal * 10) / 10 + '%</td></tr>'
         }
       }
-      pkmnListString += "</tbody></table>";
-      document.getElementById("pokemonList").innerHTML = pkmnListString;
-    });
+      pkmnListString += '</tbody></table>'
+      document.getElementById('pokemonList').innerHTML = pkmnListString
+    })
   } else {
-    document.getElementById("pokemonList").innerHTML = "Pokémons markers are disabled";;
+    document.getElementById('pokemonList').innerHTML = 'Pokémons markers are disabled'
   }
   if (Store.get('showGyms')) {
-    $.each(map_data.gyms, function(key, value) {
-      if (arenaCount[map_data.gyms[key]['team_id']] == 0 || arenaCount[map_data.gyms[key]['team_id']] == null) {
-        arenaCount[map_data.gyms[key]['team_id']] = 1;
+    $.each(mapData.gyms, function (key, value) {
+      if (arenaCount[mapData.gyms[key]['team_id']] === 0 || !arenaCount[mapData.gyms[key]['team_id']]) {
+        arenaCount[mapData.gyms[key]['team_id']] = 1
       } else {
-        arenaCount[map_data.gyms[key]['team_id']] += 1;
+        arenaCount[mapData.gyms[key]['team_id']] += 1
       }
-      arenaTotal++;
-      var arenaListString = "<table><th>Icon</th><th>Team Color</th><th>Count</th><th>%</th><tr><td></td><td>Total</td><td>" + arenaTotal + "</td></tr>";
+      arenaTotal++
+      var arenaListString = '<table><th>Icon</th><th>Team Color</th><th>Count</th><th>%</th><tr><td></td><td>Total</td><td>' + arenaTotal + '</td></tr>'
       for (var i = 0; i < arenaCount.length; i++) {
         if (arenaCount[i] > 0) {
-          if (i == 1) {
-            arenaListString += "<tr><td><img src=\"static/forts/Mystic.png\" /></td><td>" + "Blue" + "</td><td>" + arenaCount[i] + "</td><td>" + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + "%</td></tr>";
-          } else if (i == 2) {
-            arenaListString += "<tr><td><img src=\"static/forts/Valor.png\" /></td><td>" + "Red" + "</td><td>" + arenaCount[i] + "</td><td>" + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + "%</td></tr>";
-          } else if (i == 3) {
-            arenaListString += "<tr><td><img src=\"static/forts/Instinct.png\" /></td><td>" + "Yellow" + "</td><td>" + arenaCount[i] + "</td><td>" + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + "%</td></tr>";
+          if (i === 1) {
+            arenaListString += '<tr><td><img src="static/forts/Mystic.png" /></td><td>' + 'Blue' + '</td><td>' + arenaCount[i] + '</td><td>' + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + '%</td></tr>'
+          } else if (i === 2) {
+            arenaListString += '<tr><td><img src="static/forts/Valor.png" /></td><td>' + 'Red' + '</td><td>' + arenaCount[i] + '</td><td>' + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + '%</td></tr>'
+          } else if (i === 3) {
+            arenaListString += '<tr><td><img src="static/forts/Instinct.png" /></td><td>' + 'Yellow' + '</td><td>' + arenaCount[i] + '</td><td>' + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + '%</td></tr>'
           } else {
-            arenaListString += "<tr><td><img src=\"static/forts/Uncontested.png\" /></td><td>" + "Clear" + "</td><td>" + arenaCount[i] + "</td><td>" + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + "%</td></tr>";
+            arenaListString += '<tr><td><img src="static/forts/Uncontested.png" /></td><td>' + 'Clear' + '</td><td>' + arenaCount[i] + '</td><td>' + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + '%</td></tr>'
           }
         }
       }
-      arenaListString += "</table>";
-      document.getElementById("arenaList").innerHTML = arenaListString;
-    });
+      arenaListString += '</table>'
+      document.getElementById('arenaList').innerHTML = arenaListString
+    })
   } else {
-    document.getElementById("arenaList").innerHTML = "Gyms markers are disabled";
+    document.getElementById('arenaList').innerHTML = 'Gyms markers are disabled'
   }
   if (Store.get('showPokestops')) {
-    $.each(map_data.pokestops, function(key, value) {
-      var pokestopLured = false;
-      if (map_data.pokestops[key]['lure_expiration'] != null && map_data.pokestops[key]['lure_expiration'] > 0) {
-        if (pokestopCount[1] == 0 || pokestopCount[1] == null) {
-          pokestopCount[1] = 1;
+    $.each(mapData.pokestops, function (key, value) {
+      var pokestopLured = false
+      if (mapData.pokestops[key]['lure_expiration'] && mapData.pokestops[key]['lure_expiration'] > 0) {
+        if (pokestopCount[1] === 0 || !pokestopCount[1]) {
+          pokestopCount[1] = 1
         } else {
-          pokestopCount[1] += 1;
+          pokestopCount[1] += 1
         }
       } else {
-        if (pokestopCount[0] == 0 || pokestopCount[0] == null) {
-          pokestopCount[0] = 1;
+        if (pokestopCount[0] === 0 || !pokestopCount[0]) {
+          pokestopCount[0] = 1
         } else {
-          pokestopCount[0] += 1;
+          pokestopCount[0] += 1
         }
       }
-      pokestopTotal++;
-      var pokestopListString = "<table><th>Icon</th><th>Status</th><th>Count</th><th>%</th><tr><td></td><td>Total</td><td>" + pokestopTotal + "</td></tr>";
+      pokestopTotal++
+      var pokestopListString = '<table><th>Icon</th><th>Status</th><th>Count</th><th>%</th><tr><td></td><td>Total</td><td>' + pokestopTotal + '</td></tr>'
       for (var i = 0; i < pokestopCount.length; i++) {
         if (pokestopCount[i] > 0) {
-          if (i == 0) {
-            pokestopListString += "<tr><td><img src=\"static/forts/Pstop.png\" /></td><td>" + "Not Lured" + "</td><td>" + pokestopCount[i] + "</td><td>" + Math.round(pokestopCount[i] * 100 / pokestopTotal * 10) / 10 + "%</td></tr>";
-          } else if (i == 1) {
-            pokestopListString += "<tr><td><img src=\"static/forts/PstopLured.png\" /></td><td>" + "Lured" + "</td><td>" + pokestopCount[i] + "</td><td>" + Math.round(pokestopCount[i] * 100 / pokestopTotal * 10) / 10 + "%</td></tr>";
+          if (i === 0) {
+            pokestopListString += '<tr><td><img src="static/forts/Pstop.png" /></td><td>' + 'Not Lured' + '</td><td>' + pokestopCount[i] + '</td><td>' + Math.round(pokestopCount[i] * 100 / pokestopTotal * 10) / 10 + '%</td></tr>'
+          } else if (i === 1) {
+            pokestopListString += '<tr><td><img src="static/forts/PstopLured.png" /></td><td>' + 'Lured' + '</td><td>' + pokestopCount[i] + '</td><td>' + Math.round(pokestopCount[i] * 100 / pokestopTotal * 10) / 10 + '%</td></tr>'
           }
         }
       }
-      pokestopListString += "</table>";
-      document.getElementById("pokestopList").innerHTML = pokestopListString;
-    });
+      pokestopListString += '</table>'
+      document.getElementById('pokestopList').innerHTML = pokestopListString
+    })
   } else {
-    document.getElementById("pokestopList").innerHTML = "PokéStops markers are disabled";
+    document.getElementById('pokestopList').innerHTML = 'PokéStops markers are disabled'
   }
-};
+}
 
-var sort_by = function(field, reverse, primer) {
+var sortBy = function (field, reverse, primer) {
   var key = primer
-    ? function(x) {
-      return primer(x[field]);
+    ? function (x) {
+      return primer(x[field])
     }
-    : function(x) {
-      return x[field];
-    };
+    : function (x) {
+      return x[field]
+    }
 
-  reverse = !reverse ? 1 : -1;
+  reverse = !reverse ? 1 : -1
 
-  return function(a, b) {
-    return a = key(a), b = key(b), reverse * ((a > b) - (b > a));
+  return function (a, b) {
+    return a = key(a), b = key(b), reverse * ((a > b) - (b > a))
   }
 }

--- a/templates/map.html
+++ b/templates/map.html
@@ -213,8 +213,8 @@
     <script src="static/dist/js/app.min.js"></script>
     <script src="static/js/vendor/classie.js"></script>
     <script>
-      var center_lat = {{lat}};
-      var center_lng = {{lng}};
+      var centerLat = {{lat}};
+      var centerLng = {{lng}};
     </script>
 
     <script src="static/dist/js/map.min.js"></script>

--- a/templates/mobile_list.html
+++ b/templates/mobile_list.html
@@ -2,7 +2,7 @@
 <head>
 	<title>Nearby Pokémon</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<script>var page_loaded = new Date().getTime();</script>
+	<script>var pageLoaded = new Date().getTime();</script>
 	<link rel="stylesheet" href="static/dist/css/mobile.min.css" type="text/css" />
 </head>
 <body>

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -32,8 +32,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/skel/3.0.1/skel.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js"></script>
     <script>
-      var center_lat = {{lat}};
-      var center_lng = {{lng}};
+      var centerLat = {{lat}};
+      var centerLng = {{lng}};
     </script>
     <script src="static/dist/js/map.min.js"></script>
 </head>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR partly follows #2748 (Added Javascript styling rules).

## Description
At the moment the JS files were a bit of a mess:

* Mixed tabs and spaces (on same line! My eyes!)
* Mixed naming conventions (camel-case, usage of _, etc)
* Different usage of spaces before and after keywords
* Undefined variables (... and implicitly define them in `window`)

To circumvent this, a style guide needs to be chosen or created. To get things going, I chose [StandardJS](http://standardjs.com/). I don't care which style-guide we'll use, but it has to be explicit, creating a style-guide ourselves is hard and a lot of work. StandardJS seems to have enough tools available to check and format code. So that's why I chose it.

In addition I added eslint configuration, so that javascript can be checked. Lastly I tried to automatically format map.js and app.js. I've made a script to do this, so rebases are still doable. There are still a number of open issues that eslint reports, but that can be fixed after the general style is applied (manual work, not something I'll like to rebase).

See the resulting map.js here:
https://github.com/Chlodochar/PokemonGo-Map/blob/pr-jsstyle/static/map.js

## Motivation and Context
Code style was a mess. To get a unified code-base, some style-guide needs to be used.

## How Has This Been Tested?
Go through some of the features in the webinterface.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ? ] My code follows the code style of this project. (which one?!)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
