### PR TITLE
added python linting using flake8 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ env:
   - FLASK=0.11.1
 install:
   - pip install Flask==$FLASK
+  - pip install flake8
   - pip install -r requirements.txt
+before_script:
+  - flake8 .
 script:
   - nosetests


### PR DESCRIPTION
## Description
This adds flake8 to Travis, which will check for stylistic problems in Python files. I've initially haven't set any options, so it'll output the defaults. We can decide which errors should be disabled once Travis shows them.

## Motivation and Context
We need a styleguide for Python. Flake8 seems to do this well.

## How Has This Been Tested?
Running flake8 locally.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

