### PR TITLE
Fix scanned location circles and Pokemon being hidden when not entirely in bounds of map.

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -730,12 +730,12 @@ function showInBoundsMarkers(markers) {
     var marker = markers[key].marker;
     var show = false;
     if (!markers[key].hidden) {
-      if (typeof marker.getPosition === 'function') {
-        if (map.getBounds().contains(marker.getPosition())) {
+      if (typeof marker.getBounds === 'function') {
+        if (map.getBounds().intersects(marker.getBounds())) {
           show = true;
         }
-      } else if (typeof marker.getCenter === 'function') {
-        if (map.getBounds().contains(marker.getCenter())) {
+      } else if (typeof marker.getPosition === 'function') {
+        if (map.getBounds().contains(marker.getPosition())) {
           show = true;
         }
       }


### PR DESCRIPTION
Circles drawn on map representing scanned locations are hidden when their center point moved outside of map bounds. The same goes for Pokemon, though it's not that noticable, because Pokemon are rather small.

## Description
Instead of using `map.getBounds().contains(marker.getCenter())`, use `map.getBounds().intersects(marker.getBounds())` to determine if circle (or Pokemon) should be displayed.

What still needs to be done is change the server so it also sends scanned locations to the client that are up to `r` outside the map bounds, `r` being the scan radius.

## Motivation and Context
Looks really ugly when circles disappear and pop up as you move the map around. Also it is misleading.

## How Has This Been Tested?
Docker, Chrome on Linux

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project. (I think?)