### PR TITLE
Correct assertions to check for pgoapi being installed and up-to-date

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -23,15 +23,17 @@ if os.path.isdir(oldpgoapiPath):
     shutil.rmtree(oldpgoapiPath)
     log.info("Done!")
 
-# Ensure user has updated to the new api
+# Assert pgoapi is installed
 try:
     import pgoapi
-except:
-    log.critical("Was not able to import pgoapi. Try running pip install -r requirements.txt")
+except ImportError:
+    log.critical("It seems `pgoapi` is not installed. You must run pip install -r requirements.txt again")
     sys.exit(1)
 
-if pgoapi.__version__ != pgoapi_version:
-    log.critical("Your pgoapi version (%s) appears to be out of date. Try running pip install -r requirements.txt", pgoapi.__version__)
+# Assert pgoapi >= 1.1.6 is installed
+from distutils.version import StrictVersion
+if not hasattr(pgoapi, "__version__") or StrictVersion(pgoapi.__version__) < StrictVersion(pgoapi_version):
+    log.critical("It seems `pgoapi` is not up-to-date. You must run pip install -r requirements.txt again")
     sys.exit(1)
 
 from threading import Thread, Event


### PR DESCRIPTION
## Description
People using `virtualenv` and install pip packages inside a `venv` directory will not get `src/pgoapi` in their working directory. This fails the current assertion that `src/pgoapi` exists.

This PR changes the assertion from checking the directory to checking whether pgoapi can be imported without errors and in addition will check whether version of pgoapi is at least 1.1.6.

This solves #3370

## How Has This Been Tested?
Uninstalling pgoapi. Downgrading pgoapi. Installing pgoapi.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

