### PR TITLE
Add backoff to login logic

### DIFF
--- a/pogom/pgoapi/auth_ptc.py
+++ b/pogom/pgoapi/auth_ptc.py
@@ -26,6 +26,7 @@ Author: tjado <https://github.com/tejado>
 import re
 import json
 import requests
+import time
 
 from auth import Auth
 
@@ -34,12 +35,13 @@ class AuthPtc(Auth):
     PTC_LOGIN_URL = 'https://sso.pokemon.com/sso/login?service=https%3A%2F%2Fsso.pokemon.com%2Fsso%2Foauth2.0%2FcallbackAuthorize'
     PTC_LOGIN_OAUTH = 'https://sso.pokemon.com/sso/oauth2.0/accessToken'
     PTC_LOGIN_CLIENT_SECRET = 'w8ScCUXJQc6kXKw8FiOhd8Fixzht18Dq3PEVkUCP5ZPxtgyWsbTvWHFLm2wNY0JR'
+    head = {'User-Agent': 'niantic'}
 
     def __init__(self):
         Auth.__init__(self)
-        
+
         self._auth_provider = 'ptc'
-        
+
         self._session = requests.session()
         self._session.verify = True
 
@@ -47,15 +49,21 @@ class AuthPtc(Auth):
 
         self.log.info('PTC login for: %s', username)
 
-        head = {'User-Agent': 'niantic'}
-        r = self._session.get(self.PTC_LOGIN_URL, headers=head)
-        
+
+        r = self._session.get(self.PTC_LOGIN_URL, headers=self.head)
+
+        self.log.info('Response: %s: %s', str(r), r.content)
         try:
             jdata = json.loads(r.content)
         except ValueError as e:
-            self.log.error('{}... server seems to be down :('.format(str(e)))
+            self.log.error('%s... server seems to be down :(', str(e))
+            self.log.error('%s', r.content)
             return False
-            
+
+        time.sleep(1.5)
+        return self.login_step2(jdata, username, password, True)
+
+    def login_step2(self, jdata, username, password, firstTry):
         data = {
             'lt': jdata['lt'],
             'execution': jdata['execution'],
@@ -63,8 +71,9 @@ class AuthPtc(Auth):
             'username': username,
             'password': password[:15],
         }
-        r1 = self._session.post(self.PTC_LOGIN_URL, data=data, headers=head)
+        r1 = self._session.post(self.PTC_LOGIN_URL, data=data, headers=self.head)
 
+        self.log.info('Response: %s: %s', str(r1), r1.content)
         ticket = None
         try:
             ticket = re.sub('.*ticket=', '', r1.history[0].headers['Location'])
@@ -73,8 +82,17 @@ class AuthPtc(Auth):
                 self.log.error('Could not retrieve token: %s', r1.json()['errors'][0])
             except Exception as e:
                 self.log.error('Could not retrieve token! (%s)', str(e))
-            return False
 
+            if firstTry:
+                time.sleep(3)
+                return self.login_step2(jdata, username, password, False)
+            else:
+                return False
+
+        time.sleep(1.5)
+        return self.login_oauth(ticket, True)
+
+    def login_oauth(self, ticket, firstTry):
         data1 = {
             'client_id': 'mobile-app_pokemon-go',
             'redirect_uri': 'https://www.nianticlabs.com/pokemongo/error',
@@ -82,8 +100,9 @@ class AuthPtc(Auth):
             'grant_type': 'refresh_token',
             'code': ticket,
         }
-        
+
         r2 = self._session.post(self.PTC_LOGIN_OAUTH, data=data1)
+        self.log.info('Response: %s: %s', str(r2), r2.content)
         access_token = re.sub('&expires.*', '', r2.content)
         access_token = re.sub('.*access_token=', '', access_token)
 
@@ -92,10 +111,14 @@ class AuthPtc(Auth):
             self.log.debug('PTC Session Token: %s', access_token[:25])
             self._auth_token = access_token
         else:
-            self.log.info('Seems not to be a PTC Session Token... login failed :(')
-            return False
-        
+            self.log.info('Seems not to be a PTC Session Token... login failed :( %s', access_token)
+            if firstTry:
+                time.sleep(4)
+                return self.login_oauth(ticket, False)
+            else:
+                return False
+
         self._login = True
-        
+
         return True
-        
+

