### PR TITLE
Adding start/stop functionality from the UI (Take two)

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -28,6 +28,24 @@ class Pogom(Flask):
         self.route("/loc", methods=['GET'])(self.loc)
         self.route("/next_loc", methods=['POST'])(self.next_loc)
         self.route("/mobile", methods=['GET'])(self.list_pokemon)
+        self.route("/search_control", methods=['GET'])(self.search_control_status)
+        self.route("/search_control", methods=['POST'])(self.search_control)
+
+    def set_search_control(self, control):
+        self.control = control
+
+    def search_control_status(self):
+        return jsonify({'status': self.control.status()})
+
+    def search_control(self):
+        action = request.args.get('action','none')
+        if action == 'stop':
+            self.control.stop()
+        elif action == 'start':
+            self.control.start()
+        else:
+            return jsonify({'message':'invalid use of api'})
+        return self.search_control_status()
 
     def fullmap(self):
         args = get_args()

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -252,9 +252,6 @@ def fake_search_loop():
 
 def search_loop_stop():
     global stopping
-    """
-        stops the searching method after curent operation has completed
-    """
     stopping = True
 
 def search_loop_start():

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -71,6 +71,10 @@ def get_args():
     parser.add_argument('-ns', '--no-server',
                         help='No-Server Mode. Starts the searcher but not the Webserver.',
                         action='store_true', default=False)
+    parser.add_argument('-nsc','--no-search-control',
+                        help='Disables search control',
+                        action='store_false', dest='search_control')
+    parser.set_defaults(search_control=True)
     parser.add_argument('-os', '--only-server',
                         help='Server-Only Mode. Starts only the Webserver without the searcher.',
                         action='store_true', default=False)

--- a/runserver.py
+++ b/runserver.py
@@ -25,6 +25,7 @@ from pogom.pgoapi.utilities import get_pos_by_name
 
 def main():
     global args
+    global control
     args = get_args()
 
     if args.debug:

--- a/runserver.py
+++ b/runserver.py
@@ -101,15 +101,18 @@ def main():
     config['REQ_SLEEP'] = args.scan_delay
 
     if args.no_server:
-        # This loop allows for ctrl-c interupts to work since flask won't be holding the program open
-        while True:
-            try:
-                time.sleep(60)
-            except KeyboardInterrupt:
-                control.stop()
-                break
+        wait_for_exit()
     else:
         app.run(threaded=True, use_reloader=False, debug=args.debug, host=args.host, port=args.port)
+
+# This loop allows for ctrl-c interupts to work since flask won't be holding the program open
+def wait_for_exit():
+    while True:
+        try:
+            time.sleep(60)
+        except KeyboardInterrupt:
+            control.stop()
+            break
 
 #method to start (or restart the search thread)
 def start_search_thread():

--- a/runserver.py
+++ b/runserver.py
@@ -105,7 +105,7 @@ def main():
         while True:
             try:
                 time.sleep(60)
-            except:
+            except KeyboardInterrupt:
                 control.stop()
                 break
     else:
@@ -113,7 +113,6 @@ def main():
 
 #method to start (or restart the search thread)
 def start_search_thread():
-    global args
     global search_thread
     search_loop_start()
     if not args.mock:
@@ -130,7 +129,7 @@ def start_search_thread():
     search_thread.start()
 
 #class to handle controlling the search threads
-class SearchControl():
+class SearchControl(object):
     def __init__(self):
         if args.search_control:
             self.state = 'searching'

--- a/runserver.py
+++ b/runserver.py
@@ -16,14 +16,15 @@ from flask_cors import CORS
 from pogom import config
 from pogom.app import Pogom
 from pogom.utils import get_args, insert_mock_data
-
 from pogom.search import search_loop, create_search_threads, fake_search_loop
-from pogom.models import init_database, create_tables, drop_tables, Pokemon, Pokestop, Gym
+from pogom.search import search_loop_stop, search_loop_start
+from pogom.models import init_database, create_tables, Pokemon, Pokestop, Gym
 
 from pogom.pgoapi.utilities import get_pos_by_name
 
 
-if __name__ == '__main__':
+def main():
+    global args
     args = get_args()
 
     if args.debug:
@@ -85,18 +86,12 @@ if __name__ == '__main__':
 
     if not args.only_server:
         # Gather the pokemons!
-        if not args.mock:
-            log.debug('Starting a real search thread and {} search runner thread(s)'.format(args.num_threads))
-            create_search_threads(args.num_threads)
-            search_thread = Thread(target=search_loop, args=(args,))
-        else:
-            log.debug('Starting a fake search thread')
-            insert_mock_data()
-            search_thread = Thread(target=fake_search_loop)
+        start_search_thread()
 
-        search_thread.daemon = True
-        search_thread.name = 'search_thread'
-        search_thread.start()
+    app = Pogom(__name__)
+
+    control = SearchControl()
+    app.set_search_control(control)
 
     if args.cors:
         CORS(app);
