### PR TITLE
Example Docker-Compose w/ Let's Encrypt Proxy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ Easy\ Setup
 Gruntfile.js
 package.json
 pogom.db
+Caddyfile

--- a/config/Caddyfile
+++ b/config/Caddyfile
@@ -1,0 +1,11 @@
+: {
+    proxy / pokemap:5000 {
+        proxy_header Host {host}
+        proxy_header X-Real-IP {remote}
+        proxy_header X-Forwarded-Proto {scheme}
+    }
+    tls ${EMAIL} {
+        max_certs 5
+    }
+    errors stderr
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '2'
+services:
+  httpsfrontend:
+    image: abiosoft/caddy
+    links:
+      - pokemap
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./config/Caddyfile:/etc/Caddyfile
+      - /root/.caddy
+    environment:
+      - EMAIL=youremail@yourdomain.com
+    command: "-agree --conf /etc/Caddyfile"
+    restart: always
+  pokemap:
+    build: .
+    links:
+      - pokesql
+    command: "--location=\"Orlando, FL\" --auth-service=ptc --username=youruser --password=yourpassword --db-type=mysql --db-host=pokesql --db-name=pogom --db-user=pogom --db-pass=somedbpassword --gmaps-key=someapikey"
+    restart: always
+  pokeworker:
+    build: .
+    links:
+      - pokesql
+    command: "--location=\"Miami, FL\" --auth-service=ptc --username=yourotheruser --password=yourotherpassword --db-type=mysql --db-host=pokesql --db-name=pogom --db-user=pogom --db-pass=somedbpassword --no-server --gmaps-key=someapikey"
+    restart: always
+  pokesql:
+    image: mysql:5.6
+    environment:
+      - MYSQL_DATABASE=pogom
+      - MYSQL_RANDOM_ROOT_PASSWORD=yes
+      - MYSQL_USER=pogom
+      - MYSQL_PASSWORD=somedbpassword
+    restart: always


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds an example docker-compose and Caddyfile for one server, one SQL writer, a MySQL DB, and Caddy for HTTPS termination w/ Let's Encrypt.

$EMAIL must be specified (e.g. when using docker-compose up) elsewise Caddy will prompt for it and stall.

Run commands in docker-compose.yml must receive google maps API key, username, pw.

Nothing is externally exposed port-wise except the proxy. Both locations appear on map as expected.

## Motivation and Context
Compose is good. Multi-instance is good. MySQL is good. Let's Encrypt is good.

## How Has This Been Tested?
Everything EXCEPT https is working. ACME seems to work but chrome refuses to load the page (possibly due to me using free, long scaleway.com subdomain, I have a similar setup on servers at work which functions fine)

If I disable HTTPS in the Caddyfile everything works.

MySQL Performance with Miami / Orlando as test vectors is quite good, lots of lines like "upserted 100 pokemon" and virtually null load.

## Screenshots (if appropriate):
http://imgur.com/a/Xg6uN

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
