### PR TITLE
Fix absolute paths in stats.js.

### DIFF
--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -27,7 +27,7 @@ function countMarkers() {
       var pkmnListString = "<table><thead><tr><th>Icon</th><th>Name</th><th>Count</th><th>%</th></tr></thead><tbody><tr><td></td><td>Total</td><td>" + pkmnTotal + "</td><td></td></tr>";
       for (var i = 0; i < pkmnCount.length; i++) {
         if (pkmnCount[i] != null && pkmnCount[i].Count > 0) {
-          pkmnListString += "<tr><td><img src=\"/static/icons/" + pkmnCount[i].ID + ".png\" /></td><td><a href='http://www.pokemon.com/us/pokedex/" + pkmnCount[i].ID + "' target='_blank' title='View in Pokedex' style=\"color: black;\">" + pkmnCount[i].Name + "</a></td><td>" + pkmnCount[i].Count + "</td><td>" + Math.round(pkmnCount[i].Count * 100 / pkmnTotal * 10) / 10 + "%</td></tr>";
+          pkmnListString += "<tr><td><img src=\"static/icons/" + pkmnCount[i].ID + ".png\" /></td><td><a href='http://www.pokemon.com/us/pokedex/" + pkmnCount[i].ID + "' target='_blank' title='View in Pokedex' style=\"color: black;\">" + pkmnCount[i].Name + "</a></td><td>" + pkmnCount[i].Count + "</td><td>" + Math.round(pkmnCount[i].Count * 100 / pkmnTotal * 10) / 10 + "%</td></tr>";
         }
       }
       pkmnListString += "</tbody></table>";
@@ -48,13 +48,13 @@ function countMarkers() {
       for (var i = 0; i < arenaCount.length; i++) {
         if (arenaCount[i] > 0) {
           if (i == 1) {
-            arenaListString += "<tr><td><img src=\"/static/forts/Mystic.png\" /></td><td>" + "Blue" + "</td><td>" + arenaCount[i] + "</td><td>" + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + "%</td></tr>";
+            arenaListString += "<tr><td><img src=\"static/forts/Mystic.png\" /></td><td>" + "Blue" + "</td><td>" + arenaCount[i] + "</td><td>" + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + "%</td></tr>";
           } else if (i == 2) {
-            arenaListString += "<tr><td><img src=\"/static/forts/Valor.png\" /></td><td>" + "Red" + "</td><td>" + arenaCount[i] + "</td><td>" + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + "%</td></tr>";
+            arenaListString += "<tr><td><img src=\"static/forts/Valor.png\" /></td><td>" + "Red" + "</td><td>" + arenaCount[i] + "</td><td>" + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + "%</td></tr>";
           } else if (i == 3) {
-            arenaListString += "<tr><td><img src=\"/static/forts/Instinct.png\" /></td><td>" + "Yellow" + "</td><td>" + arenaCount[i] + "</td><td>" + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + "%</td></tr>";
+            arenaListString += "<tr><td><img src=\"static/forts/Instinct.png\" /></td><td>" + "Yellow" + "</td><td>" + arenaCount[i] + "</td><td>" + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + "%</td></tr>";
           } else {
-            arenaListString += "<tr><td><img src=\"/static/forts/Uncontested.png\" /></td><td>" + "Clear" + "</td><td>" + arenaCount[i] + "</td><td>" + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + "%</td></tr>";
+            arenaListString += "<tr><td><img src=\"static/forts/Uncontested.png\" /></td><td>" + "Clear" + "</td><td>" + arenaCount[i] + "</td><td>" + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + "%</td></tr>";
           }
         }
       }
@@ -85,9 +85,9 @@ function countMarkers() {
       for (var i = 0; i < pokestopCount.length; i++) {
         if (pokestopCount[i] > 0) {
           if (i == 0) {
-            pokestopListString += "<tr><td><img src=\"/static/forts/Pstop.png\" /></td><td>" + "Not Lured" + "</td><td>" + pokestopCount[i] + "</td><td>" + Math.round(pokestopCount[i] * 100 / pokestopTotal * 10) / 10 + "%</td></tr>";
+            pokestopListString += "<tr><td><img src=\"static/forts/Pstop.png\" /></td><td>" + "Not Lured" + "</td><td>" + pokestopCount[i] + "</td><td>" + Math.round(pokestopCount[i] * 100 / pokestopTotal * 10) / 10 + "%</td></tr>";
           } else if (i == 1) {
-            pokestopListString += "<tr><td><img src=\"/static/forts/PstopLured.png\" /></td><td>" + "Lured" + "</td><td>" + pokestopCount[i] + "</td><td>" + Math.round(pokestopCount[i] * 100 / pokestopTotal * 10) / 10 + "%</td></tr>";
+            pokestopListString += "<tr><td><img src=\"static/forts/PstopLured.png\" /></td><td>" + "Lured" + "</td><td>" + pokestopCount[i] + "</td><td>" + Math.round(pokestopCount[i] * 100 / pokestopTotal * 10) / 10 + "%</td></tr>";
           }
         }
       }


### PR DESCRIPTION
When running this behind a reverse proxy and not in the document root, img tags are broken because they are referencing files from the document root instead of using relative paths.

## Description
Removed the leading slash in src attributes of img tags in `static/js/stats.js`.

## Motivation and Context
Motivation? I'd like it to work on my server, obviously :P
Also most of the ppl running this behind a rev proxy will benefit from this.

## How Has This Been Tested?
Tested on my root server with rev proxy.

## Screenshots (if appropriate):
Before: http://imgur.com/a/QuFUs

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.

