### PR TITLE
Change default of scan_delay

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -45,7 +45,7 @@ def get_args():
                         default=12)
     parser.add_argument('-sd', '--scan-delay',
                         help='Time delay between requests in scan threads',
-                        type=float, default=5)
+                        type=float, default=10)
     parser.add_argument('-ld', '--login-delay',
                         help='Time delay between each login attempt',
                         type=float, default=5)


### PR DESCRIPTION
Since now Niantic have a minimum_scanner_refresh returning 10 seconds for some cases, i think is better to raise the default value of this