### PR TITLE
Disable selection on navigation bar.

### DIFF
--- a/static/sass/layout/_header.scss
+++ b/static/sass/layout/_header.scss
@@ -16,6 +16,7 @@
 		top: 0;
 		width: 100%;
 		z-index: _misc(z-index-base) + 1;
+		@include noSelect();
 
 		> h1 {
 			color: _palette(accent2, fg-bold);

--- a/static/sass/libs/_mixins.scss
+++ b/static/sass/libs/_mixins.scss
@@ -28,3 +28,13 @@
 @mixin padding($tb, $lr, $pad: (0,0,0,0)) {
 	padding: ($tb + nth($pad,1)) ($lr + nth($pad,2)) max(0.1em, $tb - _size(element-margin) + nth($pad,3)) ($lr + nth($pad,4));
 }
+
+/// Disable's the ability for the user to select an element.
+@mixin noSelect() {
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	user-select: none;
+}


### PR DESCRIPTION
## Description
I've disabled the ability to select the text in the navigation bar. I also added a mixin to the SCSS incase it needs to be applied elsewhere.

## Motivation and Context
When using it on a touch screen sometimes the text would become selected and this created an annoying experience.

## How Has This Been Tested?
Tested on Google Chrome on Mac OS X.

## Screenshots (if appropriate):
_I can't show the change in a screenshot_

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

