### PR TITLE
Targetted task killing in generated beehive.bat

### DIFF
--- a/Tools/Hex-Beehive-Generator/location_generator.py
+++ b/Tools/Hex-Beehive-Generator/location_generator.py
@@ -30,17 +30,17 @@ rings = args.leaps
 
 if args.windows:
     # ferkin Windows
-    preamble = "taskkill /IM python.exe /F"
+    preamble = "taskkill /IM python.exe /F /FI \"WindowTitle eq PokemonGo-Map-*\""
     pythonpath = "C:\\Python27\\Python.exe"
     branchpath = args.installdir
     executable = args.installdir + "\\runserver.py"
     auth_template = '-a {} -u {} -p "{}"'  # windows people want double-quoted passwords
     actual_worker_params = '{auth} -ns -l "{lat} {lon}" -st {steps}'
-    worker_template = 'Start "{{threadname}}" /d {branchpath} /MIN {pythonpath} {executable} {actual_params}\nping 127.0.0.1 -n 6 > nul\n\n'.format(
+    worker_template = 'Start "PokemonGo-Map-{{threadname}}" /d {branchpath} /MIN {pythonpath} {executable} {actual_params}\nping 127.0.0.1 -n 6 > nul\n\n'.format(
         branchpath=branchpath, pythonpath=pythonpath, executable=executable, actual_params = actual_worker_params
     )
     actual_server_params = '-os -l "{lat} {lon}"'
-    server_template = 'Start "Server" /d {branchpath} /MIN {pythonpath} {executable} {actual_params}\nping 127.0.0.1 -n 6 > nul\n\n'.format(
+    server_template = 'Start "PokemonGo-Map-Server" /d {branchpath} /MIN {pythonpath} {executable} {actual_params}\nping 127.0.0.1 -n 6 > nul\n\n'.format(
         branchpath=branchpath, pythonpath=pythonpath, executable=executable, actual_params = actual_server_params
     )
     if args.output == "../../beehive.sh":


### PR DESCRIPTION
## Description
Add a more specific name to the windows spawned by beehive.bat so that they can be targeted by taskkill

## Motivation and Context
beehive.bat kills every running python process regardless of where it originated.  In my case this was quite annoying because it kept closing down my PokemonGo-Map webhook server.  This attempts to target only processes that were spawned by the batch file itself so that things like running webhook processes don't get killed.

## How Has This Been Tested?
Using git bash on windows I have informally tested that it kills only the python.exe processes spawned by beehive.bat

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

…-Map processes are killed.