### PR TITLE
PokeInfo auto-open & Nav layout fix

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1802,12 +1802,13 @@ body {
   background: #F8F8F8;
   box-shadow: none;
   color: #ffffff;
-  height: 100%;
   max-width: 80%;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 1.5em 1.5em 4em 1.5em;
-  position: fixed;
+  position: absolute;
   top: 3.50em;
+  bottom: 0;
   left: 0;
   visibility: hidden;
   width: 18em;

--- a/static/map.js
+++ b/static/map.js
@@ -192,6 +192,7 @@ function initSidebar() {
     $('#geoloc-switch').prop('checked', localStorage.geoLocate === 'true');
     $('#scanned-switch').prop('checked', localStorage.showScanned === 'true');
     $('#sound-switch').prop('checked', localStorage.playSound === 'true');
+    $('#aopi-switch').prop('checked', localStorage.autoOpenPokeInfo === 'true');
 
     var searchBox = new google.maps.places.SearchBox(document.getElementById('next-location'));
 
@@ -614,6 +615,9 @@ function processPokemons(i, item) {
         if (item.marker) item.marker.setMap(null);
         item.marker = setupPokemonMarker(item);
         map_data.pokemons[item.encounter_id] = item;
+        if (localStorage.autoOpenPokeInfo === 'true') {
+            item.marker.infoWindow.open(map, item.marker);
+        }
     }
 }
 
@@ -1023,5 +1027,15 @@ $(function () {
         else   
             localStorage["geoLocate"] = this.checked;  
     });
+    
+    $('#aopi-switch').change(function() {
+        localStorage["autoOpenPokeInfo"] = this.checked;
+    });
+    
+    $('#close-pokeinfo').click(function() {
+        $.each(map_data['pokemons'], function (key, value) {
+            map_data['pokemons'][key].marker.infoWindow.close();
+        });
+    })
 
 });

--- a/static/sass/layout/_nav.scss
+++ b/static/sass/layout/_nav.scss
@@ -7,12 +7,13 @@
 		background: #F8F8F8;
 		box-shadow: none;
 		color: _palette(accent2, fg-bold);
-		height: 100%;
 		max-width: 80%;
 		overflow-y: auto;
+		overflow-x: hidden;
 		padding: 1.5em 1.5em 4em 1.5em;
-		position: fixed;
+		position: absolute;
 		top: 3.50em;
+		bottom: 0;
 		left: 0;
 		visibility: hidden;
 		width: 18em;

--- a/templates/map.html
+++ b/templates/map.html
@@ -155,6 +155,19 @@
 					</label>
 				</div>
 			</div>
+			<div class="form-control switch-container">
+				<h3>Auto-open Pokeinfo</h3>
+				<div class="onoffswitch">
+					<input id="aopi-switch" type="checkbox" name="aopi-switch" class="onoffswitch-checkbox" checked>
+					<label class="onoffswitch-label" for="aopi-switch">
+						<span class="switch-label" data-on="On" data-off="Off"></span>
+						<span class="switch-handle"></span>
+					</label>
+				</div>
+			</div>
+			<div class="form-control switch-container">
+				<button class="fit" id="close-pokeinfo">Close all PokeInfo</button>
+			</div>
 		</nav>
 
 		<div id="map"></div>


### PR DESCRIPTION
## Description
Added auto-open toggle for Pokemon InfoWindow. Also a button to close them all.
Futhermore I've fixed Navigation/menu - it had 100% height thus ~56px(3.5em) of it was hidden. With this pull it isn't a problem anymore.

## Motivation and Context
This adds a new feature, and fixes nav/menu(also makes it future-proof)

## How Has This Been Tested?
Ubuntu Firefox 49.0a2
Windows Firefox 49.0a2
Android 4.4 Chrome

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

