### PR TITLE
Quickly show hidden pokemons

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1262,7 +1262,9 @@ $(function() {
     $selectExclude.on("change", function(e) {
       excludedPokemon = $selectExclude.val().map(Number);
       clearStaleMarkers();
-      Store.set('remember_select_exclude', excludedPokemon);
+      if(!$('#hidden-pokemons-switch').is(':checked')){
+        Store.set('remember_select_exclude', excludedPokemon);  
+      }
     });
     $selectNotify.on("change", function(e) {
       notifiedPokemon = $selectNotify.val().map(Number);
@@ -1367,6 +1369,16 @@ $(function() {
 
   $('#start-at-user-location-switch').change(function() {
     Store.set("startAtUserLocation", this.checked);
+  });
+  
+    $('#hidden-pokemons-switch').change(function() {
+    if(this.checked){
+        $selectExclude.val([]).trigger("change");
+        $('.hide-pokemons').hide();
+    }else{
+        $selectExclude.val(Store.get('remember_select_exclude')).trigger("change");
+        $('.hide-pokemons').show();
+    }
   });
 
 });

--- a/templates/map.html
+++ b/templates/map.html
@@ -142,7 +142,19 @@
           </select>
         </div>
         <hr width="100%">
-        <div class="form-control">
+        <!--control to show hidden pokemons -->
+        <div class="form-control switch-container">
+          <h3>Show Hidden Poke-ns</h3>
+          <div class="onoffswitch">
+            <input id="hidden-pokemons-switch" type="checkbox" name="hidden-pokemons-switch" class="onoffswitch-checkbox">
+            <label class="onoffswitch-label" for="hidden-pokemons-switch">
+            <span class="switch-label" data-on="On" data-off="Off"></span>
+            <span class="switch-handle"></span>
+            </label>
+          </div>
+        </div>
+        <!-- end control-->
+        <div class="form-control hide-pokemons">
           <label for="exclude-pokemon">
             <h3>Hide Pokémon</h3>
             <div style="max-height:165px;overflow-y:auto";>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds functionality to show hidden pokemons if this needed without breaking filters.

## Description
<!--- Describe your changes in detail -->
Sometimes we need to see hidden pokemons on the map, but for this we need delete all filters and then add it again. So i propose add switcher for this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
