### PR TITLE
Correct a translation error

### DIFF
--- a/static/locales/zh_cn.json
+++ b/static/locales/zh_cn.json
@@ -111,7 +111,7 @@
   "Cofagrigus": "死神棺",
   "Combee": "三蜜蜂",
   "Combusken": "力壮鸡",
-  "Common": "的常见",
+  "Common": "常见",
   "Conkeldurr": "修缮老头",
   "Corphish": "龙虾小兵",
   "Corsola": "太阳珊瑚",


### PR DESCRIPTION
## Description

The Chinese translation of "Common" should be "常见" instead of "的常见."
"的" is the adjective suffix in Chinese, but usually be ignored when the adjective appears alone without a noun following it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
