### PR TITLE
Update current location on next_loc

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -135,6 +135,7 @@ class Pogom(Flask):
             return 'bad parameters', 400
         else:
             self.location_queue.put((lat, lon, 0))
+            self.set_current_location((lat, lon, 0))
             log.info('Changing next location: %s,%s', lat, lon)
             return 'ok'
 


### PR DESCRIPTION
## Description
When next_loc is called the current location will be updated with the next location.

## Motivation and Context
Previous to this change, if you changed the location of the scanner then refreshed your browser, the map current location marker would go back to the original location entered at the script's startup.

With this change, changes to the current location marker will persist through browser refreshes.

## How Has This Been Tested?
Tested under normal use cases.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.