### PR TITLE
Fix scan radius to be 70 metres (adapt to API change)

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -76,7 +76,7 @@ def generate_location_steps(initial_loc, step_count):
     SOUTH = 180
     WEST = 270
 
-    pulse_radius = 0.1                  # km - radius of players heartbeat is 100m
+    pulse_radius = 0.07                  # km - radius of players heartbeat is 70m
     xdist = math.sqrt(3)*pulse_radius   # dist between column centers
     ydist = 3*(pulse_radius/2)          # dist between row centers
 

--- a/static/dist/js/map.js
+++ b/static/dist/js/map.js
@@ -633,7 +633,7 @@ function setupScannedMarker(item) {
   var marker = new google.maps.Circle({
     map: map,
     center: circleCenter,
-    radius: 100, // 10 miles in metres
+    radius: 70, // Scan radius is 70 metres
     fillColor: getColorByDate(item.last_modified),
     strokeWeight: 1
   });

--- a/static/map.js
+++ b/static/map.js
@@ -633,7 +633,7 @@ function setupScannedMarker(item) {
   var marker = new google.maps.Circle({
     map: map,
     center: circleCenter,
-    radius: 100, // 10 miles in metres
+    radius: 70, // Scan radius is 70 metres
     fillColor: getColorByDate(item.last_modified),
     strokeWeight: 1
   });


### PR DESCRIPTION
API changed scan radius from 100m to 70. This commit adapts the code so that all pokemon show up again. Fixes several issues I think.

At least this one:
https://github.com/AHAAAAAAA/PokemonGo-Map/issues/2569

regards, Kira