### PR TITLE
Added Stop Signal configuration to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ WORKDIR /usr/src/app
 # Set Entrypoint with hard-coded options
 ENTRYPOINT ["python", "./runserver.py", "--host", "0.0.0.0"]
 
+# Define how python should be stopped (Docker sends a SIGTERM by default and the server doesn't answer it)
+STOPSIGNAL SIGINT
+
 # Set default options when container is run without any command line arguments
 CMD ["-h"]
 


### PR DESCRIPTION
I noticed a long delay when using `docker stop`.
Read the documentation about this [and this blog post in particular](https://www.ctl.io/developers/blog/post/gracefully-stopping-docker-containers/) to discover Docker sends a `SIGTERM` first and then a deadly `SIGKILL` if the app doesn't respond to `SIGTERM`. Python by default only takes `SIGINT` to stop (the equivalent of a `Ctrl+C`).

## Description
Added a `STOPSIGNAL` configuration to the original `Dockerfile` so the `docker stop` command will send the right signal right away

## Motivation and Context
The `docker stop` command will respond with no delay and the server will stop gracefully

## How Has This Been Tested?
Tested by myself with the command `docker stop` :).

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

