### PR TITLE
Make header bar responsive.

### DIFF
--- a/static/sass/layout/_header.scss
+++ b/static/sass/layout/_header.scss
@@ -72,10 +72,6 @@
 				margin-left: 0.5em;
 			}
 
-			&:last-child {
-				padding-right: 1.25em;
-			}
-
 			@include breakpoint(small) {
 				padding: 0 0.5em;
 
@@ -83,14 +79,16 @@
 					padding-left: 1em;
 					margin-left: 0.25em;
 				}
-				
+
 				& + a[href="#stats"]:last-child {
 					padding-left: 1em;
 					margin-left: 0.25em;
 				}
+			}
 
-				&:last-child {
-					padding-right: 1em;
+			@include breakpoint(xsmall) {
+				& > .label {
+					display: none;
 				}
 			}
 		}

--- a/templates/map.html
+++ b/templates/map.html
@@ -35,9 +35,9 @@
     <div class="wrapper">
       <!-- Header -->
       <header id="header">
-        <a href="#nav">Options</a>
+        <a href="#nav"><span class="label">Options</span></a>
         <h1><a href="#">Pokémon Go Map</a></h1>
-		<a href="#stats" id="statsToggle" class="statsNav" style="float: right;">Stats</a>
+        <a href="#stats" id="statsToggle" class="statsNav" style="float: right;"><span class="label">Stats</span></a>
       </header>
       <!-- NAV -->
       <nav id="nav">


### PR DESCRIPTION
When viewing on small screens (read: mobile devices) the hides labels

## Description
Uses breapoint(xsmall) for hiding labels.

## Screenshots (if appropriate):
iphone: http://imgur.com/a/qxPVz
ipad: http://imgur.com/a/FNtgF

## Checklist:
- [X] My code follows the code style of this project.

Hides "Options" and "Stats" labels for xsmall screens