### PR TITLE
Add multibuildpack for scalingo support

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,3 @@
+https://github.com/Scalingo/nodejs-buildpack.git
+https://github.com/Scalingo/python-buildpack
+

--- a/scalingo.json
+++ b/scalingo.json
@@ -26,6 +26,10 @@
     "EXTRA_ARGS": {
       "description": "Any extra arguments that you want to pass to runserver.py.",
       "required": false
+    },
+    "BUILDPACK_URL": {
+      "description": "Internal variable to build with node and python",
+      "value": "https://github.com/Scalingo/multi-buildpack.git"
     }
   }
 }


### PR DESCRIPTION
Fix the scalingo deployment for the develop branch.

## Description
This PR add multi builpacks support for scaligno deployment.
It will build the assets with the nodejs buildpacks and then run the python buildpacks to launch the webserver

## Motivation and Context
The current develop code cannot be deployed to scalingo yet.
It's mentionned in #2933 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

