### PR TITLE
Fix package.json to play nicely with the heroku nodejs buildpack

### DIFF
--- a/app.json
+++ b/app.json
@@ -27,5 +27,13 @@
       "description": "Any extra arguments that you want to pass to runserver.py.",
       "required": false
     }
-  }
+  },
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    },
+    {
+      "url": "heroku/python"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "0.1.0",
   "description": "Pokemon Go Map - Live Visualization",
   "main": "Gruntfile.js",
-  "devDependencies": {
+  "dependencies": {
     "babel-preset-es2015": "^6.9.0",
     "grunt": "^0.4.5",
     "grunt-babel": "^6.0.0",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "latest",
     "grunt-contrib-concat": "latest",
     "grunt-contrib-connect": "latest",
@@ -24,9 +25,9 @@
     "jshint-stylish": "latest"
   },
   "scripts": {
-    "build": "grunt build",
-    "lint": "grunt lint",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "postinstall": "./node_modules/.bin/grunt build",
+    "build": "./node_modules/.bin/grunt build",
+    "lint": "./node_modules/.bin/grunt lint"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
Update the package.json to make this play nicely with heroku now that the dist files are gone.

## Motivation and Context
If you set up multiple buildpacks on your heroku project, specifically `heroku/nodejs` and `heroku/python` in that order, heroku deploys will create the dist css files before running the app.
Fixes #2534

## How Has This Been Tested?
`heroku push deploy:master`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.