### PR TITLE
Disable caching on GET request to /raw_data

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -754,6 +754,7 @@ function loadRawData() {
       'neLng': neLng
     },
     dataType: "json",
+    cache: false,
     beforeSend: function() {
       if (rawDataIsLoading) {
         return false;


### PR DESCRIPTION
Some browsers, prominently on mobile, will cache the request to /raw_data and future requests will not actually query the server. This results in stale data and new Pokemon not being added.

## Description
Added a cache: false flag to the jQuery ajax call.

## Motivation and Context
I frequently encounter a problem where new Pokemon spawns are not being updated when viewing the map using a mobile browser and on data.

## How Has This Been Tested?
Using the map now always requests new data, even on mobile browsers.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

