### PR TITLE
Fixes ignored --scan-delay switch

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -97,7 +97,7 @@ def login(args, position):
 
     while not api.login(args.auth_service, args.username, args.password):
         log.info('Failed to login to Pokemon Go. Trying again.')
-        time.sleep(config['REQ_SLEEP'])
+        time.sleep(args.scan_delay)
 
     log.info('Login to Pokemon Go successful.')
 
@@ -132,9 +132,9 @@ def search_thread(args):
                         response_dict = {}
             else:
                 log.info('Map Download failed. Trying again.')
-                time.sleep(config['REQ_SLEEP'])
+                time.sleep(args.scan_delay)
 
-        time.sleep(config['REQ_SLEEP'])
+        time.sleep(args.scan_delay)
 
 def process_search_threads(search_threads, curr_steps, total_steps):
     for thread in search_threads:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -97,7 +97,7 @@ def login(args, position):
 
     while not api.login(args.auth_service, args.username, args.password):
         log.info('Failed to login to Pokemon Go. Trying again.')
-        time.sleep(args.scan_delay)
+        time.sleep(config['REQ_SLEEP'])
 
     log.info('Login to Pokemon Go successful.')
 
@@ -132,9 +132,9 @@ def search_thread(args):
                         response_dict = {}
             else:
                 log.info('Map Download failed. Trying again.')
-                time.sleep(args.scan_delay)
+                time.sleep(config['REQ_SLEEP'])
 
-        time.sleep(args.scan_delay)
+        time.sleep(config['REQ_SLEEP'])
 
 def process_search_threads(search_threads, curr_steps, total_steps):
     for thread in search_threads:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -36,7 +36,7 @@ def get_args():
     parser.add_argument('-p', '--password', help='Password')
     parser.add_argument('-l', '--location', type=parse_unicode, help='Location, can be an address or coordinates')
     parser.add_argument('-st', '--step-limit', help='Steps', type=int, default=12)
-    parser.add_argument('-sd', '--scan-delay', help='Time delay before beginning new scan', type=int, default=1)
+    parser.add_argument('-sd', '--scan-delay', help='Time delay before beginning new scan', type=float, default=1)
     parser.add_argument('-dc', '--display-in-console',help='Display Found Pokemon in Console',action='store_true', default=False)
     parser.add_argument('-H', '--host', help='Set web server listening host', default='127.0.0.1')
     parser.add_argument('-P', '--port', type=int, help='Set web server listening port', default=5000)

--- a/runserver.py
+++ b/runserver.py
@@ -84,6 +84,7 @@ if __name__ == '__main__':
 
     config['ROOT_PATH'] = app.root_path
     config['GMAPS_KEY'] = args.gmaps_key
+    config['REQ_SLEEP'] = args.scan_delay
 
     if args.no_server:
         while not search_thread.isAlive():


### PR DESCRIPTION
## Description
1. Fixes --scan-delay argument being ignored.
2. Makes --scan-delay a float value, so values like 0.5 are now accepted.

## Motivation and Context
I wanted to use --scan-delay to make scans faster.

## How Has This Been Tested?
1. Tried "-sd 5" and it was completely ignored before, and worked well with the patch.
2. Tried "-sd 0.5" and it made scanning intervals shorter.

## Screenshots (if appropriate):
Taken at "-sd 0.5", scan intervals are shorter than the defaul one second. http://i.imgur.com/5sRXfu8.png

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
