### PR TITLE
Add an automatic retry if MySQL "goes away"

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -347,7 +347,6 @@ def parse_map(map_dict, step_location):
 def bulk_upsert(cls, data):
     num_rows = len(data.values())
     i = 0
-    db_retry = 0
     step = 120
 
     flaskDb.connect_db()
@@ -357,16 +356,11 @@ def bulk_upsert(cls, data):
         try:
             InsertQuery(cls, rows=data.values()[i:min(i+step, num_rows)]).upsert().execute()
         except Exception as e:
-            # TODO: make the db_retry threshold configurable
-            if 'MySQL server has gone away' in str(e) and db_retry < 25:
+            if 'MySQL server has gone away' in str(e):
                 init_database()
-                db_retry += 1
-            else:
-                log.warning("%s... Retrying", e)
+            log.warning('%s... Retrying', e)
             continue
 
-        # Successful upsert, reset db_retry
-        db_retry = 0
         i += step
 
     flaskDb.close_db(None)


### PR DESCRIPTION

## Description

Sometimes some of my workers would start failing in the upsert with "MySQL server has gone away". If this happens, they will forever try to upsert, throw the same error, and then continue. This pull request forces them to reinitialize the database connection which gives them a chance of recovering from temporary disconnects.

Working so far for me.

## Motivation and Context

Fixes intermittent database issues, keeps the workers alive

## How Has This Been Tested?

I have tested it with a series of workers which would hit this error about once a day. Since the change they have not died because of MySQL "going away".


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
