### PR TITLE
Set a HTTPS server for GPS Location

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -65,10 +65,11 @@ class Pogom(Flask):
         args = get_args()
         fixed_display = "none" if args.fixed_location else "inline"
         search_display = "inline" if args.search_control else "none"
-
+        geo_server = args.geo_server if args.geo_server else ""
         return render_template('map.html',
                                lat=self.current_location[0],
                                lng=self.current_location[1],
+                               geo_server=geo_server,
                                gmaps_key=config['GMAPS_KEY'],
                                lang=config['LOCALE'],
                                is_fixed=fixed_display,

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -66,6 +66,7 @@ class Pogom(Flask):
         fixed_display = "none" if args.fixed_location else "inline"
         search_display = "inline" if args.search_control else "none"
         geo_server = args.geo_server if args.geo_server else ""
+
         return render_template('map.html',
                                lat=self.current_location[0],
                                lng=self.current_location[1],

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -52,6 +52,8 @@ def get_args():
     parser.add_argument('-dc', '--display-in-console',
                         help='Display Found Pokemon in Console',
                         action='store_true', default=False)
+    parser.add_argument('-gs', '--geo-server',
+                        help='Set external HTTPS Geolocation Webserver.')
     parser.add_argument('-H', '--host', help='Set web server listening host',
                         default='127.0.0.1')
     parser.add_argument('-P', '--port', type=int,

--- a/templates/map.html
+++ b/templates/map.html
@@ -213,6 +213,7 @@
     <script src="static/dist/js/app.min.js"></script>
     <script src="static/js/vendor/classie.js"></script>
     <script>
+      var geo_server = "{{geo_server}}";
       var center_lat = {{lat}};
       var center_lng = {{lng}};
     </script>


### PR DESCRIPTION
As allot of servers are being disabled I'm using a raspberry pi server with no SSL certificate, and [google chrome has blocked geolocation for non HTTPS locations](https://developers.google.com/web/updates/2016/04/geolocation-on-secure-contexts-only), so I have [made bypass trough a heroku HTTPS domain](https://github.com/jlvcm/GeolocationSSLBypass) to get the my location anyway. I understand that this may not be merged but i think it may be useful for some

**WARNING: THIS IS BYPASSING A SECURITY FEATURE**

## Description
I've added a new option `-gs` `--geo-server` where you can set a https server to return the gps location, i've tried to make this using an iframe but it's blocked by chrome, the only way was to use a popup, and as so "Scan follows location" is not possible as it would spam popups, but it's possible to toggle the "Start at user's location" 

## Motivation and Context
To avoid needing to configure and/or buy a HTTPS certificate,  and teach my friends how to install certs/proxys/...  (but this is a security risk)

"fixes" some closed issues:
[#2385](https://github.com/AHAAAAAAA/PokemonGo-Map/issues/2385)
[#1812](https://github.com/AHAAAAAAA/PokemonGo-Map/issues/1812)

## How Has This Been Tested?
I have tested it by running a heroku server (  "https://geolocationsslbypass.herokuapp.com" ) and running the pokemon map on a non HTTPS server using `-gs "https://geolocationsslbypass.herokuapp.com"`.

the code to the server is there: https://github.com/jlvcm/GeolocationSSLBypass and you can deploy your own using the "deploy to heroku" button

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
