### PR TITLE
Rework "still logged in just fine" message and removed bogus spaces

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -215,8 +215,7 @@ def search(args, i):
         remaining_time = api._auth_provider._ticket_expire/1000 - time.time()
 
         if remaining_time > 60:
-            log.info("Skipping Pokemon Go login process since already logged in \
-                for another {:.2f} seconds".format(remaining_time))
+            log.info("Current login valid for {:.2f} seconds".format(remaining_time))
         else:
             login(args, position)
     else:


### PR DESCRIPTION
```
Skipping Pokemon Go login process since already logged in                 for another 1645.78 seconds
```

:eyetwitch:

## Screenshots (if appropriate):

```
Current login valid for 1797.54 seconds
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)