### PR TITLE
Fixed display issue with "Notify of Pokemon" select list

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1272,6 +1272,10 @@ $(function() {
     // recall saved lists
     $selectExclude.val(Store.get('remember_select_exclude')).trigger("change");
     $selectNotify.val(Store.get('remember_select_notify')).trigger("change");
+
+    // set the height and overflow to prevent selector from going off the page
+    $select2RenderedLists = $('.select2-selection__rendered');
+    $select2RenderedLists.css('max-height', '165px').css('overflow-y', 'scroll');
   });
 
   // run interval timers to regularly update map and timediffs


### PR DESCRIPTION
## Description
Fixed the "Notify of Pokemon" list that causes the selector menu to go off the screen when too many Pokemon are added into the list.
The changes also affect the css of "Hide Pokemon" as well with no visual or negative changes from what I've seen.

Firefox has a separate issue where the Sound slider/button vanishes off to the bottom of the viewport but that is a preexisting issue.

## Motivation and Context
Added because it becomes annoying to add a lot of pokemon.
Open Issue:
https://github.com/AHAAAAAAA/PokemonGo-Map/issues/2277

## How Has This Been Tested?
Tested on Chrome since that's where I saw the issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.