### PR TITLE
Show account in log when login fails

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -259,7 +259,7 @@ def check_login(args, account, api, position):
             raise TooManyLoginAttempts('Exceeded login attempts')
         else:
             i += 1
-            log.error('Failed to login to Pokemon Go. Trying again in %g seconds', args.login_delay)
+            log.error('Failed to login to Pokemon Go with account %s. Trying again in %g seconds', account['username'], args.login_delay)
             time.sleep(args.login_delay)
 
     log.debug('Login for account %s successful', account['username'])


### PR DESCRIPTION
Small change that show account name in log when login fails

## Description
Small change to log message

## Motivation and Context
Makes it easy to find which account is broken out of a long list of accounts

## How Has This Been Tested?
Tested on my machine

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

