### PR TITLE
Fix broken regex when parsing coordinates with no comma

### DIFF
--- a/pogom/pgoapi/utilities.py
+++ b/pogom/pgoapi/utilities.py
@@ -50,7 +50,7 @@ def to_camel_case(value):
     return "".join(c.next()(x) if x else '_' for x in value.split("_"))
 
 def get_pos_by_name(location_name):
-    prog = re.compile("^(\-?\d+\.\d+)?,\s*(\-?\d+\.\d+?)$")
+    prog = re.compile("^(\-?\d+\.\d+)[,\s]\s*(\-?\d+\.\d+?)$")
     res = prog.match(location_name)
     latitude, longitude, altitude = None, None, None
     if res:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
There is a typo in the regex that detects the location argument as coordinates.
Also fixes misaligned hex beehive generator grid.

## Description
<!--- Describe your changes in detail -->
The question mark makes the preceding expression optional. It is clear it is meant for the comma, not the latitude value.
Since it is not detected as coordinate values, the argument is passed to the GoogleV3 geolocator api, which then returns the value but with a lower precision. This is why the beehive seems misaligned.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using the hex beehive generator, the generated grid is misaligned and there are gaps between the hexes. 
Fixes:
https://github.com/AHAAAAAAA/PokemonGo-Map/issues/2810
https://github.com/AHAAAAAAA/PokemonGo-Map/issues/2796
https://github.com/AHAAAAAAA/PokemonGo-Map/issues/2693
https://github.com/AHAAAAAAA/PokemonGo-Map/issues/2552
https://github.com/AHAAAAAAA/PokemonGo-Map/issues/2621

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran using the coordinates produced by the hex beehive generator and there are no more gaps.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

