### PR TITLE
Fix multiple lured pokemon notification bug

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -782,13 +782,16 @@ function processLuredPokemon(i, item) {
         return;
     }
 
-    if (map_data.lure_pokemons[item2.pokestop_id] == null && item2.lure_expiration) {
+    if (map_data.lure_pokemons[item2.pokestop_id] == null
+            && item2.lure_expiration > new Date().getTime()) {
         //if (item.marker) item.marker.setMap(null);
         item2.marker = setupPokemonMarker(item2);
         map_data.lure_pokemons[item2.pokestop_id] = item2;
 
     }
-    if (map_data.lure_pokemons[item.pokestop_id] != null && item2.lure_expiration && item2.active_pokemon_id != map_data.lure_pokemons[item2.pokestop_id].active_pokemon_id) {
+    if (map_data.lure_pokemons[item.pokestop_id] != null
+            && item2.lure_expiration > new Date().getTime()
+            && item2.active_pokemon_id != map_data.lure_pokemons[item2.pokestop_id].active_pokemon_id) {
         //if (item.marker) item.marker.setMap(null);
         map_data.lure_pokemons[item2.pokestop_id].marker.setMap(null);
         item2.marker = setupPokemonMarker(item2);


### PR DESCRIPTION
## Description
This patch fixes a bug where notifications of lured pokemon would appear to spam the user, even after the lured pokemon disappears.

## Motivation and Context
Notifications of lured pokemon would repeatedly be triggered every updateMap() cycle (5 seconds), because processLuredPokemons() did not check if the lured pokemon passed in was expired.

To reproduce the bug, it's easier if you disable processPokemons() by commenting out the following line from updateMap():
`  $.each(result.pokemons, processPokemons);`

This way you only lured pokemon are scanned, narrowing down test subjects.

## How Has This Been Tested?
Tested by running the server, expired lured pokemon do not trigger notifications anymore in each updateMap() cycle, and new lured pokemon still trigger notifications as intended.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

