### PR TITLE
Only show pokémons available in the game

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -1052,6 +1052,9 @@ $(function () {
         var pokeList = []
 
         $.each(data, function(key, value) {
+            if (key > 151) {
+            	return false;	
+            }
             pokeList.push( { id: key, text: value + ' - #' + key } );
             idToPokemon[key] = value;
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Hides pokemon that are not available in the game from notify and exclude lists.
## Description
<!--- Describe your changes in detail -->
Currently, the notify and exclude lists show all existing pokemons from all gens.
This PR shows only pokemon currently available in the game, plus the legendary ones and ditto that will be added later (all pokemons up to #151). This declutters both the exclude and notify boxes and makes searching for pokemons easier. This is done by limiting the key to 151 while transferring JSON data to the search boxes, in a manner that does not damage the original json lists for future use.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

