### PR TITLE
Fix lured pokemon being displayed when hiding pokemon

### DIFF
--- a/static/dist/js/map.js
+++ b/static/dist/js/map.js
@@ -1074,17 +1074,22 @@ $(function () {
       if (this.checked) {
         updateMap();
       } else {
-        $.each(data[data_type], function (key, value) {
-          data[data_type][key].marker.setMap(null);
+        if (typeof data_type === 'string') {
+          data_type = [data_type];
+        }
+        $.each(data_type, function (i, type) {
+          $.each(data[type], function (key, value) {
+            data[type][key].marker.setMap(null);
+          });
+          data[type] = {};
         });
-        data[data_type] = {};
       }
     };
   }
 
   // Setup UI element interactions
   $('#gyms-switch').change(buildSwitchChangeListener(map_data, "gyms", "showGyms"));
-  $('#pokemon-switch').change(buildSwitchChangeListener(map_data, "pokemons", "showPokemon"));
+  $('#pokemon-switch').change(buildSwitchChangeListener(map_data, ["pokemons", "lure_pokemons"], "showPokemon"));
   $('#scanned-switch').change(buildSwitchChangeListener(map_data, "scanned", "showScanned"));
 
   $('#pokestops-switch').change(function () {

--- a/static/map.js
+++ b/static/map.js
@@ -1187,17 +1187,22 @@ $(function() {
       if (this.checked) {
         updateMap();
       } else {
-        $.each(data[data_type], function(key, value) {
-          data[data_type][key].marker.setMap(null);
+        if(typeof data_type === 'string') {
+          data_type = [data_type];
+        }
+        $.each(data_type, function(i, type) {
+          $.each(data[type], function (key, value) {
+            data[type][key].marker.setMap(null);
+          });
+          data[type] = {};
         });
-        data[data_type] = {}
       }
     }
   }
 
   // Setup UI element interactions
   $('#gyms-switch').change(buildSwitchChangeListener(map_data, "gyms", "showGyms"));
-  $('#pokemon-switch').change(buildSwitchChangeListener(map_data, "pokemons", "showPokemon"));
+  $('#pokemon-switch').change(buildSwitchChangeListener(map_data, ["pokemons", "lure_pokemons"], "showPokemon"));
   $('#scanned-switch').change(buildSwitchChangeListener(map_data, "scanned", "showScanned"));
 
   $('#pokestops-switch').change(function() {

--- a/static/map.js
+++ b/static/map.js
@@ -1187,11 +1187,11 @@ $(function() {
       if (this.checked) {
         updateMap();
       } else {
-        if(typeof data_type === 'string') {
+        if (typeof data_type === 'string') {
           data_type = [data_type];
         }
         $.each(data_type, function(i, type) {
-          $.each(data[type], function (key, value) {
+          $.each(data[type], function(key, value) {
             data[type][key].marker.setMap(null);
           });
           data[type] = {};


### PR DESCRIPTION
Lured Pokemon are shown when Pokemon filter is set to hide all Pokemon.

## Motivation and Context
I'm trying to fix a number of recurring JS issues that have caused a number of reverts of really nice features in the past.

## Expected Behavior
1. make sure pokemon are shown and you're scanning a location that has lured pokestops
2. hide pokemon
3. all pokemon should be hidden

## Current Behavior
1. make sure pokemon are shown and you're scanning a location that has lured pokestops
2. hide pokemon
3. wild pokemon are hidden, but lured pokemon are shown

## How Has This Been Tested?
Docker, google chrome on linux

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.

