### PR TITLE
fixed bad merge that disables db clean

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -386,10 +386,11 @@ def parse_map(map_dict, step_location):
     }
 
     bulk_upsert(ScannedLocation, scanned)
-    
-    return True
 
     clean_database()
+
+    return True
+
 
 def clean_database():
     flaskDb.connect_db()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I think that automatic merge caused to disable database clean functionality, by inserting return True before clean_database()

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This reenable database clean functionality

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Just runing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

