### PR TITLE
Add support for multiple accounts (#2546)

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -145,11 +145,7 @@ def create_empty_apis(api_count):
     for i in range(api_count):
         apis.append(PGoApi())
 
-<<<<<<< HEAD
 def search_thread(q, api_idx, search_control):
-=======
-def search_thread(q, api_idx):
->>>>>>> 63e74bdb0cba94d78630432f84e2479c60ae507c
     api = apis[api_idx]
     threadname = threading.currentThread().getName()
     log.debug("Search thread {}: started and waiting".format(threadname))

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -29,7 +29,7 @@ from .models import parse_map
 log = logging.getLogger(__name__)
 
 TIMESTAMP = '\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000'
-api = PGoApi()
+apis = []
 
 search_queue = Queue()
 
@@ -110,12 +110,12 @@ def generate_location_steps(initial_loc, step_count):
         ring += 1
 
 
-def login(args, position):
+def login(args, api, auth_service, username, password, position):
     log.info('Attempting login to Pokemon Go.')
 
     api.set_position(*position)
 
-    while not api.login(args.auth_service, args.username, args.password):
+    while not api.login(auth_service, username, password):
         log.info('Failed to login to Pokemon Go. Trying again in {:g} seconds.'.format(args.login_delay))
         time.sleep(args.login_delay)
 
@@ -125,16 +125,22 @@ def login(args, position):
 #
 # Search Threads Logic
 #
-def create_search_threads(num, search_control):
+def create_search_threads(thread_count, api_count, search_control):
     search_threads = []
-    for i in range(num):
-        t = Thread(target=search_thread, name='search_thread-{}'.format(i), args=(search_queue,search_control,))
+    for i in range(thread_count):
+        api_idx = i % api_count
+        t = Thread(target=search_thread, name='search_thread-{}'.format(i), args=(search_queue, api_idx, search_control,))
         t.daemon = True
         t.start()
         search_threads.append(t)
 
 
-def search_thread(q, search_control):
+def create_empty_apis(api_count):
+    for i in range(api_count):
+        apis.append(PGoApi())
+
+def search_thread(q, api_idx, search_control):
+    api = apis[api_idx]
     threadname = threading.currentThread().getName()
     log.debug("Search thread {}: started and waiting".format(threadname))
     while True:
@@ -214,15 +220,19 @@ def search(args, i):
 
     position = (config['ORIGINAL_LATITUDE'], config['ORIGINAL_LONGITUDE'], 0)
 
-    if api._auth_provider and api._auth_provider._ticket_expire:
-        remaining_time = api._auth_provider._ticket_expire/1000 - time.time()
+    for i, auth in enumerate(args.auths):
+        api = apis[i]
+        auth_service, username, password = auth.split(':')
+        if api._auth_provider and api._auth_provider._ticket_expire:
+            remaining_time = api._auth_provider._ticket_expire/1000 - time.time()
 
-        if remaining_time > 60:
-            log.info("Current login valid for {:.2f} seconds".format(remaining_time))
+            if remaining_time > 60:
+                log.info("Skipping Pokemon Go login for {} process since already logged in \
+                    for another {:.2f} seconds".format(username, remaining_time))
+            else:
+                login(args, api, auth_service, username, password, position)
         else:
-            login(args, position)
-    else:
-        login(args, position)
+            login(args, api, auth_service, username, password, position)
 
     lock = Lock()
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -110,10 +110,16 @@ def generate_location_steps(initial_loc, step_count):
         ring += 1
 
 
-def login(args, api, auth_service, username, password, position):
+def login(args, i, position):
     log.info('Attempting login to Pokemon Go.')
 
+    api = apis[i]
+
     api.set_position(*position)
+
+    auth_service = args.auth_service[i]
+    username = args.username[i]
+    password = args.password[i]
 
     while not api.login(auth_service, username, password):
         log.info('Failed to login to Pokemon Go. Trying again in {:g} seconds.'.format(args.login_delay))
@@ -220,19 +226,17 @@ def search(args, i):
 
     position = (config['ORIGINAL_LATITUDE'], config['ORIGINAL_LONGITUDE'], 0)
 
-    for i, auth in enumerate(args.auths):
+    for i in range(len(args.username)):
         api = apis[i]
-        auth_service, username, password = auth.split(':')
         if api._auth_provider and api._auth_provider._ticket_expire:
             remaining_time = api._auth_provider._ticket_expire/1000 - time.time()
 
             if remaining_time > 60:
-                log.info("Skipping Pokemon Go login for {} process since already logged in \
-                    for another {:.2f} seconds".format(username, remaining_time))
+                log.info("Current login ({}) valid for {:.2f} seconds".format(args.username[i], remaining_time))
             else:
-                login(args, api, auth_service, username, password, position)
+                login(args, i, position)
         else:
-            login(args, api, auth_service, username, password, position)
+            login(args, i, position)
 
     lock = Lock()
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -33,9 +33,13 @@ def get_args():
     # fuck PEP8
     configpath = os.path.join(os.path.dirname(__file__), '../config/config.ini')
     parser = configargparse.ArgParser(default_config_files=[configpath])
-
-    parser.add_argument('-a', '--auths', nargs='+',
-                         help="One or more strings in the form auth_provider:username:password")
+    parser.add_argument('-a', '--auth-service', type=str.lower, action='append',
+                        help='Auth Services, either one for all accounts or one per account. \
+                        ptc or google. Defaults all to ptc.')
+    parser.add_argument('-u', '--username', action='append',
+                        help='Usernames, one per account.')
+    parser.add_argument('-p', '--password', action='append',
+                        help='Passwords, either single one for all accounts or one per account.')
     parser.add_argument('-l', '--location', type=parse_unicode,
                         help='Location, can be an address or coordinates')
     parser.add_argument('-st', '--step-limit', help='Steps', type=int,
@@ -118,10 +122,41 @@ def get_args():
             print sys.argv[0] + ': error: arguments -l/--location is required'
             sys.exit(1)
     else:
-        if (args.auths is None or args.location is None or args.step_limit is None):
+        if (args.username is None or args.location is None or args.step_limit is None):
             parser.print_usage()
-            print sys.argv[0] + ': error: arguments -a/--auths, -l/--location, -st/--step-limit are required'
+            print sys.argv[0] + ': error: arguments -u/--username, -l/--location, -st/--step-limit are required'
             sys.exit(1)
+
+        if args.auth_service is None:
+            args.auth_service = ['ptc']
+
+        if args.password is None:
+            if config['PASSWORD'] is None:
+                config['PASSWORD'] = getpass.getpass()
+            args.password = [config['PASSWORD']]
+
+        num_username = len(args.username)
+
+        # If there are multiple usernames, then we either need one passwords that we use for all,
+        # or equal amount so that they match 1:1. Same for authentication services.
+        if num_username > 1:
+            num_passwd = len(args.password)
+            if (num_passwd == 1):
+                log.debug('More than one username and one password given. Using same password for all accounts.')
+                args.password = args.password * num_username
+            elif (num_passwd > 1 and num_username != num_passwd):
+                print sys.argv[0] + ': error: number of usernames ({}) does not match the number of passwords ({})' \
+                                    .format(num_username, num_passwd)
+                sys.exit(1);
+
+            num_auth = len(args.auth_service)
+            if (num_auth == 1):
+                log.debug('More than one username and one auth service given. Using same auth service for all accounts.')
+                args.auth_service = args.auth_service * num_username
+            if (num_auth > 1 and num_username != num_auth):
+                print sys.argv[0] + ': error: number of usernames ({}) does not match the number of auth providers ({})' \
+                                    .format(num_username, num_auth)
+                sys.exit(1);
 
     return args
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -33,10 +33,9 @@ def get_args():
     # fuck PEP8
     configpath = os.path.join(os.path.dirname(__file__), '../config/config.ini')
     parser = configargparse.ArgParser(default_config_files=[configpath])
-    parser.add_argument('-a', '--auth-service', type=str.lower,
-                        help='Auth Service', default='ptc')
-    parser.add_argument('-u', '--username', help='Username')
-    parser.add_argument('-p', '--password', help='Password')
+
+    parser.add_argument('-a', '--auths', nargs='+', type=str.lower,
+                         help="One or more strings in the form auth_provider:username:password")
     parser.add_argument('-l', '--location', type=parse_unicode,
                         help='Location, can be an address or coordinates')
     parser.add_argument('-st', '--step-limit', help='Steps', type=int,
@@ -119,15 +118,10 @@ def get_args():
             print sys.argv[0] + ': error: arguments -l/--location is required'
             sys.exit(1)
     else:
-        if (args.username is None or args.location is None or args.step_limit is None):
+        if (args.auths is None or args.location is None or args.step_limit is None):
             parser.print_usage()
-            print sys.argv[0] + ': error: arguments -u/--username, -l/--location, -st/--step-limit are required'
+            print sys.argv[0] + ': error: arguments -a/--auths, -l/--location, -st/--step-limit are required'
             sys.exit(1)
-
-        if config["PASSWORD"] is None and args.password is None:
-            config["PASSWORD"] = args.password = getpass.getpass()
-        elif args.password is None:
-            args.password = config["PASSWORD"]
 
     return args
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -34,7 +34,7 @@ def get_args():
     configpath = os.path.join(os.path.dirname(__file__), '../config/config.ini')
     parser = configargparse.ArgParser(default_config_files=[configpath])
 
-    parser.add_argument('-a', '--auths', nargs='+', type=str.lower,
+    parser.add_argument('-a', '--auths', nargs='+',
                          help="One or more strings in the form auth_provider:username:password")
     parser.add_argument('-l', '--location', type=parse_unicode,
                         help='Location, can be an address or coordinates')

--- a/runserver.py
+++ b/runserver.py
@@ -91,8 +91,8 @@ if __name__ == '__main__':
         # Gather the pokemons!
         if not args.mock:
             log.debug('Starting a real search thread and {} search runner thread(s)'.format(args.num_threads))
-            create_empty_apis(len(args.auths))
-            create_search_threads(args.num_threads, len(args.auths), search_control)
+            create_empty_apis(len(args.username))
+            create_search_threads(args.num_threads, len(args.username), search_control)
             search_thread = Thread(target=search_loop, args=(args,search_control,))
         else:
             log.debug('Starting a fake search thread')

--- a/runserver.py
+++ b/runserver.py
@@ -17,7 +17,7 @@ from pogom import config
 from pogom.app import Pogom
 from pogom.utils import get_args, insert_mock_data
 
-from pogom.search import search_loop, create_search_threads, fake_search_loop
+from pogom.search import search_loop, create_empty_apis, create_search_threads, fake_search_loop
 from pogom.models import init_database, create_tables, drop_tables, Pokemon, Pokestop, Gym
 
 from pogom.pgoapi.utilities import get_pos_by_name
@@ -91,7 +91,8 @@ if __name__ == '__main__':
         # Gather the pokemons!
         if not args.mock:
             log.debug('Starting a real search thread and {} search runner thread(s)'.format(args.num_threads))
-            create_search_threads(args.num_threads, search_control)
+            create_empty_apis(len(args.auths))
+            create_search_threads(args.num_threads, len(args.auths), search_control)
             search_thread = Thread(target=search_loop, args=(args,search_control,))
         else:
             log.debug('Starting a fake search thread')


### PR DESCRIPTION
## Description

Allows splitting scan threads between multiple accounts
for faster scanning of an area.

## Motivation and Context

Niantic throttles scans aggressively. One account can't keep up with 
15 step area and some people want much larger areas. 

It has been possible to run multiple instances of runserver.py with
smaller step values and their own areas and accounts, but it's
a lot of work to calculate the area locations by hand. 

Using multiple accounts to bypass these shortcomings was
suggested in #2546.

## How Has This Been Tested?

I've tested the program with one huge area to see how much
faster the scanning is (screenshots below).

I also tested the program with a smaller area to see if the 
search -function understands multiple threads and checks
all their active logins. It does. However I haven't seen a 
reauthentication.

I do have my doubts about the way reauthentication is done.
To me it feels like if an API ticket runs out of time the rest of the
scanning round fails. I did not make changes here as to me
it looks like this possible problem has nothing to do with
my code changes and should be handled independetly.

## Screenshots (if appropriate):
**1 account, 3 threads**
![1 account, 3 threads](https://cloud.githubusercontent.com/assets/1516312/17244473/b9c4260c-558a-11e6-82c7-29845528a00a.png)
**4 accounts, 12 threads**
![4 accounts, 12 threads](https://cloud.githubusercontent.com/assets/1516312/17244481/c43c470e-558a-11e6-8b29-cdedaf0b6ae4.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Changes to program arguments:

`-a`/`--auth-service`, `-u`/`--user` and `-p`/`--password` can now be defined multiple times.
This is also possible for config file.

If one or no users are given this patch has no impact on the behaviour of the program.
If more than one username is given, then search threads will be split among these 
accounts. 

If multiple usernames, but one password is given, then that password is used
for every account. Same goes for authentication services.