### PR TITLE
Instead of deleting out of bound data, only show/hide markers

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -686,22 +686,29 @@ function clearStaleMarkers() {
     });
 };
 
-function clearOutOfBoundsMarkers(markers) {
-  $.each(markers, function(key, value) {
-      if (markers[key].hidden) return true;  // don't remove hidden markers so we can remember they're hidden
-      var marker = markers[key].marker;
-      if(typeof marker.getPosition === 'function') {
-        if(!map.getBounds().contains(marker.getPosition())) {
-          markers[key].marker.setMap(null);
-          delete markers[key];
+function showInBoundsMarkers(markers) {
+    $.each(markers, function(key, value) {
+        var marker = markers[key].marker;
+        var show = false;
+        if (!markers[key].hidden) {
+            if(typeof marker.getPosition === 'function') {
+                if(map.getBounds().contains(marker.getPosition())) {
+                  show = true;
+                }
+            } else if(typeof marker.getCenter === 'function') {
+                if(map.getBounds().contains(marker.getCenter())) {
+                  show = true;
+                }   
+            }
         }
-      } else if(typeof marker.getCenter === 'function') {
-        if(!map.getBounds().contains(marker.getCenter())) {
-          markers[key].marker.setMap(null);
-          delete markers[key];
+        
+        if ( show && !markers[key].marker.getMap()) {
+            markers[key].marker.setMap(map);
         }
-      }
-  });
+        else if (!show && markers[key].marker.getMap()) {
+            markers[key].marker.setMap(null);    
+        }
+    });
 }
 
 function loadRawData() {
@@ -869,11 +876,11 @@ function updateMap() {
         $.each(result.pokestops, processLuredPokemon);
         $.each(result.gyms, processGyms);
         $.each(result.scanned, processScanned);
-        clearOutOfBoundsMarkers(map_data.pokemons);
-        clearOutOfBoundsMarkers(map_data.lure_pokemons);
-        clearOutOfBoundsMarkers(map_data.gyms);
-        clearOutOfBoundsMarkers(map_data.pokestops);
-        clearOutOfBoundsMarkers(map_data.scanned);
+        showInBoundsMarkers(map_data.pokemons);
+        showInBoundsMarkers(map_data.lure_pokemons);
+        showInBoundsMarkers(map_data.gyms);
+        showInBoundsMarkers(map_data.pokestops);
+        showInBoundsMarkers(map_data.scanned);
         clearStaleMarkers();
     });
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
clearOutOfBoundsMarkers deletes valuable data, which causes problems like duplicate notifications and markers coming back after they've been hidden. Refactor it so is only responsible for showing/hiding markers, and doesn't destroy data. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
