### PR TITLE
Make the non-drawing of markers that are off screen optional

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -61,7 +61,7 @@ def get_args():
     parser.add_argument('--db-pass', help='Password for the database')
     parser.add_argument('--db-host', help='IP or hostname for the database')
     parser.add_argument('-wh', '--webhook', help='Define URL(s) to POST webhook information to', nargs='*', default=False, dest='webhooks')
-    parser.add_argument('-r', '--render-all', help='Force all pokemon to display on the map even when they are off screen', action='store_true') //forces all pokemon to be loaded by the web browser so that spawn alerts can be triggered
+    parser.add_argument('-r', '--render-all', help='Force all pokemon to display on the map even when they are off screen', action='store_true') #forces all pokemon to be loaded by the web browser so that spawn alerts can be triggered
     parser.set_defaults(DEBUG=False)
 
     args = parser.parse_args()

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -61,6 +61,7 @@ def get_args():
     parser.add_argument('--db-pass', help='Password for the database')
     parser.add_argument('--db-host', help='IP or hostname for the database')
     parser.add_argument('-wh', '--webhook', help='Define URL(s) to POST webhook information to', nargs='*', default=False, dest='webhooks')
+    parser.add_argument('-r', '--render-all', help='Force all pokemon to display on the map even when they are off screen', action='store_true') //forces all pokemon to be loaded by the web browser so that spawn alerts can be triggered
     parser.set_defaults(DEBUG=False)
 
     args = parser.parse_args()

--- a/static/map.js
+++ b/static/map.js
@@ -692,13 +692,13 @@ function clearStaleMarkers() {
     });
 };
 
-function showInBoundsMarkers(markers) {
-    $.each(markers, function(key, value) {
+function showInBoundsMarkers(markers) { //display pokemon marker on map if their location meets criteria
+    $.each(markers, function(key, value) {//iterate though every marker
         var marker = markers[key].marker;
-        var show = false;
-        if (!markers[key].hidden) {
+        var show = false; //default to marker not shown
+        if (!markers[key].hidden) {//if the marker is not flagges as hidden (assuming here that it is hidden if expired or manually hidden idk)
             if(typeof marker.getPosition === 'function') {
-                if(map.getBounds().contains(marker.getPosition())) {
+                if(args.render_all is true or map.getBounds().contains(marker.getPosition())) {//check if he override is enabled (flag) or if the marker is on screen
                   show = true;
                 }
             } else if(typeof marker.getCenter === 'function') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Includes a cli flag to disable the if statement that prevents pokemon from being drawn offscreen.
## Description
<!--- Describe your changes in detail -->
A very small edit to utils to add the cli arg
A similarly small edit to maps.js to add an or statement. if the cli flag is activated it makes the if statement always true.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows people to zoom in on a map and still receive alerts when markers they are watching for spawn. It is intended for users who have a smaller scan area where alerts for markers offscreen are still in range and not for those running beehive or similar.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

At this moment I have only tested it on one server and not extensively however the change is only to two lines so I seriously doubt anything at all will be broken.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
