### PR TITLE
combine 'get_pokemon_name', 'get_args' import statements to utilize r…

### DIFF
--- a/pogom/customLog.py
+++ b/pogom/customLog.py
@@ -1,5 +1,4 @@
-from .utils import get_pokemon_name
-from pogom.utils import get_args
+from .utils import get_pokemon_name, get_args
 from datetime import datetime
 
 args = get_args()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
…elative imports

## Description
<!--- Describe your changes in detail -->
Removed `from pogom.utils import get_args` and combined with the preceding line, resulting in `from .utils import get_pokemon_name, get_args`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
While not necessary, the change was made as some issues were occurring when attempting to utilize some files in an external project. Using a relative import seemed to resolve the issue.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.