### PR TITLE
Fixes BOM marker with setup.bat on Windows

### DIFF
--- a/Easy Setup/setup.bat
+++ b/Easy Setup/setup.bat
@@ -39,9 +39,8 @@ cd ..
 "%PATH2%\Scripts\pip" install -r requirements.txt
 "%PATH2%\Scripts\pip" install -r requirements.txt --upgrade
 cd config
-copy config.ini.example config.ini
 set /p API= Enter your Google API key here:
-powershell -Command "(gc config.ini) -replace '#gmaps-key:', 'gmaps-key: %API%' | Out-File config.ini"
+"%PATH2%\python" -c "print open('config.ini.example').read().replace('#gmaps-key:','gmaps-key:%API%')" > config.ini
 
 echo All done!
 pause


### PR DESCRIPTION
Right now, the setup.bat on Windows breaks the config.file by turning it into a Little Endian UTF-16 encoded file. This in turn breaks the new config parser.

## Description
Replaced the reliance on PowerShell Cmdlet with a python one-liner alternative that doesn't break the config.ini file

## Motivation and Context
![Error](http://i.imgur.com/4wKMNL7.png)

## How Has This Been Tested?
Tested on Windows 10, x64 with latest dev branch.

## Screenshots (if appropriate):
![Error](http://i.imgur.com/4wKMNL7.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Currently, the Out-File PowerShell Cmdlet breaks config.ini by turning it into a Little Endian UTF-16 file, in turn breaking the script.
Replaced the Out-File Cmdlet with a python in-line replace of a file (I mean, we already have python, so why not make full use of it...?)