### PR TITLE
Changed notification to take you to current map instead of opening a new map

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -275,7 +275,7 @@ function setupPokemonMarker(item) {
         if(localStorage.playSound === 'true'){
           audio.play();
         }
-        sendNotification('A wild ' + item.pokemon_name + ' appeared!', 'Click to load map', 'static/icons/' + item.pokemon_id + '.png')
+        sendNotification('A wild ' + item.pokemon_name + ' appeared!', 'Click to see map', 'static/icons/' + item.pokemon_id + '.png')
     }
 
     addListeners(marker);
@@ -576,7 +576,7 @@ function sendNotification(title, text, icon) {
         });
 
         notification.onclick = function () {
-            window.open(window.location.href);
+            window.focus();
         };
     }
 }


### PR DESCRIPTION

## Description
Changed the notification javascript to change focus instead of creating a new window when clicking on the notification

## Motivation and Context
This change was made because each time i click a notification I get a new window.  Each time I click a window i get my notifications back.  I have a window open it's why I'm getting notifications, so I figured it'd be nice to just show that window.
## How Has This Been Tested?
Ran locally, set pidgey to notify on, changed tabs opened new window, when pidgey popped up I clicked it and made sure that it worked as intended.  

Tested on OsX with chrome. 

- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
If there is documentation that you'd like updated please respond to request.

