### PR TITLE
use relative location for AJAX requests

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -1088,14 +1088,13 @@ $(function () {
     window.setInterval(function() {
       if(navigator.geolocation && Store.get('geoLocate')) {
         navigator.geolocation.getCurrentPosition(function (position){
-          var baseURL = location.protocol + "//" + location.hostname + (location.port ? ":"+location.port: "");
           lat = position.coords.latitude;
           lon = position.coords.longitude;
 
           //the search function makes any small movements cause a loop. Need to increase resolution
           if(getPointDistance(marker.getPosition(), (new google.maps.LatLng(lat, lon))) > 40) //changed to 40 from PR notes, less jitter.
           {
-            $.post(baseURL + "/next_loc?lat=" + lat + "&lon=" + lon).done(function(){
+            $.post("next_loc?lat=" + lat + "&lon=" + lon).done(function(){
               var center = new google.maps.LatLng(lat, lon);
               map.panTo(center);
               marker.setPosition(center);

--- a/static/map.js
+++ b/static/map.js
@@ -1093,13 +1093,7 @@ $(function () {
 
           //the search function makes any small movements cause a loop. Need to increase resolution
           if(getPointDistance(marker.getPosition(), (new google.maps.LatLng(lat, lon))) > 40) //changed to 40 from PR notes, less jitter.
-          {
-            $.post("next_loc?lat=" + lat + "&lon=" + lon).done(function(){
-              var center = new google.maps.LatLng(lat, lon);
-              map.panTo(center);
-              marker.setPosition(center);
-            });
-          }
+            changeLocation(lat, lon);
 
         });
       }


### PR DESCRIPTION
## Description
Use relative path for `next_loc` calls in map.js

## Motivation and Context
For sites that are behind a reverse proxy, it's possible for them to be hosted in a subdirectory on a website: ex. example.com/map. To make sure everything works in that case, try to use relative paths for requests when possible.

## How Has This Been Tested?
Tested on my own server, using nginx as a reverse-proxy. Approximate server settings are as follows:
```
server {
   listen 80;
   server_name example.com;

   location /map/ {
      proxy_pass http://localhost:5000/;
      proxy_set_header X-Real-IP $remote_addr;
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
      proxy_set_header Host $http_host;
   }
}
```

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

