### PR TITLE
Hide Geolocation button and switch when -fl is on

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -926,6 +926,7 @@ function myLocationButton(map, marker) {
     var locationContainer = document.createElement('div');
 
     var locationButton = document.createElement('button');
+    locationButton.style.display = '{{is_fixed}}';
     locationButton.style.backgroundColor = '#fff';
     locationButton.style.border = 'none';
     locationButton.style.outline = 'none';

--- a/templates/map.html
+++ b/templates/map.html
@@ -87,7 +87,7 @@
 				</div>
 			</div>
 
-			<div class="form-control switch-container">
+			<div class="form-control switch-container" style="display:{{is_fixed}}">
 				<h3>Geolocation</h3>
 				<div class="onoffswitch">
 					<input id="geoloc-switch" type="checkbox" name="geoloc-switch" class="onoffswitch-checkbox" checked/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Geolocation button and switch are now hidden when -fl is on.
## Description
<!--- Describe your changes in detail -->
Added display:{{is_fixed}} to the geolocation switch and geolocation button

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#2037 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
