### PR TITLE
Update map.html

### DIFF
--- a/templates/map.html
+++ b/templates/map.html
@@ -43,8 +43,8 @@
         <div class="form-control switch-container" style="display:{{is_fixed}}" >
           <label for="next-location">
             <h3>Change your location</h3>
-            <input id="next-location" type="text" name="next-location" placeholder="Change your location">
           </label>
+          <input id="next-location" type="text" name="next-location" placeholder="Change your location">
         </div>
         <div class="form-control switch-container">
           <h3>Follow location</h3>


### PR DESCRIPTION
Tweak to sidebar HTML

## Description
Tweak to the HTML to make the "change location" input field line wrap nicely to fit inside the sidebar when running in Firefox.

## Motivation and Context
Change Location input field was nearly invisible, as it was pushed out of the sidebar with overflow:hidden, preventing access to the feature's UI.

## How Has This Been Tested?
Used Firebug to modify the HTML on the fly, double-checked results in Chrome.

## Screenshots (if appropriate):
http://s31.postimg.org/4z4lzaj9n/original.png
http://s31.postimg.org/oyz08tv63/fix.png

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

