### PR TITLE
Added a flag to clear the database upon app start

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -358,3 +358,8 @@ def create_tables(db):
     db.connect()
     db.create_tables([Pokemon, Pokestop, Gym, ScannedLocation], safe=True)
     db.close()
+
+def drop_tables(db):
+    db.connect()
+    db.drop_tables([Pokemon, Pokestop, Gym, ScannedLocation], safe=True)
+    db.close()

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -84,6 +84,9 @@ def get_args():
                         action='store_true', default=False)
     parser.add_argument('-D', '--db', help='Database filename',
                         default='pogom.db')
+    parser.add_argument('-cd', '--clear-db',
+                        help='Deletes the existing database before starting the Webserver.',
+                        action='store_true', default=False)
     parser.add_argument('-t', '--num-threads', help='Number of search threads', type=int, default=1)
     parser.add_argument('-np', '--no-pokemon',
                         help='Disables Pokemon from the map (including parsing them into local db)',

--- a/runserver.py
+++ b/runserver.py
@@ -12,8 +12,9 @@ from flask_cors import CORS
 from pogom import config
 from pogom.app import Pogom
 from pogom.utils import get_args, insert_mock_data
+
 from pogom.search import search_loop, create_search_threads, fake_search_loop
-from pogom.models import init_database, create_tables, Pokemon, Pokestop, Gym
+from pogom.models import init_database, create_tables, drop_tables, Pokemon, Pokestop, Gym
 
 from pogom.pgoapi.utilities import get_pos_by_name
 
@@ -46,6 +47,11 @@ if __name__ == '__main__':
         logging.getLogger("rpc_api").setLevel(logging.DEBUG)
 
     db = init_database()
+    if args.clear_db:
+        if args.db_type == 'mysql':
+            drop_tables(db)
+        elif os.path.isfile(args.db):
+            os.remove(args.db)
     create_tables(db)
 
     position = get_pos_by_name(args.location)


### PR DESCRIPTION
Added a new flag -cd, --clear-db to clear pogom.db.

## Description
Made it so the new flag clears the local database or the mysql database prior to adding the new data.
## Motivation and Context
#2249

## How Has This Been Tested?
Tested on my own server under Win10, how it reacts with and without the flag. Everything seems to be working as intended.

## Screenshots (if appropriate):
![prior](https://cloud.githubusercontent.com/assets/11703528/17162355/0e29359e-53be-11e6-918e-10df99bbb0e1.png)
![after](https://cloud.githubusercontent.com/assets/11703528/17162358/10f1c4d0-53be-11e6-9c29-7e21386839f0.png)
The size can be seen at the bottom and the -cd flag can be seen at the top.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
