### PR TITLE
Allow alternate config file to be specified using an environment variable

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -34,7 +34,7 @@ def verify_config_file_exists(filename):
 
 def get_args():
     # fuck PEP8
-    configpath = os.path.join(os.path.dirname(__file__), '../config/config.ini')
+    configpath = os.environ.get('POGOMAP_CONFIG', os.path.join(os.path.dirname(__file__), '../config/config.ini'))
     parser = configargparse.ArgParser(default_config_files=[configpath])
     parser.add_argument('-a', '--auth-service', type=str.lower, action='append',
                         help='Auth Services, either one for all accounts or one per account. \


### PR DESCRIPTION
## Description
Allows using the `POGOMAP_CONFIG` environment variable to specify a different `config.ini` file than `$CODE_ROOT/config/config.ini`.

## Motivation and Context
This allows me to rather easily run multiple instances of the server with separate configuration options (including the database) against one copy of the codebase.  This is not strictly *necessary* to run multiple copies of the map, but the alternatives have downsides:

* You can use arguments to `runserver.py` instead.  A primary downside of this approach is that PTC/Google and possible also DB credentials are passed on the command-line.  On most *nix systems, this exposes them to all processes running on the same system -- even other users.  On a shared system, this is a grave security risk.
* You can make a complete copy of the PokemonGo-Map directory.  The rather obvious downside here is that each copy takes about half a gigabyte of space, by the time you add in dependencies.  Additionally, each copy has to be separately maintained for updates to PokemonGo-Map and all npm/pip dependencies.

## How Has This Been Tested?
I am currently running multiple instances using this approach, using the `db` option in each `config.ini` so that each instance has its own SQLite database.  I have had no issues so far.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.