--- a/pogom/pgoapi/pgoapi.py
+++ b/pogom/pgoapi/pgoapi.py
@@ -24,6 +24,9 @@ Author: tjado <https://github.com/tejado>
 """
 
 import logging
+import re
+import requests
+import time
 
 from utilities import f2i
 
@@ -41,12 +44,12 @@ class PGoApi:
     API_ENTRY = 'https://pgorelease.nianticlabs.com/plfe/rpc'
 
     def __init__(self):
-    
+
         self.log = logging.getLogger(__name__)
 
         self._auth_provider = None
         self._api_endpoint = None
-        
+
         self._position_lat = 0
         self._position_lng = 0
         self._position_alt = 0
@@ -67,58 +70,58 @@ class PGoApi:
     def call(self):
         if not self._req_method_list:
             return False
-        
+
         if self._auth_provider is None or not self._auth_provider.is_login():
             self.log.info('Not logged in')
             return False
-        
+
         player_position = self.get_position()
-        
+
         request = RpcApi(self._auth_provider)
-        
+
         if self._api_endpoint:
             api_endpoint = self._api_endpoint
         else:
             api_endpoint = self.API_ENTRY
-        
+
         self.log.info('Execution of RPC')
         response = None
         try:
             response = request.request(api_endpoint, self._req_method_list, player_position)
         except ServerBusyOrOfflineException as e:
             self.log.info('Server seems to be busy or offline - try again!')
-        
+
         # cleanup after call execution
         self.log.info('Cleanup of request!')
         self._req_method_list = []
-        
+
         return response
-    
+
     #def get_player(self):
-    
+
     def list_curr_methods(self):
         for i in self._req_method_list:
             print("{} ({})".format(RpcEnum.RequestMethod.Name(i),i))
-    
+
     def set_logger(self, logger):
         self._ = logger or logging.getLogger(__name__)
 
     def get_position(self):
         return (self._position_lat, self._position_lng, self._position_alt)
 
-    def set_position(self, lat, lng, alt):   
+    def set_position(self, lat, lng, alt):
         self.log.debug('Set Position - Lat: %s Long: %s Alt: %s', lat, lng, alt)
-        
+
         self._position_lat = f2i(lat)
         self._position_lng = f2i(lng)
         self._position_alt = f2i(alt)
 
     def __getattr__(self, func):
         def function(**kwargs):
-        
+
             if not self._req_method_list:
                 self.log.info('Create new request...')
-        
+
             name = func.upper()
             if kwargs:
                 self._req_method_list.append( { RpcEnum.RequestMethod.Value(name): kwargs } )
@@ -127,62 +130,72 @@ class PGoApi:
             else:
                 self._req_method_list.append( RpcEnum.RequestMethod.Value(name) )
                 self.log.info("Adding '%s' to RPC request", name)
-   
+
             return self
-   
+
         if func.upper() in RpcEnum.RequestMethod.keys():
             return function
         else:
             raise AttributeError
-            
-        
+
+
     def login(self, provider, username, password):
-    
+
         if not isinstance(username, basestring) or not isinstance(password, basestring):
             raise AuthException("Username/password not correctly specified")
-        
+
         if provider == 'ptc':
             self._auth_provider = AuthPtc()
         elif provider == 'google':
             self._auth_provider = AuthGoogle()
         else:
             raise AuthException("Invalid authentication provider - only ptc/google available.")
-            
+
         self.log.debug('Auth provider: %s', provider)
-        
+
         if not self._auth_provider.login(username, password):
-            self.log.info('Login process failed') 
+            self.log.info('Login process failed')
             return False
-        
+
+        return self.start_fetch(True)
+
+    def start_fetch(self, firsTry):
         self.log.info('Starting RPC login sequence (app simulation)')
-        
+
         # making a standard call, like it is also done by the client
         self.get_player()
         self.get_hatched_eggs()
         self.get_inventory()
         self.check_awarded_badges()
         self.download_settings(hash="4a2e9bc330dae60e7b74fc85b98868ab4700802e")
-        
+
         response = self.call()
-        
-        if not response: 
-            self.log.info('Login failed!') 
+
+        if not response:
+            self.log.info('Login failed!')
             return False
-        
+
         if 'api_url' in response:
             self._api_endpoint = ('https://{}/rpc'.format(response['api_url']))
             self.log.debug('Setting API endpoint to: %s', self._api_endpoint)
-        
+
         elif 'auth_ticket' in response:
             auth_ticket = response['auth_ticket']
             self._auth_provider.set_ticket([auth_ticket['expire_timestamp_ms'], auth_ticket['start'], auth_ticket['end']])
 
         else:
             self.log.error('Login failed - unexpected server response!')
-            return False
-        
+            self.log.error('%s', response)
+            if firsTry == True:
+                self.log.warn('Retrying....')
+                time.sleep(3)
+                return self.start_fetch(False)
+            else:
+                self.log.error('No luck.')
+                return False
+
         self.log.info('Finished RPC login sequence (app simulation)')
-        self.log.info('Login process completed') 
-        
+        self.log.info('Login process completed')
+
         return True
-        
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The Pokemon login servers are not so fast. When tokens are generated, they are not directly available in other services.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This changes adds backoff to the login logic, improving overall stability and speed when starting up.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a fast connection and PC, python is too fast for the pokemon servers. Without this change, it would take up to a minute before every part of the login process succeeded. Not anymore, because 99 of 100 times, the first login statement (getting token from PTC & use that) fails and is now succeeding the second try.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

