### PR TITLE
Persist location changes across sessions when using search box

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -116,6 +116,10 @@ var StoreOptions = {
     default: [],
     type: StoreTypes.JSON
   },
+  remember_location: {
+    default: {lat: center_lat, lon: center_lng},
+    type: StoreTypes.JSON
+  },
   showGyms: {
     default: false,
     type: StoreTypes.Boolean
@@ -214,10 +218,7 @@ function removePokemonMarker(encounter_id) {
 
 function initMap() {
   map = new google.maps.Map(document.getElementById('map'), {
-    center: {
-      lat: center_lat,
-      lng: center_lng
-    },
+    center: Store.get('remember_location'),
     zoom: 16,
     fullscreenControl: true,
     streetViewControl: false,
@@ -297,10 +298,7 @@ function initMap() {
 
 function createSearchMarker() {
   marker = new google.maps.Marker({ //need to keep reference.
-    position: {
-      lat: center_lat,
-      lng: center_lng
-    },
+    position: Store.get('remember_location'),
     map: map,
     animation: google.maps.Animation.DROP,
     draggable: true
@@ -1036,10 +1034,7 @@ function addMyLocationButton() {
   locationMarker = new google.maps.Marker({
     map: map,
     animation: google.maps.Animation.DROP,
-    position: {
-      lat: center_lat,
-      lng: center_lng
-    },
+    position: Store.get('remember_location'),
     icon: {
       path: google.maps.SymbolPath.CIRCLE,
       fillOpacity: 1,
@@ -1068,6 +1063,7 @@ function changeLocation(lat, lng) {
   changeSearchLocation(lat, lng).done(function() {
     map.setCenter(loc);
     marker.setPosition(loc);
+    Store.set('remember_location', {lat: lat, lng: lng});
   });
 }
 

--- a/static/map.js
+++ b/static/map.js
@@ -117,7 +117,7 @@ var StoreOptions = {
     type: StoreTypes.JSON
   },
   remember_location: {
-    default: {lat: center_lat, lon: center_lng},
+    default: { lat: center_lat, lng: center_lng },
     type: StoreTypes.JSON
   },
   showGyms: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds remember_location to local storage and defaults to start location passed via HTML. Changing your location using the location search box will persist across sessions and open map up to last searched location. Using the default value functionality from Store ensures behavior does not change if the remember_location variable is unset.

## Motivation and Context
I have multiple searchers running in the background for friends' locations and wanted to be able to have the page automatically open up to their location instead of mine.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Chrome on Win10, tested from clean state (no remember_location var set), verified var was set properly via search box, and fresh pageload worked with saved var.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

