### PR TITLE
Add Deployment Instructions for IBM's PaaS Bluemix (pt. 2)

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,9 @@
+.git
+.github
+.gitignore
+credentials.example.json
+node_modules
+Easy\ Setup
+Gruntfile.js
+package.json
+pogom.db

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Features:
 * DB storage (sqlite or mysql) of all found pokemon
 * Incredibly fast, efficient searching algorithm (compared to everything else available)
 
-[![Deploy](https://raw.githubusercontent.com/sych74/PokemonGo-Map-in-Cloud/master/images/deploy-to-jelastic.png)](https://jelastic.com/install-application/?manifest=https://raw.githubusercontent.com/sych74/PokemonGo-Map-in-Cloud/master/manifest.jps) [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://github.com/AHAAAAAAA/PokemonGo-Map/wiki/Heroku-Deployment) 
+[![Deploy](https://raw.githubusercontent.com/sych74/PokemonGo-Map-in-Cloud/master/images/deploy-to-jelastic.png)](https://jelastic.com/install-application/?manifest=https://raw.githubusercontent.com/sych74/PokemonGo-Map-in-Cloud/master/manifest.jps) [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://github.com/AHAAAAAAA/PokemonGo-Map/wiki/Heroku-Deployment)
+[![Deploy to Bluemix](https://bluemix.net/deploy/button.png)](https://jonaharagon.github.io/PoGoMapWiki/#!bluemix.md)
 
 #[Twitter] (https://twitter.com/PoGoMDev), [Website] (https://jz6.github.io/PoGoMap/)#
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Features:
 * DB storage (sqlite or mysql) of all found pokemon
 * Incredibly fast, efficient searching algorithm (compared to everything else available)
 
-[![Deploy](https://raw.githubusercontent.com/sych74/PokemonGo-Map-in-Cloud/master/images/deploy-to-jelastic.png)](https://jelastic.com/install-application/?manifest=https://raw.githubusercontent.com/sych74/PokemonGo-Map-in-Cloud/master/manifest.jps) [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://github.com/AHAAAAAAA/PokemonGo-Map/wiki/Heroku-Deployment)
-[![Deploy to Bluemix](https://bluemix.net/deploy/button.png)](https://jonaharagon.github.io/PoGoMapWiki/#!bluemix.md)
+[![Deploy](https://raw.githubusercontent.com/sych74/PokemonGo-Map-in-Cloud/master/images/deploy-to-jelastic.png)](https://jelastic.com/install-application/?manifest=https://raw.githubusercontent.com/sych74/PokemonGo-Map-in-Cloud/master/manifest.jps) [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://github.com/AHAAAAAAA/PokemonGo-Map/wiki/Heroku-Deployment) [![Deploy to Bluemix](https://bluemix.net/deploy/button.png)](https://jonaharagon.github.io/PoGoMapWiki/#!bluemix.md)
 
 #[Twitter] (https://twitter.com/PoGoMDev), [Website] (https://jz6.github.io/PoGoMap/)#
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,19 +1,17 @@
-# Edit the env and host fields below. Insert your own values.
-# For host you should choose something unique
-# like: "username-pokemongo-map" (without the quotes)
-# auth service can either be "google" or "PTC"
+# Edit env fields below
 ---
 applications:
-- name: pokemongo-map
-  memory: 256M
-  host: yourchosenservicename
-  disk_quota: 200M
+- path: .
+  command: python runserver.py -a "$AUTH_SERVICE" -u "$USERNAME" -p "$PASSWORD" -l "$LOCATION" -st $STEP_COUNT -H 0.0.0.0 -P $PORT -k $GMAPS_KEY
+  buildpack: https://github.com/cloudfoundry/python-buildpack
+  memory: 512M
   instances: 1
-  buildpack: https://github.com/cloudfoundry/buildpack-python.git
-  env:
-      AUTH_SERVICE: yourchosenauthservice
-      GMAPS_KEY: yourgmapsapikey
-      USERNAME: yourauthserviceusername
-      PASSWORD: yourauthservicepassword
-      LOCATION: "yourlocation"
-      STEP_COUNT: 5
+  domain: mybluemix.net
+  disk_quota: 1024M
+  # env:
+  #   AUTH_SERVICE: yourchosenauthservice
+  #   GMAPS_KEY: yourgmapsapikey
+  #   USERNAME: yourauthserviceusername
+  #   PASSWORD: yourauthservicepassword
+  #   LOCATION: "yourlocation"
+  #   STEP_COUNT: 5


### PR DESCRIPTION
## Description

Add's instructions to Deploy this app to IBM's PaaS, Bluemix.

  - Add's Deploy to Bluemix Button next to other deploy buttons
  - Add's manifest.yml and .cfignore files necessary for deployment

NOTE: This is a continuation of https://github.com/AHAAAAAAA/PokemonGo-Map/pull/2383 (but against develop instead of master). Also the wiki instructions have already been merged in via https://github.com/JonahAragon/PoGoMapWiki/pull/6

## Motivation and Context

Bluemix is IBM's PaaS and its free tier has 24 hours of uptime instead of Heroku's which makes your dynos "sleep" at night in the free tier. Makes for a better 24/7 pokemon training experience. oh boy!

## How Has This Been Tested?
Only adds documentation and yml file for Bluemix. Tested multiple deployments. All works!

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
