### PR TITLE
Removed locationButton under certain conditions.

### DIFF
--- a/static/dist/js/map.js
+++ b/static/dist/js/map.js
@@ -882,6 +882,10 @@ function myLocationButton(map, marker) {
   locationButton.style.marginRight = '10px';
   locationButton.style.padding = '0px';
   locationButton.title = 'Your Location';
+  locationButton.id = 'location-button';
+  if (Store.get('geoLocate')) {
+    locationButton.style.display = 'none';
+  }
   locationContainer.appendChild(locationButton);
 
   var locationIcon = document.createElement('div');
@@ -1128,6 +1132,11 @@ $(function () {
   });
 
   $('#geoloc-switch').change(function () {
+    if (this.checked) {
+      $("#location-button").hide();
+    } else {
+      $("#location-button").show();
+    }
     $("#next-location").prop("disabled", this.checked);
     $("#next-location").css("background-color", this.checked ? "#e0e0e0" : "#ffffff");
     if (!navigator.geolocation) this.checked = false;else Store.set('geoLocate', this.checked);

--- a/static/map.js
+++ b/static/map.js
@@ -991,6 +991,10 @@ function myLocationButton(map, marker) {
   locationButton.style.marginRight = '10px';
   locationButton.style.padding = '0px';
   locationButton.title = 'Your Location';
+  locationButton.id = 'location-button';
+  if (Store.get('geoLocate')) {
+    locationButton.style.display = 'none';
+  }
   locationContainer.appendChild(locationButton);
 
   var locationIcon = document.createElement('div');
@@ -1240,6 +1244,11 @@ $(function() {
   });
 
   $('#geoloc-switch').change(function() {
+    if (this.checked) {
+      $("#location-button").hide();
+    } else {
+      $("#location-button").show();
+    }
     $("#next-location").prop("disabled", this.checked);
     $("#next-location").css("background-color", this.checked ? "#e0e0e0" : "#ffffff");
     if (!navigator.geolocation)


### PR DESCRIPTION
## Description
* Removed locationButton when Geolocation is toggled on, because current
position = worker position anyhow.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested on Win10: Edge, Chrome, Firefox.
Tested on Android 6.0.1: Chrome.

## Screenshots (if appropriate):
![before](https://cloud.githubusercontent.com/assets/11703528/17201454/3caa7d7c-5497-11e6-81c9-a6f4757a334b.png)
![after](https://cloud.githubusercontent.com/assets/11703528/17201456/44313ebe-5497-11e6-9072-8ce6195dc96f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.