### PR TITLE
Fixed table creation with MySQL/MariaDB

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -58,7 +58,7 @@ class BaseModel(Model):
 class Pokemon(BaseModel):
     # We are base64 encoding the ids delivered by the api
     # because they are too big for sqlite to handle
-    encounter_id = CharField(primary_key=True)
+    encounter_id = CharField(primary_key=True, max_length=50)
     spawnpoint_id = CharField()
     pokemon_id = IntegerField()
     latitude = DoubleField()
@@ -123,7 +123,7 @@ class Pokemon(BaseModel):
 
 
 class Pokestop(BaseModel):
-    pokestop_id = CharField(primary_key=True)
+    pokestop_id = CharField(primary_key=True, max_length=50)
     enabled = BooleanField()
     latitude = DoubleField()
     longitude = DoubleField()
@@ -162,7 +162,7 @@ class Gym(BaseModel):
     TEAM_VALOR = 2
     TEAM_INSTINCT = 3
 
-    gym_id = CharField(primary_key=True)
+    gym_id = CharField(primary_key=True, max_length=50)
     team_id = IntegerField()
     guard_pokemon_id = IntegerField()
     gym_points = IntegerField()
@@ -193,7 +193,7 @@ class Gym(BaseModel):
         return gyms
 
 class ScannedLocation(BaseModel):
-    scanned_id = CharField(primary_key=True)
+    scanned_id = CharField(primary_key=True, max_length=50)
     latitude = DoubleField()
     longitude = DoubleField()
     last_modified = DateTimeField()


### PR DESCRIPTION
Fixes `peewee.InternalError: (1071, u'Specified key was too long; max key length is 767 bytes')`.

## Description
Restricting primary key length to 50 chars for all tables.

## Motivation and Context
Newer MySQL and MariaDB versions come with a default encoding of `utf8mb4`, where `1 char = 4 bytes`. 

MyISAM maximum primary key length is 1000 bytes and InnoDB's max length is 768 bytes.

Peewee by default (because the size is never specified) creates the primary key with a length of 255 chars.

`255 * 4 = 1020 bytes`, thus users experience:

`peewee.InternalError: (1071, u'Specified key was too long; max key length is 767 bytes')`

Analyzing the data we mine now, no primary key exceeds 35 chars (28/35/27/35 respectively).

Adding a `max_length=50` fixes this issue. We could go lower/fixed size, though, but I'm not aware of the dev team plans.
## How Has This Been Tested?
Table creation has been tested against MyISAM and InnoDB engines.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Newer MySQL and MariaDB versions come with a default encoding of `utf8mb4`, where `1 char = 4 bytes`. 

MyISAM maximum primary key length is 1000 bytes and InnoDB's max length is 768 bytes.

Peewee by default (because the size is never specified) creates the primary key with a length of 255 chars.

`255 * 4 = 1020 bytes`, thus users experience:

`peewee.InternalError: (1071, u'Specified key was too long; max key length is 767 bytes')`

Analyzing the data we mine now, no primary key exceeds 35 chars (28/35/27/35 respectively).

Adding a `max_length=50` fixes this issue. We could go lower/fixed size, though, but I'm not aware of the dev team plans.