### PR TITLE
Preserve animations when marker goes off screen 

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -751,7 +751,9 @@ function showInBoundsMarkers(markers) {
 
     if (show && !markers[key].marker.getMap()) {
       markers[key].marker.setMap(map);
+      markers[key].marker.setAnimation(markers[key].marker.oldAnimation);
     } else if (!show && markers[key].marker.getMap()) {
+      markers[key].marker.oldAnimation = markers[key].marker.getAnimation();
       markers[key].marker.setMap(null);
     }
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Marker animations are lost when they go off screen. When they're removed from the map, they lose their animation setting. Save their animation setting and restore it when they're redisplayed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Chrome on Windows, scrolled bouncers off screen and back on screen. Should keep bouncing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

