### PR TITLE
updated new 70m radii

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -76,7 +76,7 @@ def generate_location_steps(initial_loc, step_count):
     SOUTH = 180
     WEST = 270
 
-    pulse_radius = 0.1                  # km - radius of players heartbeat is 100m
+    pulse_radius = 0.07                 # km - radius of players heartbeat is 70m
     xdist = math.sqrt(3)*pulse_radius   # dist between column centers
     ydist = 3*(pulse_radius/2)          # dist between row centers
 

--- a/static/dist/js/map.js
+++ b/static/dist/js/map.js
@@ -633,7 +633,7 @@ function setupScannedMarker(item) {
   var marker = new google.maps.Circle({
     map: map,
     center: circleCenter,
-    radius: 100, // 10 miles in metres
+    radius: 70, // new search radii are 70m
     fillColor: getColorByDate(item.last_modified),
     strokeWeight: 1
   });


### PR DESCRIPTION
## Description
the visible-range has been lowered to 70m, and this is the range, where you will receive the GPS data, so only this is really used in the PoGo-Map, isn't it? and therefore it needs to be changed accordingly
read this: https://www.reddit.com/r/TheSilphRoad/comments/4vhh4e/the_pok%C3%A9mon_nearby_radius_was_not_lowered_to_70m/

## Screenshots
how it looks: [http://fs5.directupload.net/images/160804/geit9zhg.png](http://fs5.directupload.net/images/160804/geit9zhg.png)
how it actually works: [http://fs5.directupload.net/images/160804/rewn9i98.png](http://fs5.directupload.net/images/160804/rewn9i98.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