@@ -107,7 +102,55 @@ if __name__ == '__main__':
 
     if args.no_server:
         # This loop allows for ctrl-c interupts to work since flask won't be holding the program open
-        while search_thread.is_alive():
-            time.sleep(60)
+        while True:
+            try:
+                time.sleep(60)
+            except:
+                control.stop()
+                break
     else:
         app.run(threaded=True, use_reloader=False, debug=args.debug, host=args.host, port=args.port)
+
+#method to start (or restart the search thread)
+def start_search_thread():
+    global args
+    global search_thread
+    search_loop_start()
+    if not args.mock:
+        log.debug('(re)Starting a real search thread and {} search runner thread(s)'.format(args.num_threads))
+        create_search_threads(args.num_threads)
+        search_thread = Thread(target=search_loop, args=(args,))
+    else:
+        log.debug('(re)Starting a fake search thread')
+        insert_mock_data()
+        search_thread = Thread(target=fake_search_loop)
+
+    search_thread.daemon = True
+    search_thread.name = 'search_thread'
+    search_thread.start()
+
+#class to handle controlling the search threads
+class SearchControl():
+    def __init__(self):
+        if args.search_control:
+            self.state = 'searching'
+        else:
+            self.state = 'disabled'
+        return
+    def start(self):
+        if self.state == 'searching' or self.state == 'disabled':
+            return
+        log.info('Start')
+        start_search_thread()
+        self.state = 'searching'
+    def stop(self):
+        if self.state == 'idle' or self.state == 'disabled':
+            return
+        log.info('Stop')
+        search_loop_stop()
+        self.state = 'idle'
+    def status(self):
+        return self.state
+
+if __name__ == '__main__':
+    main()

--- a/runserver.py
+++ b/runserver.py
@@ -18,7 +18,7 @@ from pogom.app import Pogom
 from pogom.utils import get_args, insert_mock_data
 from pogom.search import search_loop, create_search_threads, fake_search_loop
 from pogom.search import search_loop_stop, search_loop_start
-from pogom.models import init_database, create_tables, Pokemon, Pokestop, Gym
+from pogom.models import init_database, create_tables, drop_tables, Pokemon, Pokestop
 
 from pogom.pgoapi.utilities import get_pos_by_name
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -331,6 +331,21 @@ function createSearchMarker() {
   return marker;
 }
 
+var searchControlURI = 'search_control';
+function searchControl(action) {
+  $.post(searchControlURI + '?action='+encodeURIComponent(action));
+}
+function searchControlStatus(callback) {
+  $.getJSON(searchControlURI).then(function(data){
+    callback(data.status);
+  })
+}
+function updateSearchStatus() {
+  searchControlStatus(function(status) {
+    $('#search-switch').prop('checked', status === 'searching');
+  });
+}
+
 function initSidebar() {
   $('#gyms-switch').prop('checked', Store.get('showGyms'));
   $('#pokemon-switch').prop('checked', Store.get('showPokemon'));
@@ -340,6 +355,10 @@ function initSidebar() {
   $('#geoloc-switch').prop('checked', Store.get('geoLocate'));
   $('#scanned-switch').prop('checked', Store.get('showScanned'));
   $('#sound-switch').prop('checked', Store.get('playSound'));
+
+  updateSearchStatus();
+  setInterval(updateSearchStatus,5000);
+
   var searchBox = new google.maps.places.SearchBox(document.getElementById('next-location'));
   $("#next-location").css("background-color", $('#geoloc-switch').prop('checked') ? "#e0e0e0" : "#ffffff");
 
@@ -1338,5 +1357,9 @@ $(function() {
       this.checked = false;
     else
       Store.set('geoLocate', this.checked);
+  });
+
+  $('#search-switch').change(function() {
+    searchControl(this.checked?'start':'stop');
   });
 });

--- a/templates/map.html
+++ b/templates/map.html
@@ -57,6 +57,16 @@
 	    </label>
 	  </div>
 	</div>
+        <div class="form-control switch-container" style="display:{{search_control}}">
+          <h3>Search</h3>
+          <div class="onoffswitch">
+            <input id="search-switch" type="checkbox" name="search-switch" class="onoffswitch-checkbox" checked/>
+            <label class="onoffswitch-label" for="search-switch">
+              <span class="switch-label" data-on="On" data-off="Off"></span>
+              <span class="switch-handle"></span>
+            </label>
+          </div>
+        </div>
 
 	<hr width="100%" style="display:{{is_fixed}}" >
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
adds the start stop functionality requested/mentioned  in issue #1586

adds the -nsc --no-search-control option to disable this feature (on by default)

(this is the second pr for this feature, because github) previous discussion here #1795

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
allows user to start stop the service without accessing the server
<!--- If it fixes an open issue, please link to the issue here. -->
addresses issue: #1586

## How Has This Been Tested?
click the stop button, service stops cleanly
click the start button, starts again
clicking either button when already started / stopped does nothing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

added new endpoint in app.py to accept status update requests
added methods to control the search thread and to support restarting
once stopped
added option to sidebar for user controls