### PR TITLE
Use RetryOperationalError to handle reconnect/retry query

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -7,6 +7,7 @@ import time
 from peewee import Model, MySQLDatabase, SqliteDatabase, InsertQuery,\
                    IntegerField, CharField, DoubleField, BooleanField,\
                    DateTimeField, OperationalError
+from playhouse.shortcuts import RetryOperationalError
 from datetime import datetime, timedelta
 from base64 import b64encode
 
@@ -21,13 +22,17 @@ args = get_args()
 db = None
 
 
+class MyRetryDB(RetryOperationalError, MySQLDatabase):
+    pass
+
+
 def init_database():
     global db
     if db is not None:
         return db
 
     if args.db_type == 'mysql':
-        db = MySQLDatabase(
+        db = MyRetryDB(
             args.db_name,
             user=args.db_user,
             password=args.db_pass,


### PR DESCRIPTION
## Description
Use RetryOperationalError to handle reconnect and retry queries to MySQL after connection is lost.

## Motivation and Context
https://github.com/AHAAAAAAA/PokemonGo-Map/issues/2352

## How Has This Been Tested?
Restarted MySQL while the app was running, with and without patch. With patch it starts again, without it floods you forever with

`[WARNING] (2003, "Can't connect to MySQL server on 'localhost' ([Errno 111] Connection refused)")... Retrying`

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.

