### PR TITLE
Fix #2686

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -355,7 +355,7 @@ def bulk_upsert(cls, data):
         log.debug("Inserting items {} to {}".format(i, min(i+step, num_rows)))
         try:
             InsertQuery(cls, rows=data.values()[i:min(i+step, num_rows)]).upsert().execute()
-        except OperationalError as e:
+        except Exception as e:
             log.warning("%s... Retrying", e)
             continue
 


### PR DESCRIPTION
Expand the scope of exception handling to include transactional error cases.

## Description
Sometimes (as per #2686) a transaction lock error can occur. Instead of failing gracefully, the current implementation just crashes and prevents future updates from the scan instance.

## Motivation and Context
Solves a crash.

## How Has This Been Tested?
Tested via running on my local instances for half a day to ensure the crash (which normally happens w/ 6 scanners in 10 min) doesn't happen again.

## Screenshots (if appropriate):

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Include additional exception types to prevent search-thread death on a transaction lock issue.