### PR TITLE
command line for host have changed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ EXPOSE 5000
 WORKDIR /usr/src/app
 
 # Set Entrypoint with hard-coded options
-ENTRYPOINT ["python", "./runserver.py", "--host", "0.0.0.0"]
+ENTRYPOINT ["python", "./runserver.py", "-H", "0.0.0.0"]
 
 # Set default options when container is run without any command line arguments
 CMD ["-h"]


### PR DESCRIPTION
Since the cmd line for host have changed from --host to -H, this has not been updated. 

## Description
Change entrypoint to use -H
Update Dockerfile with new host param key