### PR TITLE
Hide "Start at user's location" when -fl is on

### DIFF
--- a/templates/map.html
+++ b/templates/map.html
@@ -57,7 +57,7 @@
 	    </label>
 	  </div>
 	</div>
-        <div class="form-control switch-container" >
+        <div class="form-control switch-container" style="display:{{is_fixed}}">
           <h3>Start at user's location</h3>
           <div class="onoffswitch">
             <input id="start-at-user-location-switch" type="checkbox" name="start-at-user-location-switch" class="onoffswitch-checkbox" checked/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Hide "Start at user's location" when -fl is on.
## Description
<!--- Describe your changes in detail -->
Whoever created "Start at user's location" forgot to hide it when the fixed-location (-fl) flag is on.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It works

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
