### PR TITLE
Only notify if pokemon is within current map view bounds.

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -531,7 +531,7 @@ function setupPokemonMarker(item, skipNotification, isBounceDisabled) {
         disableAutoPan: true
     });
 
-    if (notifiedPokemon.indexOf(item.pokemon_id) > -1) {
+    if (notifiedPokemon.indexOf(item.pokemon_id) > -1 && map.getBounds().contains(marker.getPosition())) {
         if (!skipNotification) {
             if (Store.get('playSound')) {
               audio.play();


### PR DESCRIPTION
## Description
This will only fire a notification if the pokemon is in the current map view bounds.

## Motivation and Context
When you are running a very large map with multiple scanners, you don't want to notify on a pokemon that isn't within a distance you can reasonably get to before it despawns. If you zoom your view to things you can reasonably get to in time, this will only notify when things spawn inside this view.

## How Has This Been Tested?
Tested on a local install I'm using to map a view large area. Works properly.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.