### PR TITLE
Add scrollbar to notify and exclude navbar lists

### DIFF
--- a/templates/map.html
+++ b/templates/map.html
@@ -126,13 +126,17 @@
 			<div class="form-control">
 				<label for="exclude-pokemon">
 					<h3>Hide Pokémon</h3>
+					<div style="max-height:160px;overflow-y:auto";>
       					<select id="exclude-pokemon" multiple="multiple"></select>
-    				</label>
+      				</div>
+    			</label>
 			</div>
 			<div class="form-control">
 				<label for="notify-pokemon">
 					<h3>Notify of Pokémon</h3>
-					<select id="notify-pokemon" multiple="multiple"></select>
+					<div style="max-height:160px;overflow-y:auto";>
+						<select id="notify-pokemon" multiple="multiple"></select>
+					</div>
 				</label>
 			</div>
 			<div class="form-control switch-container">

--- a/templates/map.html
+++ b/templates/map.html
@@ -126,7 +126,7 @@
 			<div class="form-control">
 				<label for="exclude-pokemon">
 					<h3>Hide Pokémon</h3>
-					<div style="max-height:160px;overflow-y:auto";>
+					<div style="max-height:165px;overflow-y:auto";>
       					<select id="exclude-pokemon" multiple="multiple"></select>
       				</div>
     			</label>
@@ -134,7 +134,7 @@
 			<div class="form-control">
 				<label for="notify-pokemon">
 					<h3>Notify of Pokémon</h3>
-					<div style="max-height:160px;overflow-y:auto";>
+					<div style="max-height:165px;overflow-y:auto";>
 						<select id="notify-pokemon" multiple="multiple"></select>
 					</div>
 				</label>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Wrapped the exclude and notify lists in a div to allow scrolling when list gets long. Maximum height was set to allow to see 5 selections at a time

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Requested in #2277 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested and working
## Screenshots (if appropriate):
Screenshot shows 5 items in the exclude list fitting nicely without scrolling but when there is more than 5 items (like in the notify list) it scrolls.
![screen shot 2016-07-27 at 12 21 59 am](https://cloud.githubusercontent.com/assets/1903878/17163790/88bcbe76-5390-11e6-97f5-11b4e578ad7c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

