### PR TITLE
Add scalingo one click deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Live visualization of all the pokemon (with option to show gyms and pokestops) in your area. This is a proof of concept that we can load all the pokemon visible nearby given a location. Currently runs on a Flask server displaying Google Maps with markers on it.
 
-[![Deploy](https://raw.githubusercontent.com/sych74/PokemonGo-Map-in-Cloud/master/images/deploy-to-jelastic.png)](https://jelastic.com/install-application/?manifest=https://raw.githubusercontent.com/sych74/PokemonGo-Map-in-Cloud/master/manifest.jps) [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://github.com/AHAAAAAAA/PokemonGo-Map/wiki/Heroku-Deployment) 
+[![Deploy](https://raw.githubusercontent.com/sych74/PokemonGo-Map-in-Cloud/master/images/deploy-to-jelastic.png)](https://jelastic.com/install-application/?manifest=https://raw.githubusercontent.com/sych74/PokemonGo-Map-in-Cloud/master/manifest.jps) [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://github.com/AHAAAAAAA/PokemonGo-Map/wiki/Heroku-Deployment) [![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/AHAAAAAAA/PokemonGo-Map)
 
 #[Twitter] (https://twitter.com/PoGoMDev), [Website] (https://jz6.github.io/PoGoMap/)#
 

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,31 @@
+{
+  "name": "PokemonGo Map",
+  "description": "Live visualization of all the Pokémon (with option to show gyms and pokéstops) in an area on Pokémon Go.",
+  "repository": "https://github.com/AHAAAAAAA/PokemonGo-Map",
+  "website": "https://jz6.github.io/PoGoMap/",
+  "env": {
+    "AUTH_SERVICE": {
+      "description": "Authentication service to use. (ptc or google)"
+    },
+    "USERNAME": {
+      "description": "Your username to login to the specified authentication service."
+    },
+    "PASSWORD": {
+      "description": "Your password to login to the specified authentication service."
+    },
+    "LOCATION": {
+      "description": "Location on which the map should be centered. This can be an address, co-ordinates or anything that Google Maps accepts."
+    },
+    "GMAPS_KEY": {
+      "description": "A Google Maps API key for this application."
+    },
+    "STEP_COUNT": {
+      "description": "The number of steps to take.",
+      "value": "5"
+    },
+    "EXTRA_ARGS": {
+      "description": "Any extra arguments that you want to pass to runserver.py.",
+      "required": false
+    }
+  }
+}


### PR DESCRIPTION
Add a link to deploy in one click to the [scalingo platform](https://scalingo.com)

## Description
This changes add the scalingo.json file to provide deployment informations to scalingo. (similar to app.json used for heroku) and add a deploy to scalingo button to the deployment button list on the README.md

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

