### PR TITLE
Make location marker always be on top

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -314,7 +314,8 @@ function createSearchMarker() {
     },
     map: map,
     animation: google.maps.Animation.DROP,
-    draggable: true
+    draggable: true,
+    zIndex: google.maps.Marker.MAX_ZINDEX + 1
   });
 
   var oldLocation = null;


### PR DESCRIPTION
## Description
Make location marker always be on top

## Motivation and Context
Dragging the location marker is now easier as it won't be blocked by other markers.

## How Has This Been Tested?
Tested on Chromium on Arch Linux

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

