### PR TITLE
Added check for Grunt files.

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -28,7 +28,12 @@ if __name__ == '__main__':
         log.setLevel(logging.DEBUG);
     else:
         log.setLevel(logging.INFO);
-
+    
+    # Let's not forget to run Grunt
+    if not os.path.exists('static/dist'):
+        log.critical('Please run "grunt build" before starting the server.');
+        sys.exit();
+    
     # These are very noisey, let's shush them up a bit
     logging.getLogger("peewee").setLevel(logging.INFO)
     logging.getLogger("requests").setLevel(logging.WARNING)


### PR DESCRIPTION
## Description
Server checks if the directory `static/dist` exists before allowing the server to run. This solves the problem of users missing the dist files because they didn't run `grunt build`.

## Motivation and Context
Recent commit removed dist files: https://github.com/AHAAAAAAA/PokemonGo-Map/commit/3ebb51ef48d73190e6171712c6395c119800fb35

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
