### PR TITLE
Center map on optional URL passed coords

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -205,11 +205,23 @@ function notifyAboutPokemon(id) {
     ).trigger('change')
 }
 
+function getParameterByName(name, url) {
+    if (!url) url = window.location.href;
+    name = name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+}
+
 function removePokemonMarker(encounter_id) {
     map_data.pokemons[encounter_id].marker.setMap(null);
 }
 
 function initMap() {
+	var url_lat = getParameterByName('lat');
+	var url_long = getParameterByName('long');
 
     map = new google.maps.Map(document.getElementById('map'), {
         center: {
@@ -276,6 +288,10 @@ function initMap() {
         redrawPokemon(map_data.pokemons);
         redrawPokemon(map_data.lure_pokemons);
     });
+	
+	if (url_lat) {
+		centerMap(url_lat, url_long, 16);
+	}
 };
 
 function createSearchMarker() {

--- a/static/map.js
+++ b/static/map.js
@@ -221,7 +221,7 @@ function removePokemonMarker(encounter_id) {
 
 function initMap() {
 	var url_lat = getParameterByName('lat');
-	var url_long = getParameterByName('long');
+	var url_lng = getParameterByName('lng');
 
     map = new google.maps.Map(document.getElementById('map'), {
         center: {
@@ -290,7 +290,7 @@ function initMap() {
     });
 	
 	if (url_lat) {
-		centerMap(url_lat, url_long, 16);
+		centerMap(url_lat, url_lng, 16);
 	}
 };
 


### PR DESCRIPTION
## Description
Adds optional 'lat' and 'long' variables to the URL to allow the map to be centered anywhere on load.

## Motivation and Context
Can be used to center the map on any location, useful for multiple -ns scanned locations and a single webserver port.

## How Has This Been Tested?
Start webserver with a target location
`runserver.py -l "-23.850012, 151.257375" -fl -os` 

Load webpage with another location in the URL
`http://localhost:5000/?lat=-23.835443&long=151.252734`

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Load and center map on coords given via url.
Based on code by @wbechard