### PR TITLE
map.js: updateMap timer should not be set independently on map instantiation.

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -276,6 +276,8 @@ function initMap() {
         redrawPokemon(map_data.pokemons);
         redrawPokemon(map_data.lure_pokemons);
     });
+
+    window.setInterval(updateMap, 5000);
 };
 
 function createSearchMarker() {
@@ -1084,7 +1086,6 @@ $(function () {
 
     // run interval timers to regularly update map and timediffs
     window.setInterval(updateLabelDiffTime, 1000);
-    window.setInterval(updateMap, 5000);
     window.setInterval(function() {
       if(navigator.geolocation && Store.get('geoLocate')) {
         navigator.geolocation.getCurrentPosition(function (position){


### PR DESCRIPTION
updateMap timer in current code base is set on page load, regardless on how long can asynchronous map instantiation through initMap() actually take. If it takes longer than the currently hardcoded 5000ms on timer tick, it's called with map object still being null and crashes on first statement that tries to access map.

## Description
Moved the timer to be set synchronously after map instantiation inside initMap().

## Motivation and Context
updateMap() was crashing on slow connections / machines on first page load.

## How Has This Been Tested?
Set the timer to 1ms instead of 5000ms and see the problem for yourself. Then move to initMap().
Tested on Chrome.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

