### PR TITLE
Menu cleanup/rework

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1369,4 +1369,7 @@ $(function() {
     Store.set("startAtUserLocation", this.checked);
   });
 
+  $("#nav-accordion").accordion({
+  });
+
 });

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1184,7 +1184,8 @@ $(function() {
   // setup the stylelist
   $selectStyle.select2({
     placeholder: "Select Style",
-    data: styleList
+    data: styleList,
+    minimumResultsForSearch: Infinity,
   });
 
   // setup the list change behavior
@@ -1370,6 +1371,8 @@ $(function() {
   });
 
   $("#nav-accordion").accordion({
+    active: false,
+    collapsible: true,
   });
 
 });

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -6,6 +6,8 @@
 var $selectExclude;
 var $selectNotify;
 var $selectStyle;
+var $selectIconResolution;
+var $selectIconSize;
 
 var language = document.documentElement.lang == "" ? "en" : document.documentElement.lang;
 var idToPokemon = {};
@@ -1201,6 +1203,33 @@ $(function() {
 
   });
 
+  $selectIconResolution =  $('#pokemon-icons');
+
+  $selectIconResolution.select2({
+    placeholder: "Select Icon Resolution",
+    minimumResultsForSearch: Infinity,
+  });
+
+  $selectIconResolution.on("change", function() {
+    Store.set('pokemonIcons', this.value);
+    redrawPokemon(map_data.pokemons);
+    redrawPokemon(map_data.lure_pokemons);
+  });
+
+
+  $selectIconSize = $('#pokemon-icon-size');
+
+  $selectIconSize.select2({
+    placeholder: "Select Icon Size",
+    minimumResultsForSearch: Infinity,
+  });
+
+  $selectIconSize.on("change", function() {
+    Store.set('iconSizeModifier', this.value);
+    redrawPokemon(map_data.pokemons);
+    redrawPokemon(map_data.lure_pokemons);
+  });
+
 });
 
 $(function() {
@@ -1339,18 +1368,6 @@ $(function() {
 
   $('#sound-switch').change(function() {
     Store.set("playSound", this.checked);
-  });
-
-  $('#pokemon-icons').change(function() {
-    Store.set('pokemonIcons', this.value);
-    redrawPokemon(map_data.pokemons);
-    redrawPokemon(map_data.lure_pokemons);
-  });
-
-  $('#pokemon-icon-size').change(function() {
-    Store.set('iconSizeModifier', this.value);
-    redrawPokemon(map_data.pokemons);
-    redrawPokemon(map_data.lure_pokemons);
   });
 
   $('#geoloc-switch').change(function() {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -8,6 +8,7 @@ var $selectNotify;
 var $selectStyle;
 var $selectIconResolution;
 var $selectIconSize;
+var $selectLuredPokestopsOnly;
 
 var language = document.documentElement.lang == "" ? "en" : document.documentElement.lang;
 var idToPokemon = {};
@@ -1230,6 +1231,18 @@ $(function() {
     redrawPokemon(map_data.lure_pokemons);
   });
 
+  $selectLuredPokestopsOnly = $('#lured-pokestops-only-switch');
+
+  $selectLuredPokestopsOnly.select2({
+    placeholder: "Only Show Lured Pokestops",
+    minimumResultsForSearch: Infinity,
+  });
+
+  $selectLuredPokestopsOnly.on("change", function() {
+    Store.set("showLuredPokestopsOnly", this.value);
+    updateMap();
+  });
+
 });
 
 $(function() {
@@ -1359,11 +1372,6 @@ $(function() {
       wrapper.hide(options);
     }
     return buildSwitchChangeListener(map_data, ["pokestops"], "showPokestops").bind(this)();
-  });
-
-  $('#lured-pokestops-only-switch').change(function() {
-    Store.set("showLuredPokestopsOnly", this.value);
-    updateMap();
   });
 
   $('#sound-switch').change(function() {

--- a/static/sass/components/_form.scss
+++ b/static/sass/components/_form.scss
@@ -144,6 +144,10 @@
   right: 0px;
 }
 
+.select2-container {
+	width: 100% !important;
+}
+
 .select2-container--default .select2-selection--multiple .select2-selection__choice,
 .select2-container--default .select2-results__option--highlighted {
 	background-color: #6b6b6b !important;

--- a/static/sass/components/_form.scss
+++ b/static/sass/components/_form.scss
@@ -148,8 +148,10 @@
 	width: 100% !important;
 }
 
-.select2-container--default .select2-selection--multiple .select2-selection__choice {
-	background-color: #4A80F5 !important;
+.select2-container--default .select2-selection--multiple .select2-selection__choice,
+.select2-container--default .select2-results__option--highlighted {
+	background-color: #6b6b6b !important;
+	color: #e4e4e4;
 }
 
 .select2-container--default.select2-container--focus .select2-selection--multiple {

--- a/static/sass/components/_form.scss
+++ b/static/sass/components/_form.scss
@@ -159,3 +159,7 @@
 .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
 	color: #FFFFFF !important;
 }
+
+.select2-search__field {
+       width: auto !important;
+}

--- a/static/sass/components/_form.scss
+++ b/static/sass/components/_form.scss
@@ -144,10 +144,6 @@
   right: 0px;
 }
 
-.select2-container {
-	width: 100% !important;
-}
-
 .select2-container--default .select2-selection--multiple .select2-selection__choice,
 .select2-container--default .select2-results__option--highlighted {
 	background-color: #6b6b6b !important;

--- a/static/sass/layout/_header.scss
+++ b/static/sass/layout/_header.scss
@@ -43,7 +43,7 @@
 			}
 
 			&[href="#nav"] {
-				@include icon('\f0b0');
+				@include icon('\f013');
 				-webkit-tap-highlight-color: rgba(0,0,0,0);
 
 				&:before {

--- a/static/sass/layout/_nav.scss
+++ b/static/sass/layout/_nav.scss
@@ -105,4 +105,11 @@
 		@include breakpoint(small) {
 			padding: 2.5em 1.75em;
 		}
+
+		.ui-accordion-content {
+			padding-top: 0.5em;
+			padding-right: 0.5em;
+			padding-bottom: 0.5em;
+			padding-left: 0.5em;
+		}
 	}

--- a/static/sass/layout/_nav.scss
+++ b/static/sass/layout/_nav.scss
@@ -112,4 +112,24 @@
 			padding-bottom: 0.5em;
 			padding-left: 0.5em;
 		}
+		.ui-state-active,
+		.onoffswitch-checkbox:checked+.onoffswitch-label {
+			border-color: #3b3b3b;
+			background-color: #3b3b3b;
+		}
+		.onoffswitch-checkbox:checked+.onoffswitch-label:before {
+			border-color: #c0c0c0;
+		}
+		.ui-accordion-header.ui-state-active {
+			color: #d6d6d6;
+		}
+		.ui-corner-all {
+			border-top-left-radius: 0px;
+			border-top-right-radius: 0px;
+			border-bottom-left-radius: 0px;
+			border-bottom-right-radius: 0px;
+		}
+		.ui-state-focus {
+			outline: none;
+		}
 	}

--- a/static/sass/layout/_nav.scss
+++ b/static/sass/layout/_nav.scss
@@ -59,9 +59,9 @@
 			}
 		}
 
-		.form-control > select {
+		.form-control > select,
+		.form-control > span {
 			float: right;
-			font-size: 18px;
 		}
 
 		.close {

--- a/static/sass/layout/_nav.scss
+++ b/static/sass/layout/_nav.scss
@@ -10,7 +10,6 @@
 		height: 100%;
 		max-width: 80%;
 		overflow-y: auto;
-		padding: 1.5em 1.5em 4em 1.5em;
 		position: fixed;
 		top: 3.50em;
 		left: 0;

--- a/templates/map.html
+++ b/templates/map.html
@@ -45,11 +45,9 @@
         <div id="nav-accordion">
           <h3>Style Settings</h3>
           <div>
-            <div class="form-control">
-              <label for="map-style">
-                <h3>Map Style</h3>
-                <select id="map-style" style="min-width:100%;"></select>
-              </label>
+            <div class="form-control switch-container">
+              <h3>Map Style</h3>
+              <select id="map-style"></select>
             </div>
             <div class="form-control switch-container">
               <h3>Icons</h3>

--- a/templates/map.html
+++ b/templates/map.html
@@ -43,7 +43,29 @@
       <!-- NAV -->
       <nav id="nav">
         <div id="nav-accordion">
-          <h3>Location/Map Settings</h3>
+          <h3>Style Settings</h3>
+          <div>
+            <div class="form-control">
+              <label for="map-style">
+                <h3>Map Style</h3>
+                <select id="map-style" style="min-width:100%;"></select>
+              </label>
+            </div>
+            <div class="form-control switch-container">
+              <h3>Icons</h3>
+              <select name="pokemon-icons" id="pokemon-icons"></select>
+            </div>
+            <div class="form-control switch-container">
+              <h3>Icon Size</h3>
+              <select name="pokemon-icon-size" id="pokemon-icon-size">
+                <option value="-8">Small</option>
+                <option value="0">Normal</option>
+                <option value="10">Large</option>
+                <option value="20">X-Large</option>
+              </select>
+            </div>
+          </div>
+          <h3>Location Settings</h3>
           <div>
             <div class="form-control switch-container" style="display:{{is_fixed}}" >
               <label for="next-location">
@@ -80,12 +102,6 @@
                 <span class="switch-handle"></span>
                 </label>
               </div>
-            </div>
-            <div class="form-control">
-              <label for="map-style">
-                <h3>Map Style</h3>
-                <select id="map-style" style="min-width:100%;"></select>
-              </label>
             </div>
           </div>
 
@@ -136,19 +152,6 @@
                 <span class="switch-handle"></span>
                 </label>
               </div>
-            </div>
-            <div class="form-control switch-container">
-              <h3>Icons</h3>
-              <select name="pokemon-icons" id="pokemon-icons"></select>
-            </div>
-            <div class="form-control switch-container">
-              <h3>Icon Size</h3>
-              <select name="pokemon-icon-size" id="pokemon-icon-size">
-                <option value="-8">Small</option>
-                <option value="0">Normal</option>
-                <option value="10">Large</option>
-                <option value="20">X-Large</option>
-              </select>
             </div>
             <div class="form-control">
               <label for="exclude-pokemon">

--- a/templates/map.html
+++ b/templates/map.html
@@ -43,66 +43,6 @@
       <!-- NAV -->
       <nav id="nav">
         <div id="nav-accordion">
-          <h3>Style Settings</h3>
-          <div>
-            <div class="form-control switch-container">
-              <h3>Map Style</h3>
-              <select id="map-style"></select>
-            </div>
-            <div class="form-control switch-container">
-              <h3>Icons</h3>
-              <select name="pokemon-icons" id="pokemon-icons"></select>
-            </div>
-            <div class="form-control switch-container">
-              <h3>Icon Size</h3>
-              <select name="pokemon-icon-size" id="pokemon-icon-size">
-                <option value="-8">Small</option>
-                <option value="0">Normal</option>
-                <option value="10">Large</option>
-                <option value="20">X-Large</option>
-              </select>
-            </div>
-          </div>
-          <h3>Location Settings</h3>
-          <div>
-            <div class="form-control switch-container" style="display:{{is_fixed}}" >
-              <label for="next-location">
-              <h3>Change scan location</h3>
-              <input id="next-location" type="text" name="next-location" placeholder="Change your location">
-              </label>
-            </div>
-            <div class="form-control switch-container" style="display:{{is_fixed}}" >
-              <h3>Scan follows location</h3>
-              <div class="onoffswitch">
-                <input id="geoloc-switch" type="checkbox" name="geoloc-switch" class="onoffswitch-checkbox" checked/>
-                <label class="onoffswitch-label" for="geoloc-switch">
-                <span class="switch-label" data-on="On" data-off="Off"></span>
-                <span class="switch-handle"></span>
-                </label>
-              </div>
-            </div>
-            <div class="form-control switch-container" >
-              <h3>Start at user's location</h3>
-              <div class="onoffswitch">
-                <input id="start-at-user-location-switch" type="checkbox" name="start-at-user-location-switch" class="onoffswitch-checkbox" checked/>
-                <label class="onoffswitch-label" for="start-at-user-location-switch">
-                <span class="switch-label" data-on="On" data-off="Off"></span>
-                <span class="switch-handle"></span>
-                </label>
-              </div>
-            </div>
-            <div class="form-control switch-container" style="display:{{search_control}}">
-              <h3>Search</h3>
-              <div class="onoffswitch">
-                <input id="search-switch" type="checkbox" name="search-switch" class="onoffswitch-checkbox" checked/>
-                <label class="onoffswitch-label" for="search-switch">
-                <span class="switch-label" data-on="On" data-off="Off"></span>
-                <span class="switch-handle"></span>
-                </label>
-              </div>
-            </div>
-          </div>
-
           <h3>Marker Settings</h3>
           <div>
             <div class="form-control switch-container">
@@ -161,6 +101,46 @@
             </div>
           </div>
 
+          <h3>Location Settings</h3>
+          <div>
+            <div class="form-control switch-container" style="display:{{is_fixed}}" >
+              <label for="next-location">
+              <h3>Change scan location</h3>
+              <input id="next-location" type="text" name="next-location" placeholder="Change your location">
+              </label>
+            </div>
+            <div class="form-control switch-container" style="display:{{is_fixed}}" >
+              <h3>Scan follows location</h3>
+              <div class="onoffswitch">
+                <input id="geoloc-switch" type="checkbox" name="geoloc-switch" class="onoffswitch-checkbox" checked/>
+                <label class="onoffswitch-label" for="geoloc-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+            <div class="form-control switch-container" >
+              <h3>Start at user's location</h3>
+              <div class="onoffswitch">
+                <input id="start-at-user-location-switch" type="checkbox" name="start-at-user-location-switch" class="onoffswitch-checkbox" checked/>
+                <label class="onoffswitch-label" for="start-at-user-location-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+            <div class="form-control switch-container" style="display:{{search_control}}">
+              <h3>Search</h3>
+              <div class="onoffswitch">
+                <input id="search-switch" type="checkbox" name="search-switch" class="onoffswitch-checkbox" checked/>
+                <label class="onoffswitch-label" for="search-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+          </div>
+
           <h3>Notification Settings</h3>
           <div>
             <div class="form-control">
@@ -180,6 +160,27 @@
                 <span class="switch-handle"></span>
                 </label>
               </div>
+            </div>
+          </div>
+
+          <h3>Style Settings</h3>
+          <div>
+            <div class="form-control switch-container">
+              <h3>Map Style</h3>
+              <select id="map-style"></select>
+            </div>
+            <div class="form-control switch-container">
+              <h3>Icons</h3>
+              <select name="pokemon-icons" id="pokemon-icons"></select>
+            </div>
+            <div class="form-control switch-container">
+              <h3>Icon Size</h3>
+              <select name="pokemon-icon-size" id="pokemon-icon-size">
+                <option value="-8">Small</option>
+                <option value="0">Normal</option>
+                <option value="10">Large</option>
+                <option value="20">X-Large</option>
+              </select>
             </div>
           </div>
         </div>

--- a/templates/map.html
+++ b/templates/map.html
@@ -29,6 +29,7 @@
     <!-- retina iPhone 6 iOS 7 -->
     <link rel="apple-touch-icon" href="static/appicons/180x180.png" sizes="180x180">
     <link rel="stylesheet" href="static/dist/css/app.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.css">
     <script src="static/js/vendor/modernizr.custom.js"></script>
   </head>
   <body id="top">
@@ -41,162 +42,169 @@
       </header>
       <!-- NAV -->
       <nav id="nav">
-        <div class="form-control switch-container" style="display:{{is_fixed}}" >
-          <label for="next-location">
-            <h3>Change scan location</h3>
-            <input id="next-location" type="text" name="next-location" placeholder="Change your location">
-          </label>
-        </div>
-        <div class="form-control switch-container" style="display:{{is_fixed}}" >
-          <h3>Scan follows location</h3>
-	  <div class="onoffswitch">
-	    <input id="geoloc-switch" type="checkbox" name="geoloc-switch" class="onoffswitch-checkbox" checked/>
-	    <label class="onoffswitch-label" for="geoloc-switch">
-	    <span class="switch-label" data-on="On" data-off="Off"></span>
-	    <span class="switch-handle"></span>
-	    </label>
-	  </div>
-	</div>
-        <div class="form-control switch-container" >
-          <h3>Start at user's location</h3>
-          <div class="onoffswitch">
-            <input id="start-at-user-location-switch" type="checkbox" name="start-at-user-location-switch" class="onoffswitch-checkbox" checked/>
-            <label class="onoffswitch-label" for="start-at-user-location-switch">
-            <span class="switch-label" data-on="On" data-off="Off"></span>
-            <span class="switch-handle"></span>
-            </label>
-          </div>
-        </div>
-
-        <div class="form-control switch-container" style="display:{{search_control}}">
-          <h3>Search</h3>
-          <div class="onoffswitch">
-            <input id="search-switch" type="checkbox" name="search-switch" class="onoffswitch-checkbox" checked/>
-            <label class="onoffswitch-label" for="search-switch">
-              <span class="switch-label" data-on="On" data-off="Off"></span>
-              <span class="switch-handle"></span>
-            </label>
-          </div>
-        </div>
-
-	<hr width="100%" style="display:{{is_fixed}}" >
-
-        <p>Select markers to be visible on map.</p>
-        <div class="form-control switch-container">
-          <h3>Pokémon</h3>
-          <div class="onoffswitch">
-            <input id="pokemon-switch" type="checkbox" name="pokemon-switch" class="onoffswitch-checkbox" checked>
-            <label class="onoffswitch-label" for="pokemon-switch">
-            <span class="switch-label" data-on="On" data-off="Off"></span>
-            <span class="switch-handle"></span>
-            </label>
-          </div>
-        </div>
-        <div class="form-control switch-container">
-          <h3>Gyms</h3>
-          <div class="onoffswitch">
-            <input id="gyms-switch" type="checkbox" name="gyms-switch" class="onoffswitch-checkbox" checked>
-            <label class="onoffswitch-label" for="gyms-switch">
-            <span class="switch-label" data-on="On" data-off="Off"></span>
-            <span class="switch-handle"></span>
-            </label>
-          </div>
-        </div>
-        <div class="form-control switch-container">
-          <h3>Pokéstops</h3>
-          <div class="onoffswitch">
-            <input id="pokestops-switch" type="checkbox" name="pokestops-switch" class="onoffswitch-checkbox" checked>
-            <label class="onoffswitch-label" for="pokestops-switch">
-            <span class="switch-label" data-on="On" data-off="Off"></span>
-            <span class="switch-handle"></span>
-            </label>
-          </div>
-        </div>
-        <div class="form-control switch-container" id="lured-pokestops-only-wrapper" style="display:none">
-          <select name="lured-pokestops-only-switch" id="lured-pokestops-only-switch">
-            <option value="0">All</option>
-            <option value="1">Only Lured</option>
-          </select>
-        </div>
-        <div class="form-control switch-container">
-          <h3>Scanned Locations</h3>
-          <div class="onoffswitch">
-            <input id="scanned-switch" type="checkbox" name="scanned-switch" class="onoffswitch-checkbox">
-            <label class="onoffswitch-label" for="scanned-switch">
-            <span class="switch-label" data-on="On" data-off="Off"></span>
-            <span class="switch-handle"></span>
-            </label>
-          </div>
-        </div>
-        <div class="form-control switch-container">
-          <h3>Icons</h3>
-          <select name="pokemon-icons" id="pokemon-icons"></select>
-        </div>
-        <div class="form-control switch-container">
-          <h3>Icon Size</h3>
-          <select name="pokemon-icon-size" id="pokemon-icon-size">
-            <option value="-8">Small</option>
-            <option value="0">Normal</option>
-            <option value="10">Large</option>
-            <option value="20">X-Large</option>
-          </select>
-        </div>
-        <hr width="100%">
-        <div class="form-control">
-          <label for="exclude-pokemon">
-            <h3>Hide Pokémon</h3>
-            <div style="max-height:165px;overflow-y:auto";>
-              <select id="exclude-pokemon" multiple="multiple"></select>
+        <div id="nav-accordion">
+          <h3>Location/Map Settings</h3>
+          <div>
+            <div class="form-control switch-container" style="display:{{is_fixed}}" >
+              <label for="next-location">
+              <h3>Change scan location</h3>
+              <input id="next-location" type="text" name="next-location" placeholder="Change your location">
+              </label>
             </div>
-          </label>
-        </div>
-        <div class="form-control">
-          <label for="notify-pokemon">
-            <h3>Notify of Pokémon</h3>
-            <div style="max-height:165px;overflow-y:auto";>
-              <select id="notify-pokemon" multiple="multiple"></select>
+            <div class="form-control switch-container" style="display:{{is_fixed}}" >
+              <h3>Scan follows location</h3>
+              <div class="onoffswitch">
+                <input id="geoloc-switch" type="checkbox" name="geoloc-switch" class="onoffswitch-checkbox" checked/>
+                <label class="onoffswitch-label" for="geoloc-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
             </div>
-          </label>
-        </div>
-        <div class="form-control switch-container">
-          <h3>Notify with sound</h3>
-          <div class="onoffswitch">
-            <input id="sound-switch" type="checkbox" name="sound-switch" class="onoffswitch-checkbox" checked>
-            <label class="onoffswitch-label" for="sound-switch">
-            <span class="switch-label" data-on="On" data-off="Off"></span>
-            <span class="switch-handle"></span>
-            </label>
+            <div class="form-control switch-container" >
+              <h3>Start at user's location</h3>
+              <div class="onoffswitch">
+                <input id="start-at-user-location-switch" type="checkbox" name="start-at-user-location-switch" class="onoffswitch-checkbox" checked/>
+                <label class="onoffswitch-label" for="start-at-user-location-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+            <div class="form-control switch-container" style="display:{{search_control}}">
+              <h3>Search</h3>
+              <div class="onoffswitch">
+                <input id="search-switch" type="checkbox" name="search-switch" class="onoffswitch-checkbox" checked/>
+                <label class="onoffswitch-label" for="search-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+            <div class="form-control">
+              <label for="map-style">
+                <h3>Map Style</h3>
+                <select id="map-style" style="min-width:100%;"></select>
+              </label>
+            </div>
           </div>
-        </div>
-        <div class="form-control">
-          <hr width="100%">
-          <label for="map-style">
-            <h3>Map Style</h3>
-            <select id="map-style" style="min-width:100%;"></select>
-          </label>
+
+          <h3>Marker Settings</h3>
+          <div>
+            <div class="form-control switch-container">
+              <h3>Pokémon</h3>
+              <div class="onoffswitch">
+                <input id="pokemon-switch" type="checkbox" name="pokemon-switch" class="onoffswitch-checkbox" checked>
+                <label class="onoffswitch-label" for="pokemon-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+            <div class="form-control switch-container">
+              <h3>Gyms</h3>
+              <div class="onoffswitch">
+                <input id="gyms-switch" type="checkbox" name="gyms-switch" class="onoffswitch-checkbox" checked>
+                <label class="onoffswitch-label" for="gyms-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+            <div class="form-control switch-container">
+              <h3>Pokéstops</h3>
+              <div class="onoffswitch">
+                <input id="pokestops-switch" type="checkbox" name="pokestops-switch" class="onoffswitch-checkbox" checked>
+                <label class="onoffswitch-label" for="pokestops-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+            <div class="form-control switch-container" id="lured-pokestops-only-wrapper" style="display:none">
+              <select name="lured-pokestops-only-switch" id="lured-pokestops-only-switch">
+                <option value="0">All</option>
+                <option value="1">Only Lured</option>
+              </select>
+            </div>
+            <div class="form-control switch-container">
+              <h3>Scanned Locations</h3>
+              <div class="onoffswitch">
+                <input id="scanned-switch" type="checkbox" name="scanned-switch" class="onoffswitch-checkbox">
+                <label class="onoffswitch-label" for="scanned-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+            <div class="form-control switch-container">
+              <h3>Icons</h3>
+              <select name="pokemon-icons" id="pokemon-icons"></select>
+            </div>
+            <div class="form-control switch-container">
+              <h3>Icon Size</h3>
+              <select name="pokemon-icon-size" id="pokemon-icon-size">
+                <option value="-8">Small</option>
+                <option value="0">Normal</option>
+                <option value="10">Large</option>
+                <option value="20">X-Large</option>
+              </select>
+            </div>
+            <div class="form-control">
+              <label for="exclude-pokemon">
+              <h3>Hide Pokémon</h3>
+              <div style="max-height:165px;overflow-y:auto";>
+                <select id="exclude-pokemon" multiple="multiple"></select>
+              </div>
+              </label>
+            </div>
+          </div>
+
+          <h3>Notification Settings</h3>
+          <div>
+            <div class="form-control">
+              <label for="notify-pokemon">
+                <h3>Notify of Pokémon</h3>
+                <div style="max-height:165px;overflow-y:auto";>
+                  <select id="notify-pokemon" multiple="multiple"></select>
+                </div>
+              </label>
+            </div>
+            <div class="form-control switch-container">
+              <h3>Notify with sound</h3>
+              <div class="onoffswitch">
+                <input id="sound-switch" type="checkbox" name="sound-switch" class="onoffswitch-checkbox" checked>
+                <label class="onoffswitch-label" for="sound-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+          </div>
         </div>
       </nav>
-	  <nav id="stats">
-		<div class="switch-container">
-		  <div class="switch-container">
-			<center><h1 id="stats-pkmn-label">Loading...</h1></center>
-		  </div>
-		  <div id="pokemonList" style="color: black;"></div>
-		  <div class="switch-container">
-			<center><h1 id="stats-gym-label"></h1></center>
-		  </div>
-		  <div id="arenaList" style="color: black;"></div>
-		  <div class="switch-container">
-			<center><h1 id="stats-pkstop-label"></h1></center>
-		  </div>
-		  <div id="pokestopList" style="color: black;"></div>
-		</div>
-	  </nav>
+      <nav id="stats">
+        <div class="switch-container">
+          <div class="switch-container">
+            <center><h1 id="stats-pkmn-label">Loading...</h1></center>
+          </div>
+          <div id="pokemonList" style="color: black;"></div>
+          <div class="switch-container">
+            <center><h1 id="stats-gym-label"></h1></center>
+          </div>
+          <div id="arenaList" style="color: black;"></div>
+          <div class="switch-container">
+            <center><h1 id="stats-pkstop-label"></h1></center>
+          </div>
+          <div id="pokestopList" style="color: black;"></div>
+        </div>
+      </nav>
       <div id="map"></div>
     </div>
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.9.1/polyfill.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/skel/3.0.1/skel.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js"></script>
     <script src="static/dist/js/app.min.js"></script>


### PR DESCRIPTION
* Change options icon to a gear. We're doing more than filtering now
* Add jquery-ui, we'll use the [accordion widget](https://jqueryui.com/accordion/) to clean up our menu
* Clean up tabs in map.html and wrap all the options in divs and h3s for jquery-ui's accordion
* Remove search box in map style dropdown
* Move map dropdown up to Location/Map settings
* Fix minor CSS bug in search boxes where it was cutting off the placeholder text

https://github.com/AHAAAAAAA/PokemonGo-Map/issues/3181