### PR TITLE
Add key listeners for showing/hidding of items.

### DIFF
--- a/static/dist/js/map.js
+++ b/static/dist/js/map.js
@@ -1071,5 +1071,24 @@ $(function () {
     $('#geoloc-switch').change(function () {
         if (!navigator.geolocation) this.checked = false;else Store.set('geoLocate', this.checked);
     });
+
+    $("body").on("keypress", function(event) {
+        if (event.which == 103) { // g
+            $("#gyms-switch").prop('checked', !Store.get('showGyms'));
+            $("#gyms-switch").change();
+        }
+        if (event.which == 108) { // l
+            $("#scanned-switch").prop('checked', !Store.get('showScanned'));
+            $("#scanned-switch").change();
+        }
+        if (event.which == 112) { // p
+            $("#pokemon-switch").prop('checked', !Store.get('showPokemon'));
+            $("#pokemon-switch").change();
+        }
+        if (event.which == 115) { // s
+            $("#pokestops-switch").prop('checked', !Store.get('showPokestops'));
+            $("#pokestops-switch").change();
+        }
+    });
 });
 //# sourceMappingURL=map.js.map

--- a/static/map.js
+++ b/static/map.js
@@ -1219,4 +1219,22 @@ $(function () {
             Store.set('geoLocate', this.checked);
     });
 
+    $("body").on("keypress", function(event) {
+        if (event.which == 103) { // g
+            $("#gyms-switch").prop('checked', !Store.get('showGyms'));
+            $("#gyms-switch").change();
+        }
+        if (event.which == 108) { // l
+            $("#scanned-switch").prop('checked', !Store.get('showScanned'));
+            $("#scanned-switch").change();
+        }
+        if (event.which == 112) { // p
+            $("#pokemon-switch").prop('checked', !Store.get('showPokemon'));
+            $("#pokemon-switch").change();
+        }
+        if (event.which == 115) { // s
+            $("#pokestops-switch").prop('checked', !Store.get('showPokestops'));
+            $("#pokestops-switch").change();
+        }
+    });
 });


### PR DESCRIPTION
Add key listeners for showing/hidding of (p)okemon, poke(s)tops, (g)yms and scanned (l)ocations.

## Description
Simply adds a key listener for 4 keys: p, s, g and l

## Motivation and Context
I'm using the scanned location layer quite often, so a key listener would be handy.

## How Has This Been Tested?
Local docker instance

## Screenshots (if appropriate):
Not possible

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
