### PR TITLE
added javascript styling rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+**/vendor/**
+**/dist/**
+**/node_modules/**
+**/server.js
+**/venv/**
+Gruntfile.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": "standard",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": false
+    },
+    "ecmaVersion": 6,
+    "sourceType": "module"
+  },
+  "env": {
+    "browser": true,
+    "jquery": true
+  },
+  "globals": {
+    "google": true,
+    "centerLat": true,
+    "centerLng": true
+  },
+  "rules": {
+    "semi": 0
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,5 @@ install:
   - npm install grunt-cli -g
   - npm install
 script:
-  - npm run lint
   - npm run build
   - nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 env:
   - FLASK=0.11.1
 install:
+  - nvm install 4.4.7
   - pip install Flask==$FLASK
   - pip install -r requirements.txt
   - npm install grunt-cli -g

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,17 +14,8 @@ module.exports = function(grunt) {
         }
       }
     },
-    jshint: {
-      files: ['Gruntfile.js', 'js/*.js', '!js/vendor/**/*.js'],
-      options: {
-        reporter: require('jshint-stylish'),
-        globals: {
-          jQuery: true,
-          console: true,
-          module: true,
-          document: true
-        }
-      }
+    eslint: {
+      src: ['static/js/*.js', '!js/vendor/**/*.js']
     },
     babel: {
       options: {
@@ -96,7 +87,7 @@ module.exports = function(grunt) {
   });
 
   grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-eslint');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-sass');
   grunt.loadNpmTasks('grunt-contrib-copy');
@@ -109,7 +100,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('js-build', ['babel', 'uglify']);
   grunt.registerTask('css-build', ['sass', 'cssmin']);
-  grunt.registerTask('js-lint', ['jshint']);
+  grunt.registerTask('js-lint', ['eslint']);
 
   grunt.registerTask('build', ['clean', 'js-build', 'css-build']);
   grunt.registerTask('lint', ['js-lint']);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "Gruntfile.js",
   "dependencies": {
     "babel-preset-es2015": "^6.9.0",
+    "eslint": "^3.1.1",
+    "eslint-config-standard": "^5.3.5",
+    "eslint-plugin-promise": "^2.0.0",
+    "eslint-plugin-standard": "^2.0.0",
     "grunt": "^0.4.5",
     "grunt-babel": "^6.0.0",
     "grunt-cli": "^1.2.0",
@@ -13,16 +17,15 @@
     "grunt-contrib-connect": "latest",
     "grunt-contrib-copy": "latest",
     "grunt-contrib-cssmin": "latest",
-    "grunt-contrib-jshint": "latest",
     "grunt-contrib-uglify": "latest",
     "grunt-contrib-watch": "latest",
+    "grunt-eslint": "^19.0.0",
     "grunt-html-validation": "^0.1.18",
     "grunt-include-file": "^0.1.1",
     "grunt-legacssy": "latest",
     "grunt-sass": "latest",
     "grunt-unused": "latest",
-    "grunt-usemin": "latest",
-    "jshint-stylish": "latest"
+    "grunt-usemin": "latest"
   },
   "scripts": {
     "postinstall": "./node_modules/.bin/grunt build",


### PR DESCRIPTION
## Description
This adds standard-js linting rules using eslint. It replaces the non-functioning jshint tasks in Grunt with ones from eslint. In addition it disables linting in Travis as there are MANY linting errors and all PRs would fail this test. We will eventually enable linting in Travis once the issues are fixed.

#2058 was made earlier, but it included linting rules as well as changes to adhere to those hinting rules. #2058 will be rolled out in multiple PRs, where this one is the first.

## Motivation and Context
The jshint linting task in Grunt did not do anything as it was referring to non-existing files. It also did not specify a specific styleguide. Related issues #1562 and #1806.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
