### PR TITLE
Bounce ends when marker is clicked

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -497,13 +497,18 @@ function getGoogleSprite(index, sprite, display_height) {
     };
 }
 
-function setupPokemonMarker(item, skipNotification) {
+function setupPokemonMarker(item, skipNotification, isBounceDisabled) {
 
     // Scale icon size up with the map exponentially
     var icon_size = 2 + (map.getZoom()-3) * (map.getZoom()-3) * .2 + Store.get('iconSizeModifier');
     var pokemon_index = item.pokemon_id - 1;
     var sprite = pokemon_sprites[Store.get('pokemonIcons')] || pokemon_sprites['highres']
     var icon = getGoogleSprite(pokemon_index, sprite, icon_size);
+	
+	var animationDisabled = false;
+	if(isBounceDisabled == true){
+		animationDisabled = true;
+	}
 
     var marker = new google.maps.Marker({
         position: {
@@ -514,7 +519,13 @@ function setupPokemonMarker(item, skipNotification) {
         optimized: false,
         map: map,
         icon: icon,
+		animationDisabled: animationDisabled,
     });
+	
+	marker.addListener('click', function() {
+		this.setAnimation(null);
+		this.animationDisabled = true;
+	});
 
     marker.infoWindow = new google.maps.InfoWindow({
         content: pokemonLabel(item.pokemon_name, item.disappear_time, item.pokemon_id, item.latitude, item.longitude, item.encounter_id),
@@ -528,8 +539,9 @@ function setupPokemonMarker(item, skipNotification) {
             }
             sendNotification('A wild ' + item.pokemon_name + ' appeared!', 'Click to load map', 'static/icons/' + item.pokemon_id + '.png', item.latitude, item.longitude);
         }
-        // Icons still get a bounce, even on redraw
-        marker.setAnimation(google.maps.Animation.BOUNCE);
+		if (marker.animationDisabled != true){
+			marker.setAnimation(google.maps.Animation.BOUNCE);	
+		}
     }
 
     addListeners(marker);
@@ -860,8 +872,12 @@ function updateMap() {
 function redrawPokemon(pokemon_list) {
     var skipNotification = true;
     $.each(pokemon_list, function(key, value) {
+		var isBounceDisabled = false;
+		if(this.marker.animationDisabled != false){
+			isBounceDisabled = true;
+		};
         var item =  pokemon_list[key];
-        var new_marker = setupPokemonMarker(item, skipNotification);
+        var new_marker = setupPokemonMarker(item, skipNotification, isBounceDisabled);
         item.marker.setMap(null);
         pokemon_list[key].marker = new_marker;
     });

--- a/static/map.js
+++ b/static/map.js
@@ -504,11 +504,11 @@ function setupPokemonMarker(item, skipNotification, isBounceDisabled) {
     var pokemon_index = item.pokemon_id - 1;
     var sprite = pokemon_sprites[Store.get('pokemonIcons')] || pokemon_sprites['highres']
     var icon = getGoogleSprite(pokemon_index, sprite, icon_size);
-	
-	var animationDisabled = false;
-	if(isBounceDisabled == true){
-		animationDisabled = true;
-	}
+
+    var animationDisabled = false;
+    if(isBounceDisabled == true){
+        animationDisabled = true;
+    }
 
     var marker = new google.maps.Marker({
         position: {
@@ -872,12 +872,8 @@ function updateMap() {
 function redrawPokemon(pokemon_list) {
     var skipNotification = true;
     $.each(pokemon_list, function(key, value) {
-		var isBounceDisabled = false;
-		if(this.marker.animationDisabled != false){
-			isBounceDisabled = true;
-		};
         var item =  pokemon_list[key];
-        var new_marker = setupPokemonMarker(item, skipNotification, isBounceDisabled);
+        var new_marker = setupPokemonMarker(item, skipNotification, this.marker.animationDisabled);
         item.marker.setMap(null);
         pokemon_list[key].marker = new_marker;
     });


### PR DESCRIPTION
## Description
Bounce animation stops when marker is clicked. 

## Motivation and Context
Prevents continuous loop of bouncing pokémon ( #1955 )

**rework of #1979 based on improvements in #2017**

## How Has This Been Tested?
By running the setup several times on Linux and Windows.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

