### PR TITLE
Fix requirements.txt for Mac OS X System Python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-six==1.10.0
+six>=1.4.1
 Flask==0.11.1
 Jinja2==2.8
 MarkupSafe==0.23


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Mac OS X El Capitan ships with six version 1.4.1 installed to its Python. Users who use their system python (not recommended but done by many) will encounter an error while running `pip install -r requirements.txt` :

`OSError: [Errno 1] Operation not permitted`

This is because Mac OS X does not allow upgrade of included packages.
Changing six minimum version to 1.4.1 fixes this problem, and I did not seem to encounter any compatibility issues while using it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It works

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.

