### PR TITLE
moving Mapstyle selector to Option menu with select2 and rebased from #2040

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -5,6 +5,7 @@
 
 var $selectExclude;
 var $selectNotify;
+var $selectStyle;
 
 var language = document.documentElement.lang == "" ? "en" : document.documentElement.lang;
 var idToPokemon = {};
@@ -224,7 +225,7 @@ function initMap() {
     zoom: 16,
     fullscreenControl: true,
     streetViewControl: false,
-    mapTypeControl: true,
+    mapTypeControl: false,
     mapTypeControlOptions: {
       style: google.maps.MapTypeControlStyle.DROPDOWN_MENU,
       position: google.maps.ControlPosition.RIGHT_TOP,
@@ -1148,6 +1149,40 @@ $(function() {
   if (Notification.permission !== "granted") {
     Notification.requestPermission();
   }
+});
+
+$(function() {
+	// populate Navbar Style menu
+	$selectStyle = $("#map-style")
+	
+	// Load Stylenames from locale and populate lists
+	$.getJSON("static/locales/mapstyle." + language + ".json").done(function(data){
+		var styleList = []
+		
+		$.each(data, function(key, value){
+			styleList.push( { id: key, text: value } );
+		});
+		
+		
+		// setup the stylelist
+		$selectStyle.select2({
+			placeholder: "Select Style",
+			data: styleList
+		});
+
+		// setup the list change behavior
+		$selectStyle.on("change", function (e) {
+			selectedStyle = $selectStyle.val();
+			map.setMapTypeId(selectedStyle)
+			Store.set('map_style', selectedStyle)
+		});
+		
+		
+		// recall saved mapstyle
+		$selectStyle.val(Store.get('map_style')).trigger("change");
+		
+	});
+
 });
 
 $(function() {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1152,36 +1152,36 @@ $(function() {
 });
 
 $(function() {
-	// populate Navbar Style menu
-	$selectStyle = $("#map-style")
+    // populate Navbar Style menu
+    $selectStyle = $("#map-style")
 	
 	// Load Stylenames from locale and populate lists
 	$.getJSON("static/locales/mapstyle." + language + ".json").done(function(data){
-		var styleList = []
-		
-		$.each(data, function(key, value){
-			styleList.push( { id: key, text: value } );
-		});
-		
-		
-		// setup the stylelist
-		$selectStyle.select2({
-			placeholder: "Select Style",
-			data: styleList
-		});
+        var styleList = []
 
-		// setup the list change behavior
-		$selectStyle.on("change", function (e) {
-			selectedStyle = $selectStyle.val();
-			map.setMapTypeId(selectedStyle)
-			Store.set('map_style', selectedStyle)
-		});
+        $.each(data, function(key, value){
+            styleList.push( { id: key, text: value } );
+        });
 		
 		
-		// recall saved mapstyle
-		$selectStyle.val(Store.get('map_style')).trigger("change");
+        // setup the stylelist
+        $selectStyle.select2({
+            placeholder: "Select Style",
+            data: styleList
+        });
+
+        // setup the list change behavior
+        $selectStyle.on("change", function (e) {
+            selectedStyle = $selectStyle.val();
+            map.setMapTypeId(selectedStyle)
+        Store.set('map_style', selectedStyle)
+        });
 		
-	});
+		
+        // recall saved mapstyle
+        $selectStyle.val(Store.get('map_style')).trigger("change");
+
+    });
 
 });
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1152,36 +1152,36 @@ $(function() {
 });
 
 $(function() {
-    // populate Navbar Style menu
-    $selectStyle = $("#map-style")
+  // populate Navbar Style menu
+  $selectStyle = $("#map-style")
 	
-	// Load Stylenames from locale and populate lists
-	$.getJSON("static/locales/mapstyle." + language + ".json").done(function(data){
-        var styleList = []
+  // Load Stylenames from locale and populate lists
+  $.getJSON("static/locales/mapstyle." + language + ".json").done(function(data){
+    var styleList = []
 
-        $.each(data, function(key, value){
-            styleList.push( { id: key, text: value } );
-        });
+    $.each(data, function(key, value){
+    styleList.push( { id: key, text: value } );
+  });
 		
 		
-        // setup the stylelist
-        $selectStyle.select2({
-            placeholder: "Select Style",
-            data: styleList
-        });
+  // setup the stylelist
+  $selectStyle.select2({
+    placeholder: "Select Style",
+    data: styleList
+  });
 
-        // setup the list change behavior
-        $selectStyle.on("change", function (e) {
-            selectedStyle = $selectStyle.val();
-            map.setMapTypeId(selectedStyle)
-        Store.set('map_style', selectedStyle)
-        });
+  // setup the list change behavior
+  $selectStyle.on("change", function (e) {
+    selectedStyle = $selectStyle.val();
+    map.setMapTypeId(selectedStyle);
+    Store.set('map_style', selectedStyle);
+  });
 		
 		
-        // recall saved mapstyle
-        $selectStyle.val(Store.get('map_style')).trigger("change");
+  // recall saved mapstyle
+  $selectStyle.val(Store.get('map_style')).trigger("change");
 
-    });
+  });
 
 });
 

--- a/static/locales/mapstyle.de.json
+++ b/static/locales/mapstyle.de.json
@@ -1,0 +1,1 @@
+{"roadmap":"Karte","satellite":"Satellite","nolabels_style":"Keine Labels","dark_style":"Dunkel","style_light2":"Licht2","style_pgo":"PokemonGo","dark_style_nl":"Dunkel (Keine Labels)","style_light2_nl":"Licht2 (Keine Labels)","style_pgo_nl":"PokemonGo (Keine Labels)"}

--- a/static/locales/mapstyle.en.json
+++ b/static/locales/mapstyle.en.json
@@ -1,0 +1,1 @@
+{"roadmap":"Roadmap","satellite":"Satellite","nolabels_style":"No Labels","dark_style":"Dark","style_light2":"Light2","style_pgo":"PokemonGo","dark_style_nl":"Dark (No Labels)","style_light2_nl":"Light2 (No Labels)","style_pgo_nl":"PokemonGo (No Labels)"}

--- a/static/locales/mapstyle.fr.json
+++ b/static/locales/mapstyle.fr.json
@@ -1,0 +1,1 @@
+{"roadmap":"Plan","satellite":"Satellite","nolabels_style":"pas d'étiquettes","dark_style":"Foncé","style_light2":"Lumière2","style_pgo":"PokemonGo","dark_style_nl":"Foncé (pas d'étiquettes)","style_light2_nl":"Lumière2 (pas d'étiquettes)","style_pgo_nl":"PokemonGo (pas d'étiquettes)"}

--- a/templates/map.html
+++ b/templates/map.html
@@ -147,6 +147,13 @@
             </label>
           </div>
         </div>
+        <div class="form-control">
+            <hr width="100%">
+            <label for="map-style">
+                <h3>Style</h3>
+                <select id="map-style" style="min-width:100%;"></select>
+            </label>
+        </div>
       </nav>
 	  <nav id="stats">
 		<div class="switch-container">

--- a/templates/map.html
+++ b/templates/map.html
@@ -148,11 +148,11 @@
           </div>
         </div>
         <div class="form-control">
-            <hr width="100%">
-            <label for="map-style">
-                <h3>Map Style</h3>
-                <select id="map-style" style="min-width:100%;"></select>
-            </label>
+          <hr width="100%">
+          <label for="map-style">
+            <h3>Map Style</h3>
+            <select id="map-style" style="min-width:100%;"></select>
+          </label>
         </div>
       </nav>
 	  <nav id="stats">

--- a/templates/map.html
+++ b/templates/map.html
@@ -150,7 +150,7 @@
         <div class="form-control">
             <hr width="100%">
             <label for="map-style">
-                <h3>Style</h3>
+                <h3>Map Style</h3>
                 <select id="map-style" style="min-width:100%;"></select>
             </label>
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

*added dropdown menu to Option menu with map styles in select2 style
*made the dropdown read localstorage so it reads the last used style
*made it compatible with local with .json files
*removed mapstyle selector from map itself

More screen real estate especially on mobile
 also responds to #1674

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
real estate upgrade especially on small screens (see issue: #1674)

## How Has This Been Tested?
after editing loaded page on:
 Microsoft Edge 
 Chrome ( Win10)
 IPhone Safari
 IPhone Chrome

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/14372954/17151608/86f1a2b2-5374-11e6-8f99-fac6634b6c35.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
