### PR TITLE
No grunt build is needed when running only searchers

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -29,10 +29,11 @@ if __name__ == '__main__':
     else:
         log.setLevel(logging.INFO);
 
-    # Let's not forget to run Grunt
-    if not os.path.exists(os.path.join(os.path.dirname(__file__), 'static/dist')):
-        log.critical('Please run "grunt build" before starting the server.');
-        sys.exit();
+    # Let's not forget to run Grunt / Only needed when running with webserver
+    if not args.no_server:
+        if not os.path.exists(os.path.join(os.path.dirname(__file__), 'static/dist')):
+            log.critical('Please run "grunt build" before starting the server.');
+            sys.exit();
 
     # These are very noisey, let's shush them up a bit
     logging.getLogger("peewee").setLevel(logging.INFO)


### PR DESCRIPTION
When starting the server with -ns option no frontend is started. 
In this case the grunt build is not needed. This can be useful for seperate nodes running only searchers. 

## Description
Oneliner change to check if the frontend is needed or not. 

## Motivation and Context
No need to install nodejs / npm / grunt if the node only acts as server in a more complicated setup. 

## How Has This Been Tested?
Tested on my own nodes. ( Linux ) 
This should work on all platforms since it's just a conditional check on the passed args. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